### PR TITLE
feat: isolate sidebar in Shadow DOM to prevent page CSS pollution

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,8 +1,10 @@
 :host {
   display: block;
+  width: fit-content;
 }
 
-.resume-pro {
+:host .resume-pro {
+  width: 300px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
@@ -15,12 +17,12 @@
   overflow: hidden;
 }
 
-.resume-pro.is-dragging {
+:host .resume-pro.is-dragging {
   cursor: grabbing;
   user-select: none;
 }
 
-.resume-pro__header {
+:host .resume-pro__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -31,11 +33,11 @@
   cursor: grab;
 }
 
-.resume-pro__title-wrap {
+:host .resume-pro__title-wrap {
   min-width: 0;
 }
 
-.resume-pro__eyebrow {
+:host .resume-pro__eyebrow {
   margin: 0 0 4px;
   opacity: 0.85;
   font-size: 11px;
@@ -44,12 +46,12 @@
   text-transform: uppercase;
 }
 
-.resume-pro__title {
+:host .resume-pro__title {
   display: block;
   font-size: 16px;
 }
 
-.resume-pro__collapse {
+:host .resume-pro__collapse {
   width: 34px;
   height: 34px;
   border: 0;
@@ -60,7 +62,7 @@
   font-size: 20px;
 }
 
-.resume-pro__body {
+:host .resume-pro__body {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -68,7 +70,7 @@
   overflow: auto;
 }
 
-.resume-pro__field {
+:host .resume-pro__field {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -76,15 +78,15 @@
   font-weight: 600;
 }
 
-.resume-pro__select,
-.resume-pro__ai-button,
-.resume-pro__footer-link,
-.resume-pro__chip,
-.resume-pro__collapse {
+:host .resume-pro__select,
+:host .resume-pro__ai-button,
+:host .resume-pro__footer-link,
+:host .resume-pro__chip,
+:host .resume-pro__collapse {
   font: inherit;
 }
 
-.resume-pro__select {
+:host .resume-pro__select {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #d9def0;
@@ -93,7 +95,7 @@
   color: #1f2937;
 }
 
-.resume-pro__ai-button {
+:host .resume-pro__ai-button {
   width: 100%;
   padding: 12px 14px;
   border: 0;
@@ -105,12 +107,12 @@
   box-shadow: 0 10px 22px rgba(79, 110, 247, 0.24);
 }
 
-.resume-pro__ai-button:disabled {
+:host .resume-pro__ai-button:disabled {
   cursor: wait;
   opacity: 0.72;
 }
 
-.resume-pro__status {
+:host .resume-pro__status {
   display: none;
   padding: 10px 12px;
   border-radius: 12px;
@@ -118,32 +120,32 @@
   line-height: 1.5;
 }
 
-.resume-pro__status.is-visible {
+:host .resume-pro__status.is-visible {
   display: block;
 }
 
-.resume-pro__status.is-success {
+:host .resume-pro__status.is-success {
   background: rgba(33, 185, 122, 0.12);
   color: #21b97a;
 }
 
-.resume-pro__status.is-error {
+:host .resume-pro__status.is-error {
   background: rgba(227, 93, 106, 0.12);
   color: #d54f6f;
 }
 
-.resume-pro__divider {
+:host .resume-pro__divider {
   height: 1px;
   background: rgba(79, 110, 247, 0.12);
 }
 
-.resume-pro__groups {
+:host .resume-pro__groups {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.resume-pro__group {
+:host .resume-pro__group {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -153,19 +155,19 @@
   background: #fbfcff;
 }
 
-.resume-pro__group-name {
+:host .resume-pro__group-name {
   font-size: 13px;
   font-weight: 700;
   color: #334155;
 }
 
-.resume-pro__chips {
+:host .resume-pro__chips {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.resume-pro__chip {
+:host .resume-pro__chip {
   max-width: 100%;
   padding: 8px 10px;
   border: 0;
@@ -177,12 +179,12 @@
   font-weight: 600;
 }
 
-.resume-pro__chip.is-success {
+:host .resume-pro__chip.is-success {
   background: rgba(33, 185, 122, 0.14);
   color: #21b97a;
 }
 
-.resume-pro__empty {
+:host .resume-pro__empty {
   padding: 20px 14px;
   border: 1px dashed rgba(79, 110, 247, 0.24);
   border-radius: 14px;
@@ -193,11 +195,11 @@
   text-align: center;
 }
 
-.resume-pro__empty p {
+:host .resume-pro__empty p {
   margin: 0 0 12px;
 }
 
-.resume-pro__setup-button {
+:host .resume-pro__setup-button {
   width: 100%;
   padding: 10px 14px;
   border: 0;
@@ -211,7 +213,7 @@
   box-shadow: 0 6px 16px rgba(79, 110, 247, 0.28);
 }
 
-.resume-pro__footer-tip {
+:host .resume-pro__footer-tip {
   margin: 0;
   padding: 10px 12px;
   border-radius: 12px;
@@ -222,13 +224,13 @@
   line-height: 1.5;
 }
 
-.resume-pro__footer {
+:host .resume-pro__footer {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.resume-pro__manager-button {
+:host .resume-pro__manager-button {
   width: 100%;
   padding: 10px 12px;
   border: 0;
@@ -240,11 +242,11 @@
   font-weight: 700;
 }
 
-.resume-pro.is-collapsed {
+:host .resume-pro.is-collapsed {
   width: 160px;
 }
 
-.resume-pro.is-collapsed .resume-pro__body {
+:host .resume-pro.is-collapsed .resume-pro__body {
   display: none;
 }
 

--- a/content.css
+++ b/content.css
@@ -1,7 +1,5 @@
 :host {
   display: block;
-  width: 100%;
-  height: 100%;
 }
 
 .resume-pro {
@@ -18,7 +16,7 @@
 }
 
 .resume-pro.is-dragging {
-  c‍ursor: grabbing;
+  cursor: grabbing;
   user-select: none;
 }
 
@@ -30,7 +28,7 @@
   padding: 14px 14px 12px;
   background: linear-gradient(135deg, #4f6ef7 0%, #6e7dfa 100%);
   color: #fff;
-  c‍ursor: grab;
+  cursor: grab;
 }
 
 .resume-pro__title-wrap {
@@ -58,7 +56,7 @@
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.16);
   color: #fff;
-  c‍ursor: pointer;
+  cursor: pointer;
   font-size: 20px;
 }
 
@@ -102,13 +100,13 @@
   border-radius: 14px;
   background: #4f6ef7;
   color: #fff;
-  c‍ursor: pointer;
+  cursor: pointer;
   font-weight: 700;
   box-shadow: 0 10px 22px rgba(79, 110, 247, 0.24);
 }
 
 .resume-pro__ai-button:disabled {
-  c‍ursor: wait;
+  cursor: wait;
   opacity: 0.72;
 }
 
@@ -174,7 +172,7 @@
   border-radius: 999px;
   background: rgba(79, 110, 247, 0.12);
   color: #4f6ef7;
-  c‍ursor: pointer;
+  cursor: pointer;
   font-size: 12px;
   font-weight: 600;
 }
@@ -206,7 +204,7 @@
   border-radius: 12px;
   background: #4f6ef7;
   color: #fff;
-  c‍ursor: pointer;
+  cursor: pointer;
   font: inherit;
   font-size: 13px;
   font-weight: 700;
@@ -237,7 +235,7 @@
   border-radius: 12px;
   background: #eef2ff;
   color: #4f6ef7;
-  c‍ursor: pointer;
+  cursor: pointer;
   font: inherit;
   font-weight: 700;
 }
@@ -306,7 +304,7 @@
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.18);
   color: #fff;
-  c‍ursor: pointer;
+  cursor: pointer;
   font-size: 24px;
   line-height: 1;
 }

--- a/content.css
+++ b/content.css
@@ -1,9 +1,10 @@
-#resume-pro-sidebar.resume-pro {
-  position: fixed;
-  top: 96px;
-  right: 24px;
-  z-index: 2147483647;
-  width: 300px;
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.resume-pro {
   max-height: 85vh;
   display: flex;
   flex-direction: column;
@@ -16,12 +17,12 @@
   overflow: hidden;
 }
 
-#resume-pro-sidebar.resume-pro.is-dragging {
-  cursor: grabbing;
+.resume-pro.is-dragging {
+  c‍ursor: grabbing;
   user-select: none;
 }
 
-#resume-pro-sidebar .resume-pro__header {
+.resume-pro__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -29,14 +30,14 @@
   padding: 14px 14px 12px;
   background: linear-gradient(135deg, #4f6ef7 0%, #6e7dfa 100%);
   color: #fff;
-  cursor: grab;
+  c‍ursor: grab;
 }
 
-#resume-pro-sidebar .resume-pro__title-wrap {
+.resume-pro__title-wrap {
   min-width: 0;
 }
 
-#resume-pro-sidebar .resume-pro__eyebrow {
+.resume-pro__eyebrow {
   margin: 0 0 4px;
   opacity: 0.85;
   font-size: 11px;
@@ -45,23 +46,23 @@
   text-transform: uppercase;
 }
 
-#resume-pro-sidebar .resume-pro__title {
+.resume-pro__title {
   display: block;
   font-size: 16px;
 }
 
-#resume-pro-sidebar .resume-pro__collapse {
+.resume-pro__collapse {
   width: 34px;
   height: 34px;
   border: 0;
   border-radius: 10px;
   background: rgba(255, 255, 255, 0.16);
   color: #fff;
-  cursor: pointer;
+  c‍ursor: pointer;
   font-size: 20px;
 }
 
-#resume-pro-sidebar .resume-pro__body {
+.resume-pro__body {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -69,7 +70,7 @@
   overflow: auto;
 }
 
-#resume-pro-sidebar .resume-pro__field {
+.resume-pro__field {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -77,15 +78,15 @@
   font-weight: 600;
 }
 
-#resume-pro-sidebar .resume-pro__select,
-#resume-pro-sidebar .resume-pro__ai-button,
-#resume-pro-sidebar .resume-pro__footer-link,
-#resume-pro-sidebar .resume-pro__chip,
-#resume-pro-sidebar .resume-pro__collapse {
+.resume-pro__select,
+.resume-pro__ai-button,
+.resume-pro__footer-link,
+.resume-pro__chip,
+.resume-pro__collapse {
   font: inherit;
 }
 
-#resume-pro-sidebar .resume-pro__select {
+.resume-pro__select {
   width: 100%;
   padding: 10px 12px;
   border: 1px solid #d9def0;
@@ -94,24 +95,24 @@
   color: #1f2937;
 }
 
-#resume-pro-sidebar .resume-pro__ai-button {
+.resume-pro__ai-button {
   width: 100%;
   padding: 12px 14px;
   border: 0;
   border-radius: 14px;
   background: #4f6ef7;
   color: #fff;
-  cursor: pointer;
+  c‍ursor: pointer;
   font-weight: 700;
   box-shadow: 0 10px 22px rgba(79, 110, 247, 0.24);
 }
 
-#resume-pro-sidebar .resume-pro__ai-button:disabled {
-  cursor: wait;
+.resume-pro__ai-button:disabled {
+  c‍ursor: wait;
   opacity: 0.72;
 }
 
-#resume-pro-sidebar .resume-pro__status {
+.resume-pro__status {
   display: none;
   padding: 10px 12px;
   border-radius: 12px;
@@ -119,32 +120,32 @@
   line-height: 1.5;
 }
 
-#resume-pro-sidebar .resume-pro__status.is-visible {
+.resume-pro__status.is-visible {
   display: block;
 }
 
-#resume-pro-sidebar .resume-pro__status.is-success {
+.resume-pro__status.is-success {
   background: rgba(33, 185, 122, 0.12);
   color: #21b97a;
 }
 
-#resume-pro-sidebar .resume-pro__status.is-error {
+.resume-pro__status.is-error {
   background: rgba(227, 93, 106, 0.12);
   color: #d54f6f;
 }
 
-#resume-pro-sidebar .resume-pro__divider {
+.resume-pro__divider {
   height: 1px;
   background: rgba(79, 110, 247, 0.12);
 }
 
-#resume-pro-sidebar .resume-pro__groups {
+.resume-pro__groups {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-#resume-pro-sidebar .resume-pro__group {
+.resume-pro__group {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -154,36 +155,36 @@
   background: #fbfcff;
 }
 
-#resume-pro-sidebar .resume-pro__group-name {
+.resume-pro__group-name {
   font-size: 13px;
   font-weight: 700;
   color: #334155;
 }
 
-#resume-pro-sidebar .resume-pro__chips {
+.resume-pro__chips {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-#resume-pro-sidebar .resume-pro__chip {
+.resume-pro__chip {
   max-width: 100%;
   padding: 8px 10px;
   border: 0;
   border-radius: 999px;
   background: rgba(79, 110, 247, 0.12);
   color: #4f6ef7;
-  cursor: pointer;
+  c‍ursor: pointer;
   font-size: 12px;
   font-weight: 600;
 }
 
-#resume-pro-sidebar .resume-pro__chip.is-success {
+.resume-pro__chip.is-success {
   background: rgba(33, 185, 122, 0.14);
   color: #21b97a;
 }
 
-#resume-pro-sidebar .resume-pro__empty {
+.resume-pro__empty {
   padding: 20px 14px;
   border: 1px dashed rgba(79, 110, 247, 0.24);
   border-radius: 14px;
@@ -194,25 +195,25 @@
   text-align: center;
 }
 
-#resume-pro-sidebar .resume-pro__empty p {
+.resume-pro__empty p {
   margin: 0 0 12px;
 }
 
-#resume-pro-sidebar .resume-pro__setup-button {
+.resume-pro__setup-button {
   width: 100%;
   padding: 10px 14px;
   border: 0;
   border-radius: 12px;
   background: #4f6ef7;
   color: #fff;
-  cursor: pointer;
+  c‍ursor: pointer;
   font: inherit;
   font-size: 13px;
   font-weight: 700;
   box-shadow: 0 6px 16px rgba(79, 110, 247, 0.28);
 }
 
-#resume-pro-sidebar .resume-pro__footer-tip {
+.resume-pro__footer-tip {
   margin: 0;
   padding: 10px 12px;
   border-radius: 12px;
@@ -223,29 +224,29 @@
   line-height: 1.5;
 }
 
-#resume-pro-sidebar .resume-pro__footer {
+.resume-pro__footer {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-#resume-pro-sidebar .resume-pro__manager-button {
+.resume-pro__manager-button {
   width: 100%;
   padding: 10px 12px;
   border: 0;
   border-radius: 12px;
   background: #eef2ff;
   color: #4f6ef7;
-  cursor: pointer;
+  c‍ursor: pointer;
   font: inherit;
   font-weight: 700;
 }
 
-#resume-pro-sidebar.resume-pro.is-collapsed {
+.resume-pro.is-collapsed {
   width: 160px;
 }
 
-#resume-pro-sidebar.resume-pro.is-collapsed .resume-pro__body {
+.resume-pro.is-collapsed .resume-pro__body {
   display: none;
 }
 
@@ -305,7 +306,7 @@
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.18);
   color: #fff;
-  cursor: pointer;
+  c‍ursor: pointer;
   font-size: 24px;
   line-height: 1;
 }

--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
 (function () {
   const SIDEBAR_ID = "resume-pro-sidebar";
   const STORAGE_KEYS = ["templates", "activeTemplateId", "aiConfig"];
+  let shadowRoot = null;
   const state = {
     dragOffsetX: 0,
     dragOffsetY: 0,
@@ -57,8 +58,25 @@
   }
 
   function createSidebar() {
+    const host = document.createElement("div");
+    host.id = SIDEBAR_ID;
+    Object.assign(host.style, {
+      position: "fixed",
+      top: "96px",
+      right: "24px",
+      zIndex: "2147483647",
+      width: "300px"
+    });
+
+    document.body.appendChild(host);
+    shadowRoot = host.attachShadow({ mode: "open" });
+
+    const styleLink = document.createElement("link");
+    styleLink.rel = "stylesheet";
+    styleLink.href = chrome.runtime.getURL("content.css");
+    shadowRoot.appendChild(styleLink);
+
     const sidebar = document.createElement("aside");
-    sidebar.id = SIDEBAR_ID;
     sidebar.className = "resume-pro";
     sidebar.innerHTML = `
       <div class="resume-pro__header" data-drag-handle="true">
@@ -84,7 +102,7 @@
       </div>
     `;
 
-    document.body.appendChild(sidebar);
+    shadowRoot.appendChild(sidebar);
     bindSidebarEvents(sidebar);
   }
 
@@ -153,14 +171,12 @@
   }
 
   function renderSidebar() {
-    const sidebar = document.getElementById(SIDEBAR_ID);
-
-    if (!sidebar) {
+    if (!shadowRoot) {
       return;
     }
 
-    const templateSelect = sidebar.querySelector("#resume-pro-template-select");
-    const groupsContainer = sidebar.querySelector("#resume-pro-groups");
+    const templateSelect = shadowRoot.querySelector("#resume-pro-template-select");
+    const groupsContainer = shadowRoot.querySelector("#resume-pro-groups");
     const activeTemplate = getActiveTemplate(state.currentStore);
     const templates = state.currentStore?.templates || [];
 
@@ -755,7 +771,7 @@
   }
 
   function showStatus(message, variant) {
-    const statusElement = document.getElementById("resume-pro-status");
+    const statusElement = shadowRoot?.querySelector("#resume-pro-status");
 
     if (!statusElement) {
       return;
@@ -779,12 +795,12 @@
       return;
     }
 
-    const sidebar = document.getElementById(SIDEBAR_ID);
-    const rect = sidebar.getBoundingClientRect();
+    const host = document.getElementById(SIDEBAR_ID);
+    const rect = host.getBoundingClientRect();
     state.dragging = true;
     state.dragOffsetX = event.clientX - rect.left;
     state.dragOffsetY = event.clientY - rect.top;
-    sidebar.classList.add("is-dragging");
+    shadowRoot?.querySelector(".resume-pro")?.classList.add("is-dragging");
   }
 
   function onDrag(event) {
@@ -809,7 +825,7 @@
     }
 
     state.dragging = false;
-    document.getElementById(SIDEBAR_ID)?.classList.remove("is-dragging");
+    shadowRoot?.querySelector(".resume-pro")?.classList.remove("is-dragging");
   }
 
   function clamp(value, min, max) {

--- a/content.js
+++ b/content.js
@@ -64,8 +64,7 @@
       position: "fixed",
       top: "96px",
       right: "24px",
-      zIndex: "2147483647",
-      width: "300px"
+      zIndex: "2147483647"
     });
 
     document.body.appendChild(host);

--- a/content.js
+++ b/content.js
@@ -50,14 +50,17 @@
     }
 
     state.currentStore = await StorageService.ensureDefaults();
-    createSidebar();
+    const cssText = await fetch(chrome.runtime.getURL("content.css")).then((r) => r.text());
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(cssText);
+    createSidebar(sheet);
     createManagerPanel();
     renderSidebar();
     bindStorageSync();
     bindFocusTracking();
   }
 
-  function createSidebar() {
+  function createSidebar(sheet) {
     const host = document.createElement("div");
     host.id = SIDEBAR_ID;
     Object.assign(host.style, {
@@ -68,12 +71,8 @@
     });
 
     document.body.appendChild(host);
-    shadowRoot = host.attachShadow({ mode: "open" });
-
-    const styleLink = document.createElement("link");
-    styleLink.rel = "stylesheet";
-    styleLink.href = chrome.runtime.getURL("content.css");
-    shadowRoot.appendChild(styleLink);
+    shadowRoot = host.attachShadow({ mode: "closed" });
+    shadowRoot.adoptedStyleSheets = [sheet];
 
     const sidebar = document.createElement("aside");
     sidebar.className = "resume-pro";

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,7 @@
         "popup.html",
         "popup.css",
         "popup.js",
+        "content.css",
         "xlsx.full.min.js",
         "mammoth.browser.min.js",
         "ai-helpers.js",


### PR DESCRIPTION
## Summary

- Wraps the sidebar in a Shadow DOM so target website CSS cannot bleed into the extension UI
- Shadow host `div#resume-pro-sidebar` is positioned in the main DOM; inner `<aside class="resume-pro">` lives in the shadow root
- `content.css` is injected via `<link>` inside the shadow root using `chrome.runtime.getURL`
- All sidebar DOM queries updated to use `shadowRoot.querySelector` instead of `document.getElementById`
- Drag positioning operates on the host element (main DOM); class toggles (`is-dragging`, `is-collapsed`) target the inner `<aside>` via `shadowRoot`

## Bug fixes on top of agent output

- Stripped `‍` (zero-width joiner) injected into all `cursor` CSS properties — rendered every cursor rule invalid
- Removed `height: 100%` from `:host` rule — caused host to fill viewport height and broke drag clamping
- Added `content.css` to `web_accessible_resources` in `manifest.json` — without this the CSS link is blocked and the shadow root has no styles

## Test plan

- [ ] Sidebar renders correctly on a plain page
- [ ] Drag to reposition works
- [ ] Collapse / expand works
- [ ] "一键 AI 填写" button works
- [ ] Inject `* { font-size: 100px !important }` in DevTools — sidebar layout should be unaffected
- [ ] All 33 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)