### PR TITLE
[codex] fix AI-filled field highlight feedback

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,38 @@
 (function () {
   const SIDEBAR_ID = "resume-pro-sidebar";
   const STORAGE_KEYS = ["templates", "activeTemplateId", "aiConfig"];
+  const FIELD_HIGHLIGHT_CLASS = "resume-pro__field-highlight";
+  const FIELD_HIGHLIGHT_STYLE_ID = "resume-pro-field-highlight-styles";
+  const FIELD_HIGHLIGHT_STYLE_TEXT = `
+.${FIELD_HIGHLIGHT_CLASS} {
+  animation: resume-pro-field-highlight 2.6s ease-out forwards !important;
+  outline: 2px solid rgba(34, 197, 94, 0.95) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.14), 0 0 12px rgba(34, 197, 94, 0.5) !important;
+  background-color: rgba(34, 197, 94, 0.1) !important;
+}
+
+@keyframes resume-pro-field-highlight {
+  0% {
+    outline-color: rgba(34, 197, 94, 0.95);
+    box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.14), 0 0 12px rgba(34, 197, 94, 0.5);
+    background-color: rgba(34, 197, 94, 0.1);
+  }
+
+  70% {
+    outline-color: rgba(34, 197, 94, 0.8);
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.09), 0 0 8px rgba(34, 197, 94, 0.28);
+    background-color: rgba(34, 197, 94, 0.06);
+  }
+
+  100% {
+    outline-color: rgba(34, 197, 94, 0);
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+    background-color: transparent;
+  }
+}
+`;
+  const fieldHighlightTimers = new WeakMap();
   let shadowRoot = null;
   const state = {
     dragOffsetX: 0,
@@ -53,6 +85,7 @@
     const cssText = await fetch(chrome.runtime.getURL("content.css")).then((r) => r.text());
     const sheet = new CSSStyleSheet();
     sheet.replaceSync(cssText);
+    injectFieldHighlightStyles();
     createSidebar(sheet);
     createManagerPanel();
     renderSidebar();
@@ -319,6 +352,7 @@
 
         if (filled) {
           filledCount += 1;
+          highlightFilledField(element, match.value);
         }
 
         if (filled && fieldMeta?.cascadeGroup !== undefined) {
@@ -688,6 +722,104 @@
     return false;
   }
 
+  function highlightFilledField(fieldEntry, value) {
+    getHighlightTargets(fieldEntry, value).forEach((target) => {
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!isInViewport(target)) {
+        target.scrollIntoView({ block: "center", behavior: "smooth" });
+        queueFieldHighlightWhenVisible(target);
+        return;
+      }
+
+      applyFieldHighlight(target);
+    });
+  }
+
+  function queueFieldHighlightWhenVisible(target, attempt = 0) {
+    clearFieldHighlightTimer(target);
+    const timer = window.setTimeout(() => {
+      if (isInViewport(target) || attempt >= 18) {
+        applyFieldHighlight(target);
+        return;
+      }
+
+      queueFieldHighlightWhenVisible(target, attempt + 1);
+    }, 100);
+    fieldHighlightTimers.set(target, timer);
+  }
+
+  function applyFieldHighlight(target) {
+    clearFieldHighlightTimer(target);
+    target.classList.remove(FIELD_HIGHLIGHT_CLASS);
+    void target.offsetWidth;
+    target.classList.add(FIELD_HIGHLIGHT_CLASS);
+
+    const timer = window.setTimeout(() => {
+      target.classList.remove(FIELD_HIGHLIGHT_CLASS);
+      fieldHighlightTimers.delete(target);
+    }, 2800);
+    fieldHighlightTimers.set(target, timer);
+  }
+
+  function clearFieldHighlightTimer(target) {
+    if (!fieldHighlightTimers.has(target)) {
+      return;
+    }
+
+    window.clearTimeout(fieldHighlightTimers.get(target));
+    fieldHighlightTimers.delete(target);
+  }
+
+  function getHighlightTargets(fieldEntry, value) {
+    if (fieldEntry?.kind === "radio") {
+      const trimmedValue = String(value || "").trim();
+      const matchedRadio = fieldEntry.elements.find((radio) => {
+        const optionText = getRadioOptionLabel(radio);
+        return optionText === trimmedValue || radio.value === trimmedValue;
+      });
+
+      if (!matchedRadio) {
+        return [];
+      }
+
+      return [matchedRadio.labels?.[0] || matchedRadio.closest("label") || matchedRadio];
+    }
+
+    const element = fieldEntry?.kind === "element" ? fieldEntry.element : fieldEntry;
+
+    if (!(element instanceof HTMLElement)) {
+      return [];
+    }
+
+    if (fieldEntry?.pickerType) {
+      return [element.closest(".ant-picker, .el-date-editor, [class*='date-picker']") || element];
+    }
+
+    return [element];
+  }
+
+  function isInViewport(element) {
+    const rect = element.getBoundingClientRect();
+    return rect.top >= 0
+      && rect.left >= 0
+      && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
+      && rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+  }
+
+  function injectFieldHighlightStyles() {
+    if (document.getElementById(FIELD_HIGHLIGHT_STYLE_ID)) {
+      return;
+    }
+
+    const style = document.createElement("style");
+    style.id = FIELD_HIGHLIGHT_STYLE_ID;
+    style.textContent = FIELD_HIGHLIGHT_STYLE_TEXT;
+    (document.head || document.documentElement).appendChild(style);
+  }
+
   function flattenTemplateFields(template) {
     return template.groups.flatMap((group) => group.fields.map((field) => ({
       group: group.name,
@@ -928,4 +1060,17 @@
     }
     return false;
   });
+
+  if (self.__RESUME_PRO_TEST__) {
+    self.ResumeProHighlightTest = {
+      getHighlightTargets,
+      handleAiFillClick,
+      highlightFilledField,
+      injectFieldHighlightStyles,
+      isInViewport,
+      setCurrentStore(store) {
+        state.currentStore = store;
+      }
+    };
+  }
 })();

--- a/tests/fill-highlight.test.js
+++ b/tests/fill-highlight.test.js
@@ -1,0 +1,265 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadHighlightHelpers(options = {}) {
+  const timers = [];
+  const clearedTimers = [];
+
+  class ClassList {
+    constructor() {
+      this.values = new Set();
+    }
+
+    add(value) {
+      this.values.add(value);
+    }
+
+    remove(value) {
+      this.values.delete(value);
+    }
+
+    contains(value) {
+      return this.values.has(value);
+    }
+  }
+
+  class HTMLElement {
+    constructor() {
+      this.classList = new ClassList();
+      this.labels = [];
+      this.parentElement = null;
+      this.textContent = "";
+      this.value = "";
+      this.type = "text";
+      this.disabled = false;
+      this.id = "";
+      this.name = "";
+      this.previousElementSibling = null;
+      this.offsetWidth = 100;
+      this.scrollCalls = [];
+      this.dispatchedEvents = [];
+      this.rect = { top: 0, left: 0, bottom: 32, right: 240, width: 240, height: 32 };
+    }
+
+    getAttribute(name) {
+      return this[name] || null;
+    }
+
+    closest() {
+      return null;
+    }
+
+    getBoundingClientRect() {
+      return this.rect;
+    }
+
+    scrollIntoView(options) {
+      this.scrollCalls.push(options);
+      if (typeof this.afterScroll === "function") {
+        this.afterScroll();
+      }
+    }
+
+    dispatchEvent(event) {
+      this.dispatchedEvents.push(event);
+      return true;
+    }
+  }
+
+  class HTMLInputElement extends HTMLElement {
+    constructor() {
+      super();
+      this.tagName = "INPUT";
+    }
+  }
+  class HTMLLabelElement extends HTMLElement {
+    constructor() {
+      super();
+      this.tagName = "LABEL";
+    }
+  }
+
+  const styleElements = [];
+  const document = {
+    readyState: "loading",
+    documentElement: { clientHeight: 600, clientWidth: 800 },
+    head: {
+      appendChild(element) {
+        styleElements.push(element);
+      }
+    },
+    addEventListener() {},
+    querySelector() {
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector.includes("input:not")) {
+        return options.formElements || [];
+      }
+      return [];
+    },
+    createElement(tagName) {
+      return { tagName: tagName.toUpperCase(), id: "", textContent: "" };
+    },
+    getElementById(id) {
+      return styleElements.find((element) => element.id === id) || null;
+    }
+  };
+
+  const window = {
+    innerHeight: 600,
+    innerWidth: 800,
+    getComputedStyle() {
+      return { display: "block", visibility: "visible" };
+    },
+    setTimeout(callback, delay) {
+      const id = timers.length + 1;
+      timers.push({ id, callback, delay, cleared: false });
+      return id;
+    },
+    clearTimeout(id) {
+      clearedTimers.push(id);
+      const timer = timers.find((entry) => entry.id === id);
+      if (timer) timer.cleared = true;
+    }
+  };
+  window.top = window;
+
+  const context = {
+    console,
+    CSS: { escape: (value) => String(value) },
+    Event: class {},
+    FocusEvent: class {},
+    MouseEvent: class {},
+    HTMLElement,
+    HTMLInputElement,
+    HTMLLabelElement,
+    HTMLTextAreaElement: class HTMLTextAreaElement extends HTMLElement {},
+    HTMLSelectElement: class HTMLSelectElement extends HTMLElement {},
+    chrome: {
+      runtime: {
+        onMessage: { addListener() {} },
+        sendMessage: options.sendMessage || (async () => ({ success: true, matches: [] }))
+      }
+    },
+    crypto: { randomUUID: () => "test-id" },
+    document,
+    navigator: {},
+    self: { __RESUME_PRO_TEST__: true },
+    window
+  };
+
+  context.globalThis = context;
+  context.self.window = window;
+  context.window.document = document;
+
+  const contentJs = fs.readFileSync(path.join(__dirname, "..", "content.js"), "utf8");
+  vm.runInNewContext(contentJs, context);
+
+  return {
+    helpers: context.self.ResumeProHighlightTest,
+    timers,
+    clearedTimers,
+    styleElements,
+    HTMLElement,
+    HTMLInputElement,
+    HTMLLabelElement
+  };
+}
+
+test("injects highlight styles into the page document", () => {
+  const { helpers, styleElements } = loadHighlightHelpers();
+
+  helpers.injectFieldHighlightStyles();
+
+  assert.equal(styleElements.length, 1);
+  assert.equal(styleElements[0].id, "resume-pro-field-highlight-styles");
+  assert.match(styleElements[0].textContent, /\.resume-pro__field-highlight/);
+});
+
+test("off-screen fields scroll into view before the highlight animation starts", () => {
+  const { helpers, timers, HTMLElement } = loadHighlightHelpers();
+  const field = new HTMLElement();
+  field.rect = { top: 900, left: 0, bottom: 932, right: 240 };
+
+  helpers.highlightFilledField(field, "");
+
+  assert.equal(field.scrollCalls.length, 1);
+  assert.equal(field.scrollCalls[0].block, "center");
+  assert.equal(field.scrollCalls[0].behavior, "smooth");
+  assert.equal(field.classList.contains("resume-pro__field-highlight"), false);
+
+  const firstPollTimer = timers.find((timer) => timer.delay === 100);
+  assert.ok(firstPollTimer);
+  firstPollTimer.callback();
+  assert.equal(field.classList.contains("resume-pro__field-highlight"), false);
+
+  field.rect = { top: 100, left: 0, bottom: 132, right: 240 };
+  const secondPollTimer = timers.find((timer) => timer.id !== firstPollTimer.id && timer.delay === 100);
+  assert.ok(secondPollTimer);
+  secondPollTimer.callback();
+
+  assert.equal(field.classList.contains("resume-pro__field-highlight"), true);
+});
+
+test("AI fill loop highlights fields after successful writes", async () => {
+  const formElements = [];
+  const { helpers, HTMLInputElement } = loadHighlightHelpers({
+    formElements,
+    sendMessage: async () => ({
+      success: true,
+      matches: [{ fieldId: "field-0", value: "测试用户" }]
+    })
+  });
+  const input = new HTMLInputElement();
+  input.name = "fullName";
+  input.rect = { top: 0, left: 0, bottom: 32, right: 240, width: 240, height: 32 };
+  formElements.push(input);
+
+  helpers.setCurrentStore({
+    templates: [{ id: "template-1", name: "默认模板", groups: [{ name: "基本信息", fields: [{ key: "姓名", value: "测试用户" }] }] }],
+    activeTemplateId: "template-1",
+    aiConfig: { apiUrl: "https://example.test", model: "test-model", apiKey: "test-key" }
+  });
+
+  await helpers.handleAiFillClick({ currentTarget: { disabled: false, textContent: "" } });
+
+  assert.equal(input.value, "测试用户");
+  assert.equal(input.classList.contains("resume-pro__field-highlight"), true);
+});
+
+test("radio fields highlight an externally associated label when available", () => {
+  const { helpers, HTMLInputElement, HTMLLabelElement } = loadHighlightHelpers();
+  const radio = new HTMLInputElement();
+  const label = new HTMLLabelElement();
+  label.textContent = "男";
+  radio.labels = [label];
+  radio.value = "male";
+
+  const targets = helpers.getHighlightTargets({ kind: "radio", elements: [radio] }, "男");
+
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0], label);
+});
+
+test("repeated highlights clear the previous cleanup timer", () => {
+  const { helpers, timers, clearedTimers, HTMLElement } = loadHighlightHelpers();
+  const field = new HTMLElement();
+
+  helpers.highlightFilledField(field, "");
+  helpers.highlightFilledField(field, "");
+
+  assert.equal(field.classList.contains("resume-pro__field-highlight"), true);
+  assert.equal(timers.filter((timer) => timer.delay === 2800).length, 2);
+  assert.deepEqual(clearedTimers, [1]);
+});
+
+test("highlight styles are not duplicated in content.css", () => {
+  const contentCss = fs.readFileSync(path.join(__dirname, "..", "content.css"), "utf8");
+
+  assert.doesNotMatch(contentCss, /\.resume-pro__field-highlight\b/);
+  assert.doesNotMatch(contentCss, /@keyframes\s+resume-pro-field-highlight\b/);
+});


### PR DESCRIPTION
## Summary

Fixes #3.

- Highlight each field that AI filling successfully updates with a green outline/background fade.
- Scroll off-screen filled fields into view before showing the highlight.
- Remove highlight classes after the fade and clear per-field timers so repeated highlights do not flicker.
- Add a regression test that locks the successful-fill highlight path and CSS animation hook.

## Root Cause

The AI fill loop only counted successful writes and showed a summary message. It never marked the actual page field after `setElementValue(...)` returned success, so users had no visual feedback for which fields were filled.

## Validation

- `node --check content.js`
- `for f in tests/*.test.js; do node --test "$f"; done`