### PR TITLE
docs(d01): freeze desktop MVP product and architecture baseline

### DIFF
--- a/docs/desktop-mvp/README.md
+++ b/docs/desktop-mvp/README.md
@@ -5,13 +5,13 @@
 | 标题 | 桌面求职管理 MVP 设计基线 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review（**未冻结**；负责人确认前下游只做可丢弃原型） |
+| 状态 | 可修订开工基线（PR 合并后生效） |
 | Issue | [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | Epic | [#15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
 
 本文档集是 Epic #15 的 **P0 设计基线**。D01 **只产出设计决策**，不实现桌面应用、SQLite 迁移、Native Messaging host、协议 JSON Schema、安装器或插件功能变更。当前插件仍为 Manifest V3 `0.3.0`，权限与填写行为保持不变。
 
-负责人在本 PR / #17 上确认关键决策之前，**不得宣称架构已冻结**。下游只允许可丢弃原型，不得把本目录当作已批准的实现接口。
+负责人已授权本轮收尾后合并。本文作为**可修订的开工基线**：合并后 D02/D03/D05 按现有推荐方案推进，不继续以穷尽所有实现细节为 D01 门禁。安全/数据约束必须满足，具体接口与测试在对应子 issue 完成；实现发现新事实时先同步相关契约，不擅自扩产品范围。双平台正式发行覆盖、签名和备份加密等发布选择在相关交付 issue 最终确认。
 
 ## 如何阅读
 

--- a/docs/desktop-mvp/README.md
+++ b/docs/desktop-mvp/README.md
@@ -17,7 +17,7 @@
 
 按角色选择入口，不必按文件顺序通读：
 
-1. **产品 / 负责人**：先读本页「关键决策快照」和 [需要负责人选择的项](downstream-decisions.md#需要项目负责人选择)，再读 [产品需求](product-requirements.md) 的目标用户、产品规则、阶段模型、离线意图/绑定，以及合成走查。
+1. **产品 / 负责人**：先读本页「关键决策快照」和 [需要负责人选择的项](downstream-decisions.md#4-需要项目负责人选择)，再读 [产品需求](product-requirements.md) 的目标用户、产品规则、阶段模型、离线意图/绑定，以及合成走查。
 2. **D02 / D06 / D13（壳、进程、安装）**：读 [架构 ADR](adr-architecture.md) 的技术选型、**进程角色**（不是「两个 EXE」契约）、跨平台适配边界、安装与仓库布局。D02 起必须做 **macOS 原型**，不能等 Windows 全做完再移植。
 3. **D03 / D04 / D08 / D09 / D10（数据与界面）**：读 [产品需求](product-requirements.md) 的对象关系、字段目录、`restoreEpoch`、提醒语义和走查；物理 schema 仍归 D03。
 4. **D05 / D07（协议与插件连接）**：读 ADR 的协议原则，产品需求的 **保存意图 vs 已绑定业务消息**，以及 [数据与隐私](data-privacy.md) 的快照暂存 / 密钥规则。不要在 D01 寻找完整 JSON Schema。
@@ -70,22 +70,22 @@
 | 5 | 默认阶段 | 插件保存岗位 → `saved`（已收藏），**不是** `submitted`。插件「确认已投递」归 **D07** |
 | 6 | 身份 | 申请 UUID；两层候选（精确三元组 / 同公司提示）；**禁止**自动合并 |
 | 7 | 离线保存 | 区分 **保存意图**（已确认要存、尚未绑定申请）与 **已绑定业务消息**。曾经配对但桌面暂不可用：可持久化意图并显示「待同步」，**不得**显示「桌面已保存」。未安装/从未配对：不建长期队列 |
-| 8 | 快照 | 确认留档时立即生成不可变字节；桌面不可用时字节进 **扩展源 IndexedDB**，元数据进 `chrome.storage.local`。重试不得从最新模板重生成 |
-| 9 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；幂等键 `(clientInstanceId, messageId, restoreEpoch)` |
+| 8 | 快照 | 确认留档时立即生成不可变字节；无论桌面是否在线，发送前完整字节先提交到 **扩展源 IndexedDB**，完整提交/哈希 ACK 前保留，元数据进 `chrome.storage.local`。重试不得从最新模板重生成 |
+| 9 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；当前 epoch 校验与完整历史回执对账分离（见产品 §8.11） |
 | 10 | 配对 | **D01 不加 `key`**。桌面 UI **粘贴扩展 ID**；**第一条 NM 不是配对消息** |
-| 11 | 恢复隔离 | 备份保留 `archiveId`；每次成功切换 current 指针 **新铸 `restoreEpoch`（UUID）**，不从备份拷贝、不按 backup.generation+1。旧队列盖章对不上则暂停 |
+| 11 | 恢复隔离 | 备份保留 `archiveId`；每次成功切换 current 指针 **新铸 `restoreEpoch`（UUID）**，不从备份恢复当前身份；历史回执可含 sourceRestoreEpoch，不按 backup.generation+1。旧队列盖章对不上则暂停 |
 | 12 | 提醒 | 关窗 ≠ 退出。启用后台提醒时走 **用户授权的系统调度通知**，不把进程闲置包装成次日提醒。不偷偷开机启动。主动退出须展示能力限制 |
 | 13 | 通知语义 | `replyClass` = 业务类型；`sendMode` = 发送方式（`human` / `automated` / `unknown`）。面试邀请等 **不得**仅因类型投影成「人工回复」 |
 | 14 | 密钥 | 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库（Windows Credential Manager / DPAPI，macOS Keychain）；二者都不进档案/备份/日志 |
 | 15 | 备份 | MVP **不加密**；导出警告含 PII |
 | 16 | 填写留档 | 默认只存事件元数据；逐字段值默认关闭；快照 ≤ 2 MiB |
-| 17 | 交付物 | Windows：NSIS per-user 安装包。macOS：`.app` / `.dmg`。正式版是否必须双平台同时交付 → [开放问题](downstream-decisions.md#需要项目负责人选择) |
+| 17 | 交付物 | Windows：NSIS per-user 安装包。macOS：`.app` / `.dmg`。正式版是否必须双平台同时交付 → [开放问题](downstream-decisions.md#4-需要项目负责人选择) |
 
-未确认项见 [需要项目负责人选择](downstream-decisions.md#需要项目负责人选择)。原型验证项见 [需要后续原型验证](downstream-decisions.md#需要后续原型验证)。
+未确认项见 [需要项目负责人选择](downstream-decisions.md#4-需要项目负责人选择)。原型验证项见 [需要后续原型验证](downstream-decisions.md#5-需要后续原型验证)。
 
 ## 开放问题入口
 
-只把真正需要负责人拍板的问题放在 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。当前建议的负责人选择集：
+只把真正需要负责人拍板的问题放在 [downstream-decisions.md](downstream-decisions.md#4-需要项目负责人选择)。当前建议的负责人选择集：
 
 1. 首个对外「正式桌面 MVP」是否必须 Windows + macOS 同时交付
 2. Tauri 2 vs Electron
@@ -101,4 +101,4 @@
 
 **明确不交付：** `/desktop` 源码树、crate 脚手架、SQLite `CREATE TABLE`、协议 JSON Schema、Native Messaging 注册、安装器、Tauri/Electron 安装、真实 AI 调用、邮箱连接、插件权限/版本变更、合并、关闭 #17、宣称架构已冻结。
 
-下游任务编号与 GitHub issue 对照见 [downstream-decisions.md](downstream-decisions.md#d02d14-消费映射)。
+下游任务编号与 GitHub issue 对照见 [downstream-decisions.md](downstream-decisions.md#2-d02d14-消费映射)。

--- a/docs/desktop-mvp/README.md
+++ b/docs/desktop-mvp/README.md
@@ -71,11 +71,12 @@
 | 6 | 身份 | 申请 UUID；两层候选（精确三元组 / 同公司提示）；**禁止**自动合并 |
 | 7 | 离线保存 | 区分 **保存意图**（已确认要存、尚未绑定申请）与 **已绑定业务消息**。曾经配对但桌面暂不可用：可持久化意图并显示「待同步」，**不得**显示「桌面已保存」。未安装/从未配对：不建长期队列 |
 | 8 | 快照 | 确认留档时立即生成不可变字节；无论桌面是否在线，发送前完整字节先提交到 **扩展源 IndexedDB**，完整提交/哈希 ACK 前保留，元数据进 `chrome.storage.local`。重试不得从最新模板重生成 |
-| 9 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；当前 epoch 校验与完整历史回执对账分离（见产品 §8.11） |
+| 9 | 协议 | 握手后写入与 `outbox.reconcile` **必须**在信封携带当前 `archiveId`/`restoreEpoch`；health/handshake 禁止携带。分片每块独立持久化 `messageId`。64 KiB 指完整 UTF-8 JSON |
 | 10 | 配对 | **D01 不加 `key`**。桌面 UI **粘贴扩展 ID**；**第一条 NM 不是配对消息** |
 | 11 | 恢复隔离 | 备份保留 `archiveId`；每次成功切换 current 指针 **新铸 `restoreEpoch`（UUID）**，不从备份恢复当前身份；历史回执可含 sourceRestoreEpoch，不按 backup.generation+1。旧队列盖章对不上则暂停 |
 | 12 | 提醒 | 关窗 ≠ 退出。启用后台提醒时走 **用户授权的系统调度通知**，不把进程闲置包装成次日提醒。不偷偷开机启动。主动退出须展示能力限制 |
-| 13 | 通知语义 | `replyClass` = 业务类型；`sendMode` = 发送方式（`human` / `automated` / `unknown`）。面试邀请等 **不得**仅因类型投影成「人工回复」 |
+| 13 | 通知语义 | `replyClass` ≠ `sendMode`。已导入未分类 = `imported_unclassified`，禁止显示「尚未导入」。面试邀请不得写成「人工回复」 |
+| 18 | 事件顺序 | 每申请单调 `eventSequence` 与写入同事务；`recordedAt` 不做折叠键 |
 | 14 | 密钥 | 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库（Windows Credential Manager / DPAPI，macOS Keychain）；二者都不进档案/备份/日志 |
 | 15 | 备份 | MVP **不加密**；导出警告含 PII |
 | 16 | 填写留档 | 默认只存事件元数据；逐字段值默认关闭；快照 ≤ 2 MiB |

--- a/docs/desktop-mvp/README.md
+++ b/docs/desktop-mvp/README.md
@@ -1,0 +1,97 @@
+# Resume Pro 桌面求职管理 MVP — 设计文档索引
+
+| 字段 | 值 |
+| --- | --- |
+| 标题 | 桌面求职管理 MVP 设计基线 |
+| 作者 | D01 design PR |
+| 日期 | 2026-09-06 |
+| 状态 | Draft / Ready for review |
+| Issue | [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
+| Epic | [#15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
+
+本文档集是 Epic #15 的 **P0 设计冻结** 产物。D01 **只产出设计决策**，不实现桌面应用、SQLite 迁移、Native Messaging host、协议 JSON Schema、安装器或插件功能变更。当前插件仍为 Manifest V3 `0.3.0`，权限与填写行为保持不变。
+
+负责人在本 PR / #17 上确认关键决策之前，下游只允许可丢弃原型，不得冻结实现接口。
+
+## 如何阅读
+
+按角色选择入口，不必按文件顺序通读：
+
+1. **产品 / 负责人**：先读本页「关键决策快照」和 [需要负责人选择的项](downstream-decisions.md#需要项目负责人选择)，再读 [产品需求](product-requirements.md) 的目标用户、十条冻结规则、阶段模型和八个合成走查。
+2. **D02 / D06 / D13（壳、进程、安装）**：读 [架构 ADR](adr-architecture.md) 的技术选型、进程模型、安装与仓库布局。
+3. **D03 / D04 / D08 / D09 / D10（数据与界面）**：读 [产品需求](product-requirements.md) 的对象关系、字段目录和走查；物理 schema 仍归 D03。
+4. **D05 / D07（协议与插件连接）**：读 ADR 的协议原则，以及 [数据与隐私](data-privacy.md) 的密钥/URL 脱敏规则。不要在 D01 寻找完整 JSON Schema。
+5. **D11 / D12 / D14（AI、备份、首发）**：读 [数据与隐私](data-privacy.md) 与 [下游映射](downstream-decisions.md)。
+
+文档互相链接，稳定标识符（stage code、协议字段、crate 名）保持英文；正文为中文。
+
+## 文档清单
+
+| 文档 | 内容 | 主要消费者 |
+| --- | --- | --- |
+| [product-requirements.md](product-requirements.md) | MVP 产品规则、阶段、字段目录、合成走查、降级模式 | D03–D04、D07–D11、D14 |
+| [adr-architecture.md](adr-architecture.md) | Tauri 2 + Rust 选型、进程模型、协议原则、仓库布局、安装 | D02、D05、D06、D13 |
+| [data-privacy.md](data-privacy.md) | 数据归属、敏感分级、备份恢复、密钥、日志 | D03、D08、D11、D12、D13 |
+| [downstream-decisions.md](downstream-decisions.md) | D02–D14 消费清单、定案/待选/待验证、依赖图 | 全部下游 |
+
+现有插件文档 [../ai-repeat-validation.md](../ai-repeat-validation.md) **不在本次修改范围**，仍是 v0.3.0 填写/辅助新增的验证记录。
+
+## 现状（以仓库代码为准，不以 README 宣传为准）
+
+以下事实来自当前仓库，D01 不得改动这些运行时文件：
+
+| 事实 | 来源 |
+| --- | --- |
+| Manifest V3，`version` `0.3.0`，`minimum_chrome_version` `116` | [`manifest.json`](../../manifest.json) |
+| 权限：`offscreen`、`storage`、`scripting`、`activeTab`、`tabs`；`host_permissions`：`<all_urls>` | 同上 |
+| **没有** `nativeMessaging` 权限；**没有** extension `key` | 同上；未打包扩展 ID 由加载路径哈希派生，移动目录会变 |
+| 模板、`activeTemplateId`、`aiConfig`（`apiUrl` / `model` / `apiKey` 明文）存在 `chrome.storage.local` | [`content.js`](../../content.js) `STORAGE_KEYS`；[`popup.js`](../../popup.js) `DEFAULT_STORE` |
+| Service worker 今天 = `chrome.action.onClicked` → `TOGGLE_MANAGER` **加上** `ENSURE_AI_HOST`（offscreen.createDocument）。**没有** NM | [`background.js`](../../background.js)；D07 增加 NM 时不得覆盖 `onClicked` |
+| AI 请求走 offscreen `ai-host.html` + `ai-worker.js`，不在 service worker 里等响应 | [`ai-host.js`](../../ai-host.js) |
+| `chrome.storage.local` 另有 `resumeProUpdateCache` / `resumeProDismissedVersion`（更新检查）。D07 outbox 不得占用这些 key | [`popup.js`](../../popup.js) |
+| 填写由用户点击触发；`form-agent.js` 仅在确认后点击安全的「新增/添加」按钮；不提交表单 | [`form-agent.js`](../../form-agent.js) `isSafeButton` / `execute` |
+| 今天不存在求职档案、填写事件日志或桌面连接 | 全仓库无 `sendNativeMessage` / 申请对象 |
+| 以 ZIP 解压后在 Chrome/Edge 加载已解压扩展；MIT License | [`README.md`](../../README.md)、[`LICENSE`](../../LICENSE) |
+
+仓库根目录 **没有** `AGENTS.md` / `Claude.md`。
+
+## 关键决策快照
+
+下列为本次建议定案，**等负责人在 #17 / 本 PR 确认后冻结**。理由与备选见各专文。完整列表见文末「关键决策」在 [下游文档](downstream-decisions.md) 与各专文的对应章节。
+
+| # | 决策 | 一句话 |
+| --- | --- | --- |
+| 1 | 桌面栈 | **Tauri 2**；Rust 后端 = 唯一写入者；不用 Electron |
+| 2 | 安装包 | 仅 **NSIS `setup.exe`、per-user、默认不要求管理员**；MVP 不做 MSI |
+| 3 | 进程 | **两个 EXE**：Tauri GUI（后端=唯一写入者）+ 薄 `native-host.exe`。v1 **没有**第三个常驻写入进程。禁止未鉴权 HTTP |
+| 4 | 权威源 | **桌面档案是申请数据的 source of truth**；插件模板与填写在未装桌面时仍独立可用 |
+| 5 | 默认阶段 | 插件保存岗位 → `saved`（已收藏），**不是** `submitted`。插件「确认已投递」归 **D07** |
+| 6 | 身份 | 申请 UUID；两层候选（精确三元组 / 同公司提示）；**禁止**自动合并 |
+| 7 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；幂等键 `(clientInstanceId, messageId)` |
+| 8 | 配对 | **D01 不加 `key`**。桌面 UI **粘贴扩展 ID** 写入 host manifest；**第一条 NM 不是配对消息**。未配对 ≠ 未安装，且不建长期队列 |
+| 9 | 填写留档 | 默认只存事件元数据；逐字段值默认关闭；快照 ≤ 2 MiB，分片传输 |
+| 10 | 备份 | MVP **不加密**；恢复到新目录、**保留 backup 的 `archiveId`、必增 `generation`**；握手成功后插件暂停旧队列 |
+| 11 | 密钥 | 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库；二者都不进档案/备份/日志 |
+| 12 | 范围 | Windows + Chrome/Edge；无邮箱 OAuth/IMAP、无自动投递、无云账号、无多设备同步、无 Mac/Linux 成品 |
+
+未确认项与「不选的代价」见 [需要项目负责人选择](downstream-decisions.md#需要项目负责人选择)。原型验证项见 [需要后续原型验证](downstream-decisions.md#需要后续原型验证)。
+
+## 开放问题入口
+
+只把真正需要负责人拍板的问题放在 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。当前建议的负责人选择集（共 7 项，不扩写）：
+
+1. Tauri 2 vs Electron
+2. NSIS-only vs NSIS+MSI
+3. 托盘 + 后台空闲退出 vs 关窗口即杀服务
+4. 桌面粘贴扩展 ID 配对 vs 在插件里加 `key`（会迁移扩展 ID）
+5. 填写留档默认仅元数据 vs 默认包含字段值
+6. 备份不加密 vs 加密
+7. 64 KiB 信封上限 vs 其他上限
+
+## 本 D01 的交付与非交付
+
+**交付：** 本目录五份中文设计文档（含本索引）。文档 PR 即 D01 的全部实现。
+
+**明确不交付：** `/desktop` 源码树、crate 脚手架、SQLite `CREATE TABLE`、协议 JSON Schema、Native Messaging 注册、安装器、Tauri/Electron 安装、真实 AI 调用、邮箱连接、插件权限/版本变更。
+
+下游任务编号与 GitHub issue 对照见 [downstream-decisions.md](downstream-decisions.md#d02d14-消费映射)。

--- a/docs/desktop-mvp/README.md
+++ b/docs/desktop-mvp/README.md
@@ -5,36 +5,38 @@
 | 标题 | 桌面求职管理 MVP 设计基线 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review |
+| 状态 | Draft / Ready for review（**未冻结**；负责人确认前下游只做可丢弃原型） |
 | Issue | [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | Epic | [#15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
 
-本文档集是 Epic #15 的 **P0 设计冻结** 产物。D01 **只产出设计决策**，不实现桌面应用、SQLite 迁移、Native Messaging host、协议 JSON Schema、安装器或插件功能变更。当前插件仍为 Manifest V3 `0.3.0`，权限与填写行为保持不变。
+本文档集是 Epic #15 的 **P0 设计基线**。D01 **只产出设计决策**，不实现桌面应用、SQLite 迁移、Native Messaging host、协议 JSON Schema、安装器或插件功能变更。当前插件仍为 Manifest V3 `0.3.0`，权限与填写行为保持不变。
 
-负责人在本 PR / #17 上确认关键决策之前，下游只允许可丢弃原型，不得冻结实现接口。
+负责人在本 PR / #17 上确认关键决策之前，**不得宣称架构已冻结**。下游只允许可丢弃原型，不得把本目录当作已批准的实现接口。
 
 ## 如何阅读
 
 按角色选择入口，不必按文件顺序通读：
 
-1. **产品 / 负责人**：先读本页「关键决策快照」和 [需要负责人选择的项](downstream-decisions.md#需要项目负责人选择)，再读 [产品需求](product-requirements.md) 的目标用户、十条冻结规则、阶段模型和八个合成走查。
-2. **D02 / D06 / D13（壳、进程、安装）**：读 [架构 ADR](adr-architecture.md) 的技术选型、进程模型、安装与仓库布局。
-3. **D03 / D04 / D08 / D09 / D10（数据与界面）**：读 [产品需求](product-requirements.md) 的对象关系、字段目录和走查；物理 schema 仍归 D03。
-4. **D05 / D07（协议与插件连接）**：读 ADR 的协议原则，以及 [数据与隐私](data-privacy.md) 的密钥/URL 脱敏规则。不要在 D01 寻找完整 JSON Schema。
+1. **产品 / 负责人**：先读本页「关键决策快照」和 [需要负责人选择的项](downstream-decisions.md#需要项目负责人选择)，再读 [产品需求](product-requirements.md) 的目标用户、产品规则、阶段模型、离线意图/绑定，以及合成走查。
+2. **D02 / D06 / D13（壳、进程、安装）**：读 [架构 ADR](adr-architecture.md) 的技术选型、**进程角色**（不是「两个 EXE」契约）、跨平台适配边界、安装与仓库布局。D02 起必须做 **macOS 原型**，不能等 Windows 全做完再移植。
+3. **D03 / D04 / D08 / D09 / D10（数据与界面）**：读 [产品需求](product-requirements.md) 的对象关系、字段目录、`restoreEpoch`、提醒语义和走查；物理 schema 仍归 D03。
+4. **D05 / D07（协议与插件连接）**：读 ADR 的协议原则，产品需求的 **保存意图 vs 已绑定业务消息**，以及 [数据与隐私](data-privacy.md) 的快照暂存 / 密钥规则。不要在 D01 寻找完整 JSON Schema。
 5. **D11 / D12 / D14（AI、备份、首发）**：读 [数据与隐私](data-privacy.md) 与 [下游映射](downstream-decisions.md)。
 
-文档互相链接，稳定标识符（stage code、协议字段、crate 名）保持英文；正文为中文。
+文档互相链接。稳定标识符（stage code、协议字段、crate 名、进程角色名）保持英文；正文为中文。平台无关契约不写 `*.exe`。
 
 ## 文档清单
 
 | 文档 | 内容 | 主要消费者 |
 | --- | --- | --- |
-| [product-requirements.md](product-requirements.md) | MVP 产品规则、阶段、字段目录、合成走查、降级模式 | D03–D04、D07–D11、D14 |
-| [adr-architecture.md](adr-architecture.md) | Tauri 2 + Rust 选型、进程模型、协议原则、仓库布局、安装 | D02、D05、D06、D13 |
-| [data-privacy.md](data-privacy.md) | 数据归属、敏感分级、备份恢复、密钥、日志 | D03、D08、D11、D12、D13 |
+| [product-requirements.md](product-requirements.md) | MVP 产品规则、阶段、离线意图/绑定、快照暂存、提醒语义、字段目录、合成走查 | D03–D04、D07–D11、D14 |
+| [adr-architecture.md](adr-architecture.md) | Tauri 2 选型、进程角色、跨平台适配、协议原则、安装形态 | D02、D05、D06、D13 |
+| [data-privacy.md](data-privacy.md) | 数据归属、目录、敏感分级、IndexedDB 暂存、备份恢复、密钥 | D03、D08、D11、D12、D13 |
 | [downstream-decisions.md](downstream-decisions.md) | D02–D14 消费清单、定案/待选/待验证、依赖图 | 全部下游 |
 
 现有插件文档 [../ai-repeat-validation.md](../ai-repeat-validation.md) **不在本次修改范围**，仍是 v0.3.0 填写/辅助新增的验证记录。
+
+仓库根目录的 [`LICENSE`](../../LICENSE) 是 **当前插件** 的 MIT 许可。后续桌面模块的产品许可 **尚未定案**，不得把现有 MIT 写成未来所有模块的既定承诺。
 
 ## 现状（以仓库代码为准，不以 README 宣传为准）
 
@@ -48,50 +50,55 @@
 | 模板、`activeTemplateId`、`aiConfig`（`apiUrl` / `model` / `apiKey` 明文）存在 `chrome.storage.local` | [`content.js`](../../content.js) `STORAGE_KEYS`；[`popup.js`](../../popup.js) `DEFAULT_STORE` |
 | Service worker 今天 = `chrome.action.onClicked` → `TOGGLE_MANAGER` **加上** `ENSURE_AI_HOST`（offscreen.createDocument）。**没有** NM | [`background.js`](../../background.js)；D07 增加 NM 时不得覆盖 `onClicked` |
 | AI 请求走 offscreen `ai-host.html` + `ai-worker.js`，不在 service worker 里等响应 | [`ai-host.js`](../../ai-host.js) |
-| `chrome.storage.local` 另有 `resumeProUpdateCache` / `resumeProDismissedVersion`（更新检查）。D07 outbox 不得占用这些 key | [`popup.js`](../../popup.js) |
+| `chrome.storage.local` 另有 `resumeProUpdateCache` / `resumeProDismissedVersion`（更新检查）。D07 outbox / 意图队列不得占用这些 key | [`popup.js`](../../popup.js) |
 | 填写由用户点击触发；`form-agent.js` 仅在确认后点击安全的「新增/添加」按钮；不提交表单 | [`form-agent.js`](../../form-agent.js) `isSafeButton` / `execute` |
 | 今天不存在求职档案、填写事件日志或桌面连接 | 全仓库无 `sendNativeMessage` / 申请对象 |
-| 以 ZIP 解压后在 Chrome/Edge 加载已解压扩展；MIT License | [`README.md`](../../README.md)、[`LICENSE`](../../LICENSE) |
+| 以 ZIP 解压后在 Chrome/Edge 加载已解压扩展 | [`README.md`](../../README.md) |
 
 仓库根目录 **没有** `AGENTS.md` / `Claude.md`。
 
 ## 关键决策快照
 
-下列为本次建议定案，**等负责人在 #17 / 本 PR 确认后冻结**。理由与备选见各专文。完整列表见文末「关键决策」在 [下游文档](downstream-decisions.md) 与各专文的对应章节。
+下列为本次 **建议**，**等负责人在 #17 / 本 PR 确认后才可冻结**。理由与备选见各专文。
 
 | # | 决策 | 一句话 |
 | --- | --- | --- |
-| 1 | 桌面栈 | **Tauri 2**；Rust 后端 = 唯一写入者；不用 Electron |
-| 2 | 安装包 | 仅 **NSIS `setup.exe`、per-user、默认不要求管理员**；MVP 不做 MSI |
-| 3 | 进程 | **两个 EXE**：Tauri GUI（后端=唯一写入者）+ 薄 `native-host.exe`。v1 **没有**第三个常驻写入进程。禁止未鉴权 HTTP |
+| 1 | 平台 | **Windows 与 macOS 都是目标平台**。实现可 Windows 优先，但 D02 起必须做 Mac 原型。Linux 仍非首版产品。浏览器首阶段仍是 Chrome/Edge，**不默认承诺 Safari** |
+| 2 | 桌面栈 | **推荐 Tauri 2**（团队成本、体积、原生集成、跨平台维护）。Electron 可做同等产品，不是「必须管理员」或「不能做 stdio」 |
+| 3 | 进程角色 | **应用进程 = 唯一写入者**；**NM host 进程 = 翻译器**（浏览器可拉起多个实例）；WebView/WKWebView 子进程不是写入者。平台无关契约不写 `*.exe` |
 | 4 | 权威源 | **桌面档案是申请数据的 source of truth**；插件模板与填写在未装桌面时仍独立可用 |
 | 5 | 默认阶段 | 插件保存岗位 → `saved`（已收藏），**不是** `submitted`。插件「确认已投递」归 **D07** |
 | 6 | 身份 | 申请 UUID；两层候选（精确三元组 / 同公司提示）；**禁止**自动合并 |
-| 7 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；幂等键 `(clientInstanceId, messageId)` |
-| 8 | 配对 | **D01 不加 `key`**。桌面 UI **粘贴扩展 ID** 写入 host manifest；**第一条 NM 不是配对消息**。未配对 ≠ 未安装，且不建长期队列 |
-| 9 | 填写留档 | 默认只存事件元数据；逐字段值默认关闭；快照 ≤ 2 MiB，分片传输 |
-| 10 | 备份 | MVP **不加密**；恢复到新目录、**保留 backup 的 `archiveId`、必增 `generation`**；握手成功后插件暂停旧队列 |
-| 11 | 密钥 | 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库；二者都不进档案/备份/日志 |
-| 12 | 范围 | Windows + Chrome/Edge；无邮箱 OAuth/IMAP、无自动投递、无云账号、无多设备同步、无 Mac/Linux 成品 |
+| 7 | 离线保存 | 区分 **保存意图**（已确认要存、尚未绑定申请）与 **已绑定业务消息**。曾经配对但桌面暂不可用：可持久化意图并显示「待同步」，**不得**显示「桌面已保存」。未安装/从未配对：不建长期队列 |
+| 8 | 快照 | 确认留档时立即生成不可变字节；桌面不可用时字节进 **扩展源 IndexedDB**，元数据进 `chrome.storage.local`。重试不得从最新模板重生成 |
+| 9 | 协议 | 业务信封双向 **64 KiB**；文件字节走分片 NM；幂等键 `(clientInstanceId, messageId, restoreEpoch)` |
+| 10 | 配对 | **D01 不加 `key`**。桌面 UI **粘贴扩展 ID**；**第一条 NM 不是配对消息** |
+| 11 | 恢复隔离 | 备份保留 `archiveId`；每次成功切换 current 指针 **新铸 `restoreEpoch`（UUID）**，不从备份拷贝、不按 backup.generation+1。旧队列盖章对不上则暂停 |
+| 12 | 提醒 | 关窗 ≠ 退出。启用后台提醒时走 **用户授权的系统调度通知**，不把进程闲置包装成次日提醒。不偷偷开机启动。主动退出须展示能力限制 |
+| 13 | 通知语义 | `replyClass` = 业务类型；`sendMode` = 发送方式（`human` / `automated` / `unknown`）。面试邀请等 **不得**仅因类型投影成「人工回复」 |
+| 14 | 密钥 | 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库（Windows Credential Manager / DPAPI，macOS Keychain）；二者都不进档案/备份/日志 |
+| 15 | 备份 | MVP **不加密**；导出警告含 PII |
+| 16 | 填写留档 | 默认只存事件元数据；逐字段值默认关闭；快照 ≤ 2 MiB |
+| 17 | 交付物 | Windows：NSIS per-user 安装包。macOS：`.app` / `.dmg`。正式版是否必须双平台同时交付 → [开放问题](downstream-decisions.md#需要项目负责人选择) |
 
-未确认项与「不选的代价」见 [需要项目负责人选择](downstream-decisions.md#需要项目负责人选择)。原型验证项见 [需要后续原型验证](downstream-decisions.md#需要后续原型验证)。
+未确认项见 [需要项目负责人选择](downstream-decisions.md#需要项目负责人选择)。原型验证项见 [需要后续原型验证](downstream-decisions.md#需要后续原型验证)。
 
 ## 开放问题入口
 
-只把真正需要负责人拍板的问题放在 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。当前建议的负责人选择集（共 7 项，不扩写）：
+只把真正需要负责人拍板的问题放在 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。当前建议的负责人选择集：
 
-1. Tauri 2 vs Electron
-2. NSIS-only vs NSIS+MSI
-3. 托盘 + 后台空闲退出 vs 关窗口即杀服务
-4. 桌面粘贴扩展 ID 配对 vs 在插件里加 `key`（会迁移扩展 ID）
-5. 填写留档默认仅元数据 vs 默认包含字段值
-6. 备份不加密 vs 加密
-7. 64 KiB 信封上限 vs 其他上限
+1. 首个对外「正式桌面 MVP」是否必须 Windows + macOS 同时交付
+2. Tauri 2 vs Electron
+3. 后台提醒：系统调度通知 vs 常驻进程
+4. 备份不加密 vs 加密
+5. Windows 是否另发 MSI（macOS 仍是 `.dmg`）
+
+配对方式、64 KiB 信封、填写留档默认仅元数据：本次作为 **建议定案** 写入正文，不再占用拍板名额；否决时仍按「先改 D01 再动下游」处理。
 
 ## 本 D01 的交付与非交付
 
-**交付：** 本目录五份中文设计文档（含本索引）。文档 PR 即 D01 的全部实现。
+**交付：** 本目录五份中文设计文档（含本索引），以及同步后的相关 GitHub issue 正文。文档 PR 即 D01 的全部实现。
 
-**明确不交付：** `/desktop` 源码树、crate 脚手架、SQLite `CREATE TABLE`、协议 JSON Schema、Native Messaging 注册、安装器、Tauri/Electron 安装、真实 AI 调用、邮箱连接、插件权限/版本变更。
+**明确不交付：** `/desktop` 源码树、crate 脚手架、SQLite `CREATE TABLE`、协议 JSON Schema、Native Messaging 注册、安装器、Tauri/Electron 安装、真实 AI 调用、邮箱连接、插件权限/版本变更、合并、关闭 #17、宣称架构已冻结。
 
 下游任务编号与 GitHub issue 对照见 [downstream-decisions.md](downstream-decisions.md#d02d14-消费映射)。

--- a/docs/desktop-mvp/adr-architecture.md
+++ b/docs/desktop-mvp/adr-architecture.md
@@ -5,7 +5,7 @@
 | 标题 | ADR-001 桌面栈、进程角色、跨平台适配与通信原则 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review（**未冻结**） |
+| 状态 | 可修订开工基线（PR 合并后生效） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | 并列 | [product-requirements.md](product-requirements.md) · [data-privacy.md](data-privacy.md) · [downstream-decisions.md](downstream-decisions.md) |
 

--- a/docs/desktop-mvp/adr-architecture.md
+++ b/docs/desktop-mvp/adr-architecture.md
@@ -1,27 +1,27 @@
-# ADR：Windows 桌面主程序架构与技术选型
+# ADR：桌面主程序架构与技术选型
 
 | 字段 | 值 |
 | --- | --- |
-| 标题 | ADR-001 桌面栈、进程模型与通信原则 |
+| 标题 | ADR-001 桌面栈、进程角色、跨平台适配与通信原则 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review |
+| 状态 | Draft / Ready for review（**未冻结**） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | 并列 | [product-requirements.md](product-requirements.md) · [data-privacy.md](data-privacy.md) · [downstream-decisions.md](downstream-decisions.md) |
 
-本 ADR 冻结 **用什么技术、几个进程、怎么说话**。完整 JSON Schema 归 [D05 #23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23)；可执行 host 归 [D06 #24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24)；安装注册归 [D13 #29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29)。D01 不脚手架 `/desktop` 源码。
+本 ADR 建议 **用什么技术、哪些进程角色、怎么说话、平台边界在哪**。完整 JSON Schema 归 [D05 #23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23)；host 实现归 [D06 #24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24)；安装注册归 [D13 #29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29)。D01 不脚手架 `/desktop` 源码。
+
+平台无关契约使用 **进程角色名**，不写 `*.exe`。
 
 ---
 
 ## 1. Overview
 
-在现有 Chrome/Edge 插件之外增加 Windows 本地主程序：唯一写入者持有 SQLite 与附件目录；浏览器经 **Native Messaging** 连接一个 **薄 host EXE**；GUI 用 Tauri 2 WebView。插件继续用 JavaScript，根目录布局与当前 ZIP 打包不变。
+在现有 Chrome/Edge 插件之外增加 **本机桌面主程序**：唯一写入者持有 SQLite 与附件目录；浏览器经 **Native Messaging** 连接 **NM host 进程**；GUI 用 WebView（Tauri 2 下 Windows 为 WebView2，macOS 为 WKWebView）。
 
-选型约束来自本项目，而不是通用「Tauri vs Electron」清单：
+**Windows 与 macOS 都是目标平台。** 实现可 Windows 优先，但 D02 起必须有 macOS 构建与 NM 原型，不能等 Windows 全做完再移植。业务模型、SQLite、事件、AI 建议、通信消息保持平台无关。Linux 仍非首版产品。浏览器首阶段仍是 Chrome/Edge，**不默认承诺 Safari**。
 
-- 需要 **唯一写入者**、事务、附件文件、备份/恢复路径控制 → 必须有原生进程，而不是纯扩展存储。
-- Native Messaging 规定 host 用 stdin/stdout 且带 4 字节长度前缀；**GUI 不得占用该 stdout** → 无论哪种 UI 工具包都要单独的薄 host。
-- 只要 Windows；安装默认 per-user、非管理员。
+插件继续用 JavaScript，根目录布局与当前 ZIP 打包不变。
 
 ---
 
@@ -34,72 +34,80 @@ Chrome 官方协议（[Native messaging](https://developer.chrome.com/docs/exten
 - 每条消息：原生字节序的 32 位长度 + UTF-8 JSON。
 - Host → 浏览器上限 **1 MB**；浏览器 → host 上限 **64 MiB**。
 - `allowed_origins` **禁止通配符**。
-- 扩展必须声明 `nativeMessaging`；`connectNative` / `sendNativeMessage` **不能在 content script 调用**，只能在扩展页或 service worker。content script 必须先打到 SW。
+- 扩展必须声明 `nativeMessaging`；`connectNative` / `sendNativeMessage` **不能在 content script 调用**，只能在扩展页或 service worker。
 - `sendNativeMessage` **每条消息拉起一个新 host 进程**；`connectNative` 保持进程直到 port 销毁。
-- Windows：在 `HKCU\Software\Google\Chrome\NativeMessagingHosts\<name>`（或 HKLM）写入 manifest 绝对路径。Windows 上 stdout 必须 `O_BINARY`，调试日志只能写 stderr。
-- Service worker 场景下 `--parent-window` 为 0。
+- **Windows：** `HKCU\Software\Google\Chrome\NativeMessagingHosts\<name>` 指向 manifest；stdout 必须 `O_BINARY`；另有 `--parent-window=`（SW 下为 0）。
+- **macOS / Linux：** manifest 在固定目录。用户级 Chrome 默认为 `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/<name>.json`；系统级 `/Library/Google/Chrome/NativeMessagingHosts/`。macOS/Linux 上 `path` **必须是绝对路径**。
 
-Edge 文档（[Native messaging](https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging)）同构：`stdio`、`allowed_origins`、HKCU `SOFTWARE\Microsoft\Edge\NativeMessagingHosts\<name>`。Host → Edge 上限 1 MB；Edge → host 文档写的是 4 GB。若同时上架两个商店，两个扩展 ID 都要写入 `allowed_origins`（MVP 未上架，但 unpacked Chrome 与 Edge 是 **两个 ID**）。
+Edge（[Native messaging](https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging)）同构。Windows 上写 `HKCU\SOFTWARE\Microsoft\Edge\NativeMessagingHosts\`。Edge 官方查找顺序会回退到 Chromium/Chrome 键——**禁止依赖该回退当配对通道**（见原 D01 结论，仍然成立）。macOS 用户级 Edge 目录为 `~/Library/Application Support/Microsoft Edge/NativeMessagingHosts/`（**待验证**频道变体，D13 对照 [Edge 文档](https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging) 实测）。
 
-Edge 官方 **查找顺序**（不得依赖当配对通道）：先 `HKCU\SOFTWARE\Microsoft\Edge\NativeMessagingHosts\`，再 Chromium，再 `Google\Chrome`；然后 HKLM / WOW6432Node 同类键。若只写 Chrome 键，Edge 仍可能 **找到** 名为 `com.resumepro.desktop` 的 host，但其 `allowed_origins` 只有 Chrome unpacked ID → Edge 报 **forbidden**，插件若当成「未安装」就会误导。
+Chrome/Edge 传给 host 的 **第一个参数是调用方 origin**（`chrome-extension://<id>/`）。`argv[0]` 是可执行路径，**不得**拿去比对 origin。实现扫描 argv 找 origin token。
 
-**冻结（D13）：** 始终分别写入 **Edge 与 Chrome 的 HKCU** 键。每个键指向一份 host manifest JSON；两份 JSON 可以相同路径（一份文件同时列入两个已配对 origin）或各一份。**禁止**指望 Edge 回退到 Chrome 键来「顺便」连上。Chrome 已配对而 Edge 未配对时，fallback 是脚枪：Edge 会连上 host 然后被 origin 拒绝。
-
-Chrome/Edge 传给 host 的 **第一个参数是调用方 origin**（`chrome-extension://<id>/`），不是 exe 路径。Windows 另有 `--parent-window=<handle>`；service worker 场景下该值为 `0`（ADR 下文 §4 校验顺序）。`argv[0]` 在 Win32 里是可执行文件路径，**不得**拿去比对 origin。
-
-这些事实迫使：**host 必须极瘦、stdout 纯净、按 origin 校验、业务 JSON 远小于 1 MB；注册必须双写 Chrome+Edge。**
+这些事实迫使：host 必须 stdout 纯净、按 origin 校验、业务 JSON 远小于 1 MB；Windows 双写 Chrome+Edge 注册；macOS 分别写 Chrome 与 Edge 的用户级 `NativeMessagingHosts`。
 
 ---
 
 ## 3. Decision
 
-### 3.1 桌面栈：Tauri 2 + Rust 数据服务（不用 Electron）
+### 3.1 桌面栈：推荐 Tauri 2（Electron 是可行备选，不是禁区）
 
-| 本项目约束 | Tauri 2 + Rust | Electron |
+**推荐 Tauri 2 + Rust 后端**，依据是 **本项目的团队成本、打包体积、原生集成与跨平台维护**，不是「Electron 必须管理员 / 天然不安全 / 不能做 stdio」。
+
+| 本项目需要 | Tauri 2 | Electron |
 | --- | --- | --- |
-| 唯一写入者 + SQLite 事务 + 附件路径 | `rusqlite`/`sqlx` 与文件系统在同一 Rust 进程；崩溃面小 | 需 `better-sqlite3` 等 native 模块，每次 Electron 升级要重建 |
-| NM host 必须是独立 EXE，且不能用 GUI 的 stdout | 可与 data-service **共享 crate**（协议编解码、幂等、路径） | 仍要单独 host EXE；Node 帮不上 stdio 帧，还多一个运行时 |
-| 仅 Windows | WebView2 在 Win11 预装；Win10 22H2 属官方支持范围（见 §8） | Chromium 整包，安装体大约 **100MB+** |
-| per-user、无管理员 | Tauri NSIS **默认 current user**，装到 `%LOCALAPPDATA%`（[Windows Installer](https://v2.tauri.app/distribute/windows-installer/)） | 常见安装器偏 Program Files / 管理员 |
-| 插件已是 JS | 桌面 UI 可用 web 技术；**不必**再塞一个 Node | 第二套 Node，且容易从渲染进程误暴露 fs |
+| 唯一写入者 + SQLite + 附件路径 | Rust 与文件系统在同一应用进程；可用 `rusqlite`/`sqlx` | 同样能做。常见是 `better-sqlite3` 等 native 模块，随 Electron ABI 重建（维护成本） |
+| Native Messaging stdio | 可用独立 helper，或 **同一产品二进制** 加 `--native-host` 进入无 GUI、二进制 stdout 模式 | **Node 可以**正确写 4 字节长度前缀（多款产品已这样做）。stdout 纪律是工程问题，不是运行时做不到 |
+| 安装体积 | 依赖系统 WebView2 / WKWebView，安装包通常明显小于内嵌 Chromium。**具体 MB 数待本仓库打样后填写，此处不写死** | 内嵌 Chromium，安装包通常更大。electron-builder 默认 NSIS **可以** `perMachine: false` 做 per-user、无管理员（[electron-builder NSIS](https://www.electron.build/nsis)） |
+| Windows + macOS | 同一套 Rust 后端；Windows WebView2、macOS WKWebView | 同一套 Chromium，两端行为更接近，体积与更新面也两端都大 |
+| 系统通知 / Keychain / 托盘 | 走原生 crate / 插件，适配面要自己测 | 生态示例多（含 NM）。渲染进程若打开 `nodeIntegration` 会放大 fs 暴露面——这是 **配置错误**，不是 Electron 必然不安全 |
+| 团队 | 新桌面代码；插件已是 JS。Rust 学习成本换共享 crate 与较小运行时 | 招聘前端更熟；等于再养一套 Chromium |
 
-**代价（必须承认）：** 团队要写 Rust；依赖 WebView2；NM host + named pipe + 单实例必须在 D02/D06 做原型（**待验证**）。不选 Tauri 的代价：安装包显著变大、沙箱叙事更弱、Node 侧更容易误开文件系统或 localhost HTTP。
+**独立 host 二进制不是唯一实现。** 可选：(A) 单独 helper 可执行文件（推荐，stdout 与 GUI 隔离更干净）；(B) 同一产品二进制以 CLI 标志进入 host 模式。两种都要保证 GUI 日志永不写到 host 的 stdout。D02/D06 原型二选一，失败则换另一种，**不**因此改业务协议。
 
-Sidecar（[Embedding External Binaries](https://v2.tauri.app/develop/sidecar/)）可用于把 `native-host.exe` 放进安装布局；host 也必须能被浏览器按 manifest `path` 直接拉起，不经过 Tauri 窗口。是否用 sidecar 打包 host 由 D13 决定，逻辑进程模型不变。
+**不选 Electron 的主要代价：** 两端都带 Chromium、更新与安全补丁面更大、SQLite native 模块要跟版本；本项目还要自己做 Keychain/DPAPI/NM 注册，Electron 并不能少掉这些适配。
 
-### 3.2 安装包：仅 NSIS `setup.exe`，per-user，MVP 无 MSI
+**选 Electron 的主要代价（若负责人改选）：** ADR 本节与 D02 脚手架作废，协议与产品模型仍可用。
 
-Tauri 可打 `.msi`（WiX，仅 Windows 主机）和 `-setup.exe`（NSIS）。Epic #15 / D13 把「是否补充 MSI」交给 D01。
+Sidecar（[Embedding External Binaries](https://v2.tauri.app/develop/sidecar/)）可把 host helper 放进安装布局；host 必须仍能被浏览器按 manifest `path` 直接拉起。
 
-**决定：** MVP 只发 NSIS per-user `setup.exe`。默认不要求管理员，安装目录在 `%LOCALAPPDATA%` 下的应用文件夹，**与用户档案目录分离**（档案见 [data-privacy.md](data-privacy.md#3-目录布局)）。
+### 3.2 安装形态
 
-企业若强需求 MSI，由后续版本/D13 增补，不作为首发承诺。`installMode=both` 会让安装器要管理员（官方说明），MVP 不采用。
+| 平台 | 建议交付 | 说明 |
+| --- | --- | --- |
+| Windows | NSIS per-user 安装包（`setup.exe` 是 **Windows 交付物文件名**，不是协议概念） | Tauri NSIS **默认 current user**，装到 `%LOCALAPPDATA%`（[Windows Installer](https://v2.tauri.app/distribute/windows-installer/)）。MVP 不默认 MSI；`installMode=both` 会要管理员，不采用 |
+| macOS | `.app` + `.dmg`（[macOS Application Bundle](https://v2.tauri.app/distribute/macos-application-bundle/)、[DMG](https://v2.tauri.app/distribute/)） | 默认最低系统 Tauri 写的是 **10.13**；本项目建议 **macOS 11+**。Apple Silicon 一等；Intel 用 `universal-apple-darwin` 或单独 x86_64，**待验证**。签名与公证见 §8 |
 
-未持有 EV/OV 代码签名证书前 **不宣传已签名**。发布说明必须写 SmartScreen「未识别的应用」警告及用户如何核对 SHA-256。
+未持有签名材料前 **不宣传已签名 / 已公证**。Windows 写 SmartScreen；macOS 写 Gatekeeper。
 
-卸载：删除程序文件、快捷方式、本应用的 NM 注册；**默认保留** `%LOCALAPPDATA%\ResumePro\archive\`。删数据必须单独确认（D13）。
+卸载：删除程序文件、快捷方式/应用包、本应用的 NM 注册；**默认保留**用户档案目录。删数据必须单独确认（D13）。
 
 ### 3.3 仓库布局（同仓，插件留在根目录）
-
-当前 ZIP 是把仓库根（含 `manifest.json`）解压后「加载已解压的扩展程序」。**禁止**把插件挪到子目录，否则现有发行说明与用户解压路径全部作废。
-
-规划中的树（D01 **只写文档，不创建 crate**）：
 
 ```text
 /                          现有插件（D01 零改动）
 /docs/desktop-mvp          本设计
 /docs/ai-repeat-validation.md   保持不动
-/desktop                   未来 Tauri 应用（D02+）：打出一个 GUI EXE
-/desktop/crates/data-service   库 crate，链进 Tauri 后端；不是第三个进程
-/desktop/crates/native-host    薄 host EXE（唯一额外二进制）
+/desktop                   未来桌面应用（D02+）
+/desktop/crates/data-service   库 crate，链进应用进程；不是第三个常驻写入进程
+/desktop/crates/native-host    host 角色（独立 helper 或同一二进制的 host 模式）
 /desktop/crates/protocol       （D05，库 crate）
 ```
 
-**v1 进程数冻结为 2：** Tauri GUI EXE + `native-host.exe`。`data-service` 是 **库**，不是常驻第三个 service EXE。
+插件与桌面 **版本号不必相等**；共享 `protocolVersion`。产品名建议 **Resume Pro Desktop**。NM host 名建议 `com.resumepro.desktop`（Chrome `name` 规则）。
 
-插件与桌面 **版本号不必相等**；共享的是 `protocolVersion`。桌面应用建议产品名 **Resume Pro Desktop**，NM host 名建议 `com.resumepro.desktop`（仅小写字母、数字、点、下划线，符合 Chrome `name` 规则）。
+当前插件 [`LICENSE`](../../LICENSE) 为 MIT。桌面模块许可 **未定案**。
 
-### 3.4 进程模型（冻结：两个 EXE）
+### 3.4 进程角色（平台无关契约）
+
+不要在协议或数据层写「两个 EXE」。角色如下：
+
+| 角色 | 职责 | 实例数 |
+| --- | --- | --- |
+| **应用进程（unique writer）** | 产品主二进制。持有 SQLite、附件、快照、幂等表、备份、current 指针、系统通知登记。Tauri 后端链 `data-service` 库 | **恰好一个**（单实例） |
+| **NM host 进程** | 解码 NM 帧、校验 origin/大小、按需启动或连接应用进程、白名单 RPC、**持久化提交后再回包**。不打开 SQLite | 浏览器可拉起 **多个**（`sendNativeMessage` 每条一个；Chrome 与 Edge 各一） |
+| **WebView / WKWebView 子进程** | 只渲染 UI，经应用内 IPC 调后端 | 由 WebView 自己管；**不是**写入者 |
+
+Windows 上这两个角色常常对应两个 `.exe` 文件；macOS 上常是 `.app/Contents/MacOS/` 里的主二进制 + helper。那是打包细节。
 
 ```mermaid
 flowchart LR
@@ -108,9 +116,9 @@ flowchart LR
     SW[background.js SW]
     CS -->|runtime.sendMessage| SW
   end
-  SW -->|"connectNative stdio\n4-byte length JSON"| HOST[native-host.exe]
-  HOST -->|"named pipe\ncurrent-user ACL"| APP[Tauri GUI EXE\nRust backend = UNIQUE WRITER]
-  UI[Tauri webview] -->|"in-process IPC"| APP
+  SW -->|"connectNative stdio"| HOST[NM host 进程]
+  HOST -->|"本地 IPC"| APP[应用进程 UNIQUE WRITER]
+  UI[WebView 子进程] -->|"in-process IPC"| APP
   APP --> DB[(SQLite)]
   APP --> ATT[attachments/]
   APP --> SNAP[snapshots/]
@@ -118,81 +126,67 @@ flowchart LR
 
 规则：
 
-1. **唯一写入者 = Tauri GUI EXE 的 Rust 后端**（链接 `data-service` 库）。Webview 与 `native-host` 都是该后端的客户端。v1 **不允许**第三个常驻 writer/service EXE。
-2. **native-host 是翻译器：** 解码 NM 帧、校验 origin 与大小、只转发白名单 RPC、**持久化提交后再回包**。Host **不**打开 SQLite。
-3. Host 发现唯一写入者未运行时 **按需启动同一个 Tauri GUI EXE（可无可见窗口）**，再连 named pipe。多个 host（Chrome 与 Edge、或多次 `sendNativeMessage`）必须连到 **这一个** 实例。
-4. **单实例：** 命名 mutex + 命名管道。第二次启动 UI：激活已有窗口，不第二写入者。第二 host：只连接。
-5. **关主窗口 = 隐藏到托盘（若 Q3 接受）或保持后端**，不等于退出写入者。Idle 时钟只在 **无可见窗口 ∧ 无活 NM 端口 ∧ 无进行中的备份/提醒** 时启动。默认 **15 分钟** 后退出进程。D02 可做成设置项，**不得**默认为 0 或「直到重启」。彻底退出走明确「退出」。**v1 无开机启动。**
-6. **建议托盘图标**，否则用户以为已退出却留下 GUI 子系统进程（见开放问题 Q3）。
-7. **禁止** 未鉴权的 localhost HTTP 端口（D05 非目标原文）。配对也不走 HTTP，见 §3.7。
-8. Named pipe DACL = 当前用户 SID；消息仍要校验调用方/会话，不因为「本机」就信任。
+1. 唯一写入者 = 应用进程。v1 **不允许**第三个常驻 writer。
+2. Host 发现应用进程未运行时可 **按需启动** 它（可无可见窗口），再连本地 IPC。所有 host 实例连这一个应用进程。
+3. **单实例：** 平台适配（Windows 命名 mutex + named pipe；macOS 建议 unix domain socket + 锁文件，或 Tauri 单实例插件）。第二次启动 UI：激活已有窗口。第二 host：只连接。
+4. **关主窗口 ≠ 退出。** 托盘（Windows）/ 菜单栏（macOS）提供「打开」「退出」。
+5. **空闲退出进程可以**，但 **不是提醒的可靠性基础**（§3.8）。
+6. **禁止**未鉴权 localhost HTTP。配对不走 HTTP（§3.7）。
+7. 本地 IPC 只允许当前用户（Windows pipe DACL = 当前 SID；macOS socket `0600` 且放在用户 Application Support 下）。不因为「本机」就信任。
 
-空闲行为：
+本地 IPC 选型 **待验证**（V1）：Windows named pipe 是现成的；macOS 用 unix socket。不要在 D01 把 named pipe 写进平台无关信封。
 
-```text
-有可见窗口 或 活 NM 端口 或 备份/提醒进行中  →  进程保持
-以上皆无                               →  开始 15 min idle timer
-idle 到期                              →  Tauri EXE 退出
-用户点「退出」                          →  立即停并断开
-MV3 SW 回收导致 port 断开              →  视为「无活 NM」；**不得丢 outbox**（V4）
-```
+### 3.5 为何 host 的 stdout 必须纯净
 
-保存岗位的进程内时序（产品语义与 **先探测再入队** 见 [product-requirements.md §5.2](product-requirements.md)）：
-
-```mermaid
-sequenceDiagram
-  participant SW as Extension SW
-  participant H as native-host
-  participant APP as Tauri EXE UNIQUE WRITER
-  Note over SW: 仅当已注册 host 且已配对且协议兼容才写 outbox
-  SW->>H: stdio 帧 handshake
-  H->>APP: named pipe connect / 按需启动本 EXE（可隐藏）
-  APP-->>SW: protocol range, appVer, archiveId, generation
-  SW->>H: application.queryCandidates
-  H->>APP: whitelist RPC
-  APP-->>SW: exact[] + sameCompany[] 最小元数据
-  SW->>H: job.save envelope 64KiB
-  H->>APP: 事务 + 幂等键
-  Note over APP: 提交后才允许 host 回包
-  APP-->>H: resultId, applicationId
-  H-->>SW: stdout 长度前缀 JSON
-```
-
-### 3.5 为何 GUI 不能兼 NM host
-
-Chrome 把 host 的 **stdout 整段当作协议帧**。任何 `println!`、日志、Tauri/WebView 调试输出都会破坏 4 字节前缀（官方排错：「All output in stdout must adhere to the protocol; debug on stderr」）。因此：
-
-- `native-host.exe`：CRT 设二进制模式；只写长度前缀 JSON；日志走文件/stderr。
-- Tauri GUI EXE：WINDOWS 子系统，可有自己的 stdout，但 **不要** 注册为 NM host 的 `path`。Host 按需启动的是 **这个** EXE（可无窗口），不是第三个 writer。
+Chrome 把 host 的 **stdout 整段当作协议帧**。GUI 框架日志会破坏 4 字节前缀。因此 host 模式：CRT/进程设二进制 stdout；只写长度前缀 JSON；日志走文件/stderr。这与「必须两个文件」不是同一句话。
 
 ### 3.6 插件侧连接落点（D07 实现，D01 约束）
 
-今天 [`background.js`](../../background.js) 处理两件事：`chrome.action.onClicked` → `TOGGLE_MANAGER`，以及 `ENSURE_AI_HOST`（`offscreen.createDocument`）。D07 **追加** NM，不得覆盖 `onClicked`。
+今天 [`background.js`](../../background.js) 处理 `onClicked` → `TOGGLE_MANAGER` 以及 `ENSURE_AI_HOST`。D07 **追加** NM，不得覆盖 `onClicked`。
 
-D07 将：
+D07 将：在 **service worker** 调用 `connectNative`（推荐）或受控的 `sendNativeMessage`；增加 `nativeMessaging` 权限（**D07 版本号提升，不是 0.3.0**）；`desktopSaveIntents` / `desktopOutbox` / `desktopClientInstanceId` / `desktopPairing`；侧边栏保存岗位与确认投递。快照字节走扩展源 IndexedDB（见产品 §8.5）。
 
-- 在 **service worker** 调用 `connectNative`（推荐）或受控的 `sendNativeMessage`；content script 不得直连。
-- 增加 `nativeMessaging` 权限——这是 **D07 的插件变更**，伴随版本号提升；**不是 D01，也不在 0.3.0 做**。
-- 持久化 outbox 使用新 key `desktopOutbox`；另存 `desktopClientInstanceId`（每扩展安装/Profile 一次生成的 UUID）。**禁止**占用已有 `templates`、`activeTemplateId`、`aiConfig`、`resumeProUpdateCache`、`resumeProDismissedVersion`。
-- 插件「确认已投递」按钮与 `submit.confirm` RPC 同属 D07（与 `job.save` 共用绑定/outbox；**不是**填写成功）。桌面手动确认仍归 D04。
-
-MV3 SW 空闲回收是否会断开 `connectNative`：**待验证**（V4）。缓解：短 RPC + 断线重连 + outbox；SW 回收看起来像「NM 断开」，**不得丢队列**。
-
-`sendNativeMessage` 每条拉起新 host 在本模型下 **可接受**（host 无状态，写入在 Tauri 后端），但冷启动更慢。D05 应规定：优先长连接，回落短连接，两者幂等语义相同。
+MV3 SW 与 `connectNative` 生命周期 **待验证**（V4）。
 
 ### 3.7 非 NM 配对引导（冻结）
 
-Chrome **不会启动** host，除非调用方 origin 已在该 host manifest 的 `allowed_origins` 里。因此插件 **不能** 把 `chrome.runtime.id` 经 NM 送给尚未认识它的 host。localhost HTTP 已禁止，所以配对必须走桌面 UI。
+Chrome **不会启动** host，除非 origin 已在 `allowed_origins`。插件不能把 `chrome.runtime.id` 经 NM 送给尚未认识它的 host。
 
-**冻结流程：**
+**冻结：** 桌面 UI 粘贴扩展 ID（Chrome / Edge 分开）→ 写入对应该浏览器的 host manifest → 提示重载扩展。第一条 NM 是 `handshake`，不是配对。
 
-1. D13 安装时向 Chrome **和** Edge 的 HKCU `NativeMessagingHosts\com.resumepro.desktop` 写入 manifest（host 已注册；`allowed_origins` 初始为空或仅含此前已配对 origin）。
-2. 用户在桌面「连接浏览器」中 **粘贴扩展 ID**（从 `chrome://extensions` / `edge://extensions` 复制）。Chrome 与 Edge **分别**粘贴、分别写入。
-3. 桌面把 `chrome-extension://<id>/` 写入对应浏览器的 host manifest（无通配符），提示 **重新加载扩展**（V3）。Chrome/Edge 是否无需重启即可重读 manifest：**待验证**（V3）；失败则文案要求重载或重启浏览器。
-4. **第一条 NM 消息不是配对消息**，而是 `handshake`。配对在 NM 能成功之前已经完成。
-5. 开发机隔离注册脚本（D06）可以预写测试 ID；生产 allowlist **不**接受任意扩展。
+- Windows：HKCU Chrome 与 Edge 键都写（不靠 Edge→Chrome fallback）。
+- macOS：写入用户级 `NativeMessagingHosts` 目录（Chrome 官方路径见 §2；Edge 路径 D13 实测）。不写系统级 `/Library/...`（要管理员）。
 
-降级：**已安装但未配对**（host 已注册，本 origin forbidden 或未列入）≠ 未安装。插件必须单独文案「请在桌面粘贴扩展 ID」，**不建长期 outbox**，**不说「未安装」**。移动 ZIP 目录导致路径哈希 ID 变化 = 需要重新粘贴，同样走未配对。
+**已安装但未配对** ≠ 未安装：不建 SaveIntent。移动 ZIP 导致 ID 变化 = 重新粘贴。
+
+### 3.8 提醒与后台（平台实现）
+
+共同语义见 [产品需求 §5.4](product-requirements.md#54-提醒与进程生命周期共同语义)。
+
+| | Windows | macOS |
+| --- | --- | --- |
+| 关窗 | 隐藏到托盘（若启用） | 隐藏到菜单栏 extra / Dock 仍在（习惯不同，D02 选一种并写进设置） |
+| 后台提醒 | 用户授权后，用 **计划应用通知** `ScheduledToastNotification` / AppNotification 日程 API（[Schedule an app notification](https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/app-notifications-scheduled)）。官方：计划通知有约 **5 分钟投递窗口**，关机过久可能丢 | `UNUserNotificationCenter` + `UNCalendarNotificationTrigger`（需通知权限）。不要求 Login Item |
+| 未打包 Win32 | Toast 常需 AUMID / Compat 库，**待验证**（V9） | — |
+| 主动退出 | 默认移除未触发的计划 Toast，并告知 | 默认移除 pending UNNotification，并告知 |
+| 开机启动 | **不**注册 Run 键 / 计划任务保活 | **不**偷偷加 Login Item |
+| 进程空闲退出 | 允许；与提醒解耦 | 允许；与提醒解耦 |
+
+D10 验收：启用后台提醒并授权后，**杀掉应用进程**，到期仍应尽量弹出系统通知（受 OS 窗口限制）。未授权时待办列表与逾期汇总仍可用。
+
+### 3.9 跨平台适配边界（D02 起就要列测试）
+
+| 边界 | Windows | macOS |
+| --- | --- | --- |
+| 用户数据目录 | `FOLDERID_LocalAppData` → `%LOCALAPPDATA%\ResumePro\` | `NSApplicationSupportDirectory` → `~/Library/Application Support/ResumePro/` |
+| 应用缓存 | LocalAppData 下 `cache\` 或 WebView2 用户数据文件夹 | `NSCachesDirectory` → `~/Library/Caches/ResumePro/` |
+| 本地 IPC / 单实例 | named pipe + mutex | unix socket + 锁文件（或等价）。**待验证** |
+| 按需启动应用进程 | host 启动产品 `.exe`，无控制台窗口 | host 启动 `.app` bundle 内二进制；路径含空格。**待验证** Gatekeeper 对 helper 的影响 |
+| NM 注册 | HKCU Chrome + Edge | 用户级 NativeMessagingHosts 目录，Chrome + Edge |
+| 凭据 | Credential Manager / DPAPI | Keychain |
+| 通知 / 托盘 | Toast + 托盘图标 | UNUserNotification + 菜单栏 |
+| 安装升级卸载 | NSIS per-user；卸载留档案 | dmg 拖入 / 删 .app；卸载留 Application Support 档案 |
+| 签名 | Authenticode；无证书则 SmartScreen | Developer ID + 公证 |
 
 ---
 
@@ -206,178 +200,128 @@ D05 必须包含的信封字段（此处冻结名字与枚举，不写 JSON Sche
 
 - `correlationId` = 请求 `messageId`。
 - `ok: true` 的写入应答必须有 `resultId`。
-- `ok: false` **没有** `resultId`，除非这是对 **已完成写入** 的幂等重放（此时 `ok: true` 并返回原 `resultId`）。
-- 成功时 `error` 省略或 `null`。
+- `ok: false` **没有** `resultId`，除非这是对 **已完成写入且 restoreEpoch 相符** 的幂等重放。
+- SaveIntent **不是** NM `messageType`。
 
-逻辑形状：
-
-```json
-{
-  "protocolVersion": 1,
-  "messageId": "0193a0c2-7c1a-7d2e-b8c1-0f1e2d3c4b5a",
-  "clientInstanceId": "ext-instance-uuid",
-  "messageType": "job.save",
-  "occurredAt": "2026-09-06T12:00:00.000Z",
-  "payload": {}
-}
-```
-
-```json
-{
-  "protocolVersion": 1,
-  "correlationId": "0193a0c2-7c1a-7d2e-b8c1-0f1e2d3c4b5a",
-  "resultId": "res-uuid",
-  "ok": true,
-  "payload": { "applicationId": "app-uuid" }
-}
-```
-
-**MVP `messageType` 枚举（英文点号，冻结）：**
+**MVP `messageType` 枚举：**
 
 | `messageType` | 方向 | 说明 |
 | --- | --- | --- |
-| `health` | 双向 | 探活，无业务写入 |
-| `handshake` | 双向 | 返回协议区间、app 版本、`archiveId`、`generation`、`capabilities`。**不是配对** |
-| `application.queryCandidates` | 插件→桌面 | 两层候选，最小元数据（见产品 §7） |
-| `job.save` | 插件→桌面 | 用户确认后的岗位保存 |
+| `health` | 双向 | 探活 |
+| `handshake` | 双向 | 返回协议区间、app 版本、`archiveId`、`restoreEpoch`、`capabilities`。**不是配对** |
+| `application.queryCandidates` | 插件→桌面 | 两层候选，最小元数据 |
+| `job.save` | 插件→桌面 | 已绑定后的岗位保存 |
 | `fill.submit` | 插件→桌面 | 填写事件元数据 + 可选 `snapshotId`/`sha256`（**不含**快照字节） |
-| `snapshot.chunk` | 插件→桌面 | 快照文件分片；每帧业务 JSON ≤ 64 KiB，payload 含序号与数据块 |
+| `snapshot.chunk` | 插件→桌面 | 快照分片；每帧 ≤ 64 KiB |
 | `submit.confirm` | 插件→桌面 | 用户明确确认已投递（D07） |
-| `outbox.reconcile` | 插件→桌面 | 入参 messageId 列表，出参已存在的 `(messageId, resultId)`；供恢复后「关联」使用。**不是**通用查询 |
-
-无通用 SQL、无任意路径读写、无远程 shell、无「配对」NM 类型。
-
-`clientInstanceId`：插件在 `chrome.storage.local.desktopClientInstanceId` 生成一次 UUID（每个扩展安装 / 浏览器 Profile）。存储被清则新 ID，旧幂等键不再匹配，这是可接受的。
+| `outbox.reconcile` | 插件→桌面 | 入参 messageId 列表，出参当前 epoch 库中已存在的 `(messageId, resultId)` |
 
 原则：
 
-1. **握手成功**即返回当前 `(archiveId, generation)`。插件版本与桌面版本不必相同。仅当协议区间不兼容或桌面 kill switch 时握手失败并 **禁止业务写入**。`generation` 变化 **不是**握手失败。
-2. **至少一次传送，业务恰好一次：** 应答只在事务提交后发出。幂等键 `(clientInstanceId, messageId)`。相同载荷重放 → 原 `resultId`；同一键不同载荷 → 拒绝且可诊断（D03）。
-3. **64 KiB 是业务信封上限**（低于 Chrome host→浏览器 1 MB / 浏览器→host 64 MiB；Edge inbound 文档 4 GB 不提高产品上限）。附件与快照 **字节永不**放进 `job.save` / `fill.submit` 信封。
-4. **插件→桌面文件字节**走 `snapshot.chunk`（每块 ≤ 64 KiB）或用户可见的「改在桌面导入」。Outbox 存元数据 + `sha256` + 可选分片游标，**默认不把整份 blob 放进 `chrome.storage.local`**（配额约 10 MB，且已有更新检查 key）。单份快照 **> 2 MiB 拒绝**，明确失败，不得假成功。附件（eml/pdf）由 D09 在桌面本地拷贝，不经插件 NM。
-5. **`allowed_origins` 无通配符。** D01 不加 `key`。配对见 §3.7。
-6. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13，**双写** Chrome+Edge HKCU。
-7. 恢复：新目录、**保留 backup 的 `archiveId`、generation 必 +1**。握手 **成功** 并返回新身份；插件比对 outbox 上盖的旧 `(archiveId, generation)` 后暂停队列。用户选关联 / 丢弃 / 另存。**永不自动重放。** 关联若需知道哪些 messageId 已在库中，调用 `outbox.reconcile`。
+1. **握手成功**即返回当前 `(archiveId, restoreEpoch)`。仅协议不兼容或 kill switch 时握手失败。epoch 变化 **不是**握手失败。
+2. **至少一次传送，业务恰好一次：** 应答只在事务提交后发出。幂等键 `(clientInstanceId, messageId, restoreEpoch)`。epoch 不符 → `restore_epoch_mismatch`，不是成功重放。
+3. **64 KiB 是业务信封上限。** 快照字节走 `snapshot.chunk` 或桌面导入。插件侧字节见产品 §8.5（IndexedDB）。
+4. **`allowed_origins` 无通配符。** D01 不加 `key`。
+5. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13。
+6. 恢复：新目录、保留 backup `archiveId`、**新铸 restoreEpoch**。握手成功；插件暂停盖着旧 epoch 的绑定队列。意图重新走候选。
 
-Host 校验顺序（逻辑）：
-
-1. 在 `argv[1…]` 中解析 `chrome-extension://<id>/` token（官方：origin 是传给 host 的 **第一个参数**，不是 `argv[0]` 的 exe 路径）。忽略 `--parent-window=*`（SW 下为 0）。要求该 origin ∈ **当前** host-manifest `allowed_origins`。Windows 上 `--parent-window` 与 origin 的历史顺序（Chrome 55 前曾把 parent-window 放前面）余下差异标 **待验证**（D06），实现应用「扫描 argv 找 origin token」，不要写死 `argv[1]`。
-2. 单帧 JSON 字节 ∈ (0, 64 KiB]。
-3. JSON 可解析；`protocolVersion` 兼容。
-4. `messageType` ∈ 上表。
-5. 转发 Tauri 后端；写成功才对 stdout 回帧。
+Host 校验顺序：扫描 argv 的 origin token ∈ 当前 manifest；单帧 ∈ (0, 64 KiB]；JSON 可解析；`messageType` ∈ 上表；写成功才回帧。
 
 ---
 
 ## 5. 数据服务职责边界
 
-| 进程 | 允许 | 禁止 |
+| 角色 | 允许 | 禁止 |
 | --- | --- | --- |
-| native-host.exe | NM 编解码、origin/大小、按需启动 **Tauri GUI EXE**、转发白名单 | 打开 SQLite、写附件、弹自己的业务 GUI、写 stdout 日志 |
-| Tauri GUI EXE（Rust 后端） | SQLite、附件、快照、幂等表、备份、idle、托盘、配对写 HKCU manifest | 第三个 writer 进程、监听 127.0.0.1 给网页、执行模型返回的命令 |
-| Tauri webview | 经 in-process IPC 调后端 | 直接写 `archive.db` |
-| 插件 SW | 探测后的 outbox、握手、白名单 RPC | 把 `aiConfig.apiKey` 放进 NM；未配对就持久化队列 |
+| NM host 进程 | NM 编解码、origin/大小、按需启动应用进程、转发白名单 | 打开 SQLite、写附件、弹业务 GUI、stdout 日志 |
+| 应用进程 | SQLite、附件、快照、幂等表、备份、current 指针、系统通知登记、配对写 manifest | 第三个 writer、监听 127.0.0.1 给网页、执行模型返回的命令 |
+| WebView 子进程 | 经应用内 IPC 调后端 | 直接写 `archive.db` |
+| 插件 SW | 意图队列、绑定 outbox、握手、白名单 RPC、扩展源 IndexedDB 快照暂存 | 把 `aiConfig.apiKey` 放进 NM；从未配对就持久化意图 |
 
-SQLite 作为嵌入式库（[sqlite.org](https://sqlite.org/)）：无独立服务器、单文件、跨平台文件格式。本项目用它做 **单用户本地档案**，不是多租户服务。WAL + 唯一写入者足够；D03 再定连接模式。附件不进 blob 表，只存相对路径 + sha256，避免把备份变成无法流式校验的巨型 DB。
+SQLite 是嵌入式库（[sqlite.org](https://sqlite.org/)），单用户本地档案，文件格式跨平台。WAL + 唯一写入者。附件不进 blob 表。
 
 ---
 
 ## 6. API / Interface Changes（相对今天的插件）
 
-D01 **不改**插件。下游预期（供 D07 对照，不是现在实现）：
+D01 **不改**插件。下游预期：
 
 | 时机 | 变化 |
 | --- | --- |
-| 现在 0.3.0 | 无 NM；SW = `onClicked` + `ENSURE_AI_HOST`；存储 `templates` / `activeTemplateId` / `aiConfig` + 更新检查二 key |
-| D07 | 追加 `nativeMessaging`；SW 增加 native port（保留 `onClicked`）；`desktopOutbox` + `desktopClientInstanceId`；侧边栏「保存岗位到本地」与「确认已投递」；桌面粘贴 ID 配对 |
-| 永不（v1） | 把桌面档案镜像进 `chrome.storage`；把插件 Key 复制进桌面备份；content script 直连 native；用第一条 NM 做配对 |
-
-桌面 IPC（Tauri 命令）只暴露与 UI 同权的业务 API，不暴露 `execute_sql(string)`。
+| 现在 0.3.0 | 无 NM |
+| D07 | 追加 `nativeMessaging`；意图/绑定队列；粘贴 ID 配对；确认投递 |
+| D08 | 扩展源 IndexedDB 快照暂存；可能申请 `unlimitedStorage` |
+| 永不（v1） | 桌面档案镜像进 `chrome.storage`；插件 Key 复制进备份；content script 直连 native；用第一条 NM 做配对；content script 把快照写进 **页面** IndexedDB |
 
 ---
 
 ## 7. Alternatives Considered
 
-### 7.1 Electron + better-sqlite3 + 仍要 NM host
+### 7.1 Electron
 
-- 优点：渲染进程全是 Node/Chromium，招聘前端更熟。
-- 缺点：~100MB+ 运行时；native 模块与 Electron ABI；GUI 仍不能当 NM host；更容易从预加载脚本漏 fs。
-- **不选。**
+可行。见 §3.1。本项目仍推荐 Tauri，因为体积、WebView 复用和 Rust 后端与 host/SQLite 共享，而不是因为 Electron「不能做 NM」或「必须管理员」。
 
-### 7.2 纯插件 + `chrome.storage` / IndexedDB 当档案
+### 7.2 纯插件存储当档案
 
-- 优点：无安装器。
-- 缺点：无可靠大附件、无用户可复制的完整备份目录、卸载扩展易丢数据、无独立于浏览器的生命周期。Epic 要求桌面权威源。
-- **不选。**
+无可靠大附件、无独立于浏览器的备份目录。Epic 要求桌面权威源。**不选。**
 
-### 7.3 桌面开 localhost HTTP / WebSocket 给插件
+### 7.3 桌面开 localhost HTTP 给插件
 
-- 优点：实现快。
-- 缺点：本机任意进程可打；扩展页面 XSS 或恶意扩展可滥用；D05 明文禁止。
-- **不选。**
+D05 禁止。**不选。**
 
-### 7.4 一个 EXE 兼任 GUI 与 NM host
+### 7.4 GUI 与 host 抢同一 stdout
 
-- 优点：少一个二进制。
-- 缺点：stdout 争用；Tauri/WebView 日志会破坏帧；Windows 子系统（WINDOWS vs CONSOLE）冲突。
-- **不选。** 两个二进制，共享 crate。
+不选「未分流的同一 stdout」。可选独立 helper **或** 同一二进制的 host 模式，见 §3.1。
 
-### 7.5 MSI / per-machine 作为 MVP 默认
+### 7.5 Windows MSI 作为默认 / macOS App Store 作为默认
 
-- 优点：企业镜像友好。
-- 缺点：要管理员；与「普通求职者 per-user」冲突；WiX 只能在 Windows 上打 MSI。
-- **MVP 不选；** D13 可按需加。
+企业 MSI、Mac App Store 沙箱（对写入 Chrome NativeMessagingHosts 不友好，社区讨论常见）都不作为首版默认。**待负责人**是否补 MSI；App Store **非目标**。
 
 ---
 
-## 8. 最低运行时与 WebView2
+## 8. 最低运行时
 
-- 插件已要求 Chrome/Edge **116+**。
-- WebView2：官方支持 Windows 10 SAC 1709+ 与 Windows 11（[WebView2 简介 · 支持的 Windows](https://learn.microsoft.com/en-us/microsoft-edge/webview2/)）。Win11 预装 Evergreen Runtime；Win10 消费设备自 2022 年起大规模投放，**仍非 100%**（[Evergreen vs fixed](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/evergreen-vs-fixed-version)）。Tauri NSIS 默认可下载 bootstrapper。
-- 产品口径：**Windows 10 22H2+ x64**。ARM64 构建 **待验证**（D13）。不承诺 Windows 7（Tauri 文档虽提到 Win7 兼容开关，超出本 MVP）。
-- 用户数据用 Known Folder `FOLDERID_LocalAppData`（默认 `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`），经 `SHGetKnownFolderPath` 或等价 API，**禁止**硬编码 `C:\Users\某开发者\...`（[KNOWNFOLDERID](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid)）。
+- 插件已要求 Chrome/Edge **116+**（Windows 与 macOS 相同）。
+- WebView2：Win10 22H2 / Win11（[WebView2](https://learn.microsoft.com/en-us/microsoft-edge/webview2/)）。安装器应能引导缺失 Runtime。
+- WKWebView：随 macOS。
+- 产品建议：**Windows 10 22H2+ x64**；**macOS 11+ Apple Silicon**。Windows ARM64、macOS Intel universal **待验证**。
+- 用户数据：Windows `SHGetKnownFolderPath(FOLDERID_LocalAppData)`；macOS Application Support。**禁止**硬编码开发机路径。
 
 ---
 
 ## 9. Security & Privacy（架构切面）
 
-细节见 [data-privacy.md](data-privacy.md)。架构层硬约束：
+细节见 [data-privacy.md](data-privacy.md)。
 
-- NM origin 白名单（扫描 argv origin token）；业务信封 64 KiB；无通配；无 HTTP 配对。
-- Pipe ACL = 当前用户；拒绝其他会话。
-- 不把插件 `aiConfig` 发到桌面。桌面 Key 用 DPAPI / Credential Manager（D11）。
-- Host 与 Tauri 后端崩溃不得损坏 DB（SQLite 事务 + 备份）；失败返回 D05 错误码，不假成功。
-- 威胁：恶意扩展若进入 `allowed_origins` 可写档案 → 所以禁止通配、禁止把开发 ID 写进生产 manifest。
+- NM origin 白名单；64 KiB；无通配；无 HTTP 配对。
+- IPC 仅当前用户。
+- 不把插件 `aiConfig` 发到桌面。桌面 Key：Windows DPAPI / Credential Manager；macOS Keychain（D11）。
+- 威胁：恶意扩展进入 `allowed_origins` 可写档案 → 禁止通配。
 
 ---
 
 ## 10. Observability
 
-- 日志：错误码 + 脱敏上下文（路径只留叶名、URL 已剥 token）。禁止简历正文、邮件正文、API Key、Authorization。
-- 用户可导出诊断包（D02）：日志 + 版本 + `archiveId`/`generation`/`schemaVersion` + 队列计数；不含附件与快照正文。
-- 指标（本地计数即可，不上报）：握手成功/失败、写入延迟、idle 退出次数、NM 帧拒绝原因。
-- 告警：无云端。UI 对连续失败显示错误码。
+日志：错误码 + 脱敏上下文。禁止简历/邮件正文、API Key。
 
-冷启动目标（D06 验证，非 D01 实现）：host 已在、**Tauri GUI EXE（唯一写入者）** 已在时握手 **< 200 ms**；需要按需拉起该 EXE 时 **< 2 s**（**待验证**）。
+诊断包：日志 + 版本 + `archiveId`/`restoreEpoch`/`schemaVersion` + 意图/绑定队列计数；不含附件与快照正文。
+
+冷启动目标（D06 验证）：host 已在、应用进程已在时握手 **< 200 ms**；按需拉起 **< 2 s**（**待验证**，macOS 可能更慢）。
 
 ---
 
 ## 11. Rollout Plan
 
-阶段出口对齐 Epic #15（**阶段** ≠ **执行波次**，波次见 [downstream-decisions.md §1](downstream-decisions.md#1-硬依赖图保持原样)）：
-
 | 阶段 | 内容 |
 | --- | --- |
-| P0 | 本 ADR 经负责人确认 |
-| P1 | D02 壳 + 单实例 + 数据目录；D03 数据层；D04 手动 UI。无 NM。执行上 D02/D03/D05 可先开工，D04 等 D02+D03 |
-| P2 | D05 契约 → D06 host → D07 插件连接（含配对 UX 与 `submit.confirm`）。开发机隔离注册脚本 |
-| P3 | D08 填写留档/分片快照；D09 证据收件箱 |
-| P4 | D10 待办提醒；D11 AI 建议 |
-| P5 | D12 备份恢复；D13 生产 NSIS；D14 干净账户安装验收 |
+| P0 | 本 ADR 经负责人确认（含平台与正式版范围） |
+| P1 | D02 壳（**含 macOS 原型**）+ 单实例 + 数据目录；D03 数据层；D04 手动 UI |
+| P2 | D05 契约 → D06 host（Win + Mac 注册路径）→ D07 |
+| P3 | D08 IndexedDB 暂存 + 分片；D09 |
+| P4 | D10 系统调度提醒；D11 |
+| P5 | D12；D13 Win NSIS + Mac dmg；D14 两端安装验收（覆盖范围随正式版决议） |
 
-回滚：卸载桌面保留档案；插件去掉 NM 调用后仍能填表（权限多一项 `nativeMessaging` 不破坏旧填写）。协议不兼容时拒绝写入，不自动迁移业务消息。
-
-功能开关：桌面「允许浏览器连接」默认开；关掉则 host 对业务 RPC 返回明确错误，插件显示未连接。v1 无远程 feature flag。
+回滚：卸载桌面保留档案；插件去掉 NM 后仍能填表。
 
 ---
 
@@ -385,18 +329,20 @@ D01 **不改**插件。下游预期（供 D07 对照，不是现在实现）：
 
 | 严重度 | 风险 | 缓解 |
 | --- | --- | --- |
-| 高 | GUI stdout 污染 NM | 独立 host EXE；二进制模式；契约测试乱写 stdout |
-| 高 | 多写入者损坏 SQLite | mutex + **单一 Tauri GUI EXE / unique writer**；D02 验收第二实例 |
-| 中 | 未打包 ID 变化 / 未配对当未安装 | 桌面粘贴 ID；未配对单独降级；D01 不加 key |
-| 中 | MV3 SW 杀死 native port | 队列 + 重连；D06 原型 |
-| 中 | 部分 Win10 无 WebView2 | NSIS bootstrapper；文档说明 |
-| 低 | Rust 人力 | crate 边界小；UI 仍用 web |
+| 高 | GUI stdout 污染 NM | host 模式二进制 stdout；契约测试 |
+| 高 | 多写入者损坏 SQLite | 单实例应用进程 |
+| 高 | 把 idle 退出当成次日提醒 | 系统调度；文案；D10 杀进程测试 |
+| 中 | 未打包 ID / 未配对当未安装 | 粘贴 ID；未配对不建意图 |
+| 中 | 重复恢复碰撞 generation | restoreEpoch UUID |
+| 中 | macOS NM 路径 / 公证 / 按需启动 | D02/D06/D13 原型（V10–V12） |
+| 中 | Win 计划 Toast 5 分钟窗口 | 文案 + 打开应用汇总 |
+| 低 | Rust 人力 | crate 边界小；备选 Electron 已记录真实代价 |
 
 ---
 
 ## 13. Open Questions
 
-见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择) 第 1–4 项（栈、MSI、托盘、扩展 ID）。原型项见同文「需要后续原型验证」。
+见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。
 
 ---
 
@@ -404,12 +350,14 @@ D01 **不改**插件。下游预期（供 D07 对照，不是现在实现）：
 
 - Chrome Native messaging: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 - Edge Native messaging: https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging
-- `chrome.runtime.sendNativeMessage` / `connectNative`（同上文档）
+- Chrome 扩展 storage / IndexedDB: https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies
 - Tauri 2 Windows installer: https://v2.tauri.app/distribute/windows-installer/
+- Tauri 2 macOS bundle: https://v2.tauri.app/distribute/macos-application-bundle/
+- Tauri 2 macOS signing/notarization: https://v2.tauri.app/distribute/sign/macos/
 - Tauri 2 sidecar: https://v2.tauri.app/develop/sidecar/
-- KNOWNFOLDERID / `FOLDERID_LocalAppData`: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
-- WebView2 支持的 Windows: https://learn.microsoft.com/en-us/microsoft-edge/webview2/
-- WebView2 Evergreen vs Fixed: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/evergreen-vs-fixed-version
-- SQLite: https://sqlite.org/  · self-contained: https://www.sqlite.org/selfcontained.html
-- 本仓库 [`manifest.json`](../../manifest.json)、[`background.js`](../../background.js)
+- electron-builder NSIS `perMachine` 默认 false: https://www.electron.build/nsis
+- Windows 计划应用通知: https://learn.microsoft.com/en-us/windows/apps/develop/notifications/app-notifications/app-notifications-scheduled
+- KNOWNFOLDERID LocalAppData: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
+- WebView2: https://learn.microsoft.com/en-us/microsoft-edge/webview2/
+- SQLite: https://sqlite.org/
 - Epic #15、D02 #16、D05 #23、D06 #24、D13 #29

--- a/docs/desktop-mvp/adr-architecture.md
+++ b/docs/desktop-mvp/adr-architecture.md
@@ -200,7 +200,7 @@ D05 必须包含的信封字段（此处冻结名字与枚举，不写 JSON Sche
 
 - `correlationId` = 请求 `messageId`。
 - `ok: true` 的写入应答必须有 `resultId`。
-- `ok: false` **没有** `resultId`，除非这是对 **已完成写入且 restoreEpoch 相符** 的幂等重放。
+- `ok: false` **没有** `resultId`；已完成且当前身份/摘要相符的普通重放返回 `ok: true` 和原 resultId。历史对账结果在只读 payload 中，不授予旧消息写入权限。
 - SaveIntent **不是** NM `messageType`。
 
 **MVP `messageType` 枚举：**
@@ -212,15 +212,15 @@ D05 必须包含的信封字段（此处冻结名字与枚举，不写 JSON Sche
 | `application.queryCandidates` | 插件→桌面 | 两层候选，最小元数据 |
 | `job.save` | 插件→桌面 | 已绑定后的岗位保存 |
 | `fill.submit` | 插件→桌面 | 填写事件元数据 + 可选 `snapshotId`/`sha256`（**不含**快照字节） |
-| `snapshot.chunk` | 插件→桌面 | 快照分片；每帧 ≤ 64 KiB |
+| `snapshot.chunk` | 插件→桌面 | 完整 UTF-8 JSON（信封、序号、编码后的数据在内）≤ 64 KiB；发送前所有快照都已提交到扩展源 IDB |
 | `submit.confirm` | 插件→桌面 | 用户明确确认已投递（D07） |
-| `outbox.reconcile` | 插件→桌面 | 入参 messageId 列表，出参当前 epoch 库中已存在的 `(messageId, resultId)` |
+| `outbox.reconcile` | 插件→桌面 | 当前身份信封 + 有界完整旧身份/摘要列表；只读当前档案的历史回执，逐项返回身份、核实状态及可用 resultId，见产品 §8.11 |
 
 原则：
 
 1. **握手成功**即返回当前 `(archiveId, restoreEpoch)`。仅协议不兼容或 kill switch 时握手失败。epoch 变化 **不是**握手失败。
-2. **至少一次传送，业务恰好一次：** 应答只在事务提交后发出。幂等键 `(clientInstanceId, messageId, restoreEpoch)`。epoch 不符 → `restore_epoch_mismatch`，不是成功重放。
-3. **64 KiB 是业务信封上限。** 快照字节走 `snapshot.chunk` 或桌面导入。插件侧字节见产品 §8.5（IndexedDB）。
+2. **至少一次传送，业务恰好一次：** 普通写入先校验当前 `(archiveId, restoreEpoch)`，再按 `(clientInstanceId, messageId, sourceRestoreEpoch)` 和 payloadSha256 处理事务回执，其中 sourceRestoreEpoch 是提交时的 epoch。epoch 不符返回 `restore_epoch_mismatch`，不是成功重放。历史回执随业务库备份；只读对账按完整旧身份查询，不按新 epoch 过滤，也不改当前 epoch。详见 [产品 §8.11](product-requirements.md#811-已提交消息回执与恢复对账)。
+3. **64 KiB 是完整序列化业务信封的 UTF-8 字节上限**（不含 NM 的 4 字节长度前缀），不是原始块大小。D05 建议 raw chunk ≤ 32 KiB，并限制其他字段；仍须实际编码后测量整帧，超限拒绝，不能假定 base64/JSON 没有开销。所有快照在线/离线均先持久化到扩展源 IDB，完整提交 ACK 前保留字节。D05/D08 测试整帧 65536/65537 字节、分片中断与完整 ACK 丢失。
 4. **`allowed_origins` 无通配符。** D01 不加 `key`。
 5. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13。
 6. 恢复：新目录、保留 backup `archiveId`、**新铸 restoreEpoch**。握手成功；插件暂停盖着旧 epoch 的绑定队列。意图重新走候选。
@@ -342,7 +342,7 @@ D05 禁止。**不选。**
 
 ## 13. Open Questions
 
-见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。
+见 [downstream-decisions.md](downstream-decisions.md#4-需要项目负责人选择)。
 
 ---
 

--- a/docs/desktop-mvp/adr-architecture.md
+++ b/docs/desktop-mvp/adr-architecture.md
@@ -1,0 +1,415 @@
+# ADR：Windows 桌面主程序架构与技术选型
+
+| 字段 | 值 |
+| --- | --- |
+| 标题 | ADR-001 桌面栈、进程模型与通信原则 |
+| 作者 | D01 design PR |
+| 日期 | 2026-09-06 |
+| 状态 | Draft / Ready for review |
+| 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
+| 并列 | [product-requirements.md](product-requirements.md) · [data-privacy.md](data-privacy.md) · [downstream-decisions.md](downstream-decisions.md) |
+
+本 ADR 冻结 **用什么技术、几个进程、怎么说话**。完整 JSON Schema 归 [D05 #23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23)；可执行 host 归 [D06 #24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24)；安装注册归 [D13 #29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29)。D01 不脚手架 `/desktop` 源码。
+
+---
+
+## 1. Overview
+
+在现有 Chrome/Edge 插件之外增加 Windows 本地主程序：唯一写入者持有 SQLite 与附件目录；浏览器经 **Native Messaging** 连接一个 **薄 host EXE**；GUI 用 Tauri 2 WebView。插件继续用 JavaScript，根目录布局与当前 ZIP 打包不变。
+
+选型约束来自本项目，而不是通用「Tauri vs Electron」清单：
+
+- 需要 **唯一写入者**、事务、附件文件、备份/恢复路径控制 → 必须有原生进程，而不是纯扩展存储。
+- Native Messaging 规定 host 用 stdin/stdout 且带 4 字节长度前缀；**GUI 不得占用该 stdout** → 无论哪种 UI 工具包都要单独的薄 host。
+- 只要 Windows；安装默认 per-user、非管理员。
+
+---
+
+## 2. Background & Motivation
+
+当前插件是 MV3 service worker + offscreen AI host，无 `nativeMessaging` 权限，无扩展 `key`（见 [README 现状](README.md#现状以仓库代码为准不以-readme-宣传为准)）。`chrome.storage.local` 适合模板，不适合带附件的申请时间线和可验证备份。
+
+Chrome 官方协议（[Native messaging](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging)）：
+
+- 每条消息：原生字节序的 32 位长度 + UTF-8 JSON。
+- Host → 浏览器上限 **1 MB**；浏览器 → host 上限 **64 MiB**。
+- `allowed_origins` **禁止通配符**。
+- 扩展必须声明 `nativeMessaging`；`connectNative` / `sendNativeMessage` **不能在 content script 调用**，只能在扩展页或 service worker。content script 必须先打到 SW。
+- `sendNativeMessage` **每条消息拉起一个新 host 进程**；`connectNative` 保持进程直到 port 销毁。
+- Windows：在 `HKCU\Software\Google\Chrome\NativeMessagingHosts\<name>`（或 HKLM）写入 manifest 绝对路径。Windows 上 stdout 必须 `O_BINARY`，调试日志只能写 stderr。
+- Service worker 场景下 `--parent-window` 为 0。
+
+Edge 文档（[Native messaging](https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging)）同构：`stdio`、`allowed_origins`、HKCU `SOFTWARE\Microsoft\Edge\NativeMessagingHosts\<name>`。Host → Edge 上限 1 MB；Edge → host 文档写的是 4 GB。若同时上架两个商店，两个扩展 ID 都要写入 `allowed_origins`（MVP 未上架，但 unpacked Chrome 与 Edge 是 **两个 ID**）。
+
+Edge 官方 **查找顺序**（不得依赖当配对通道）：先 `HKCU\SOFTWARE\Microsoft\Edge\NativeMessagingHosts\`，再 Chromium，再 `Google\Chrome`；然后 HKLM / WOW6432Node 同类键。若只写 Chrome 键，Edge 仍可能 **找到** 名为 `com.resumepro.desktop` 的 host，但其 `allowed_origins` 只有 Chrome unpacked ID → Edge 报 **forbidden**，插件若当成「未安装」就会误导。
+
+**冻结（D13）：** 始终分别写入 **Edge 与 Chrome 的 HKCU** 键。每个键指向一份 host manifest JSON；两份 JSON 可以相同路径（一份文件同时列入两个已配对 origin）或各一份。**禁止**指望 Edge 回退到 Chrome 键来「顺便」连上。Chrome 已配对而 Edge 未配对时，fallback 是脚枪：Edge 会连上 host 然后被 origin 拒绝。
+
+Chrome/Edge 传给 host 的 **第一个参数是调用方 origin**（`chrome-extension://<id>/`），不是 exe 路径。Windows 另有 `--parent-window=<handle>`；service worker 场景下该值为 `0`（ADR 下文 §4 校验顺序）。`argv[0]` 在 Win32 里是可执行文件路径，**不得**拿去比对 origin。
+
+这些事实迫使：**host 必须极瘦、stdout 纯净、按 origin 校验、业务 JSON 远小于 1 MB；注册必须双写 Chrome+Edge。**
+
+---
+
+## 3. Decision
+
+### 3.1 桌面栈：Tauri 2 + Rust 数据服务（不用 Electron）
+
+| 本项目约束 | Tauri 2 + Rust | Electron |
+| --- | --- | --- |
+| 唯一写入者 + SQLite 事务 + 附件路径 | `rusqlite`/`sqlx` 与文件系统在同一 Rust 进程；崩溃面小 | 需 `better-sqlite3` 等 native 模块，每次 Electron 升级要重建 |
+| NM host 必须是独立 EXE，且不能用 GUI 的 stdout | 可与 data-service **共享 crate**（协议编解码、幂等、路径） | 仍要单独 host EXE；Node 帮不上 stdio 帧，还多一个运行时 |
+| 仅 Windows | WebView2 在 Win11 预装；Win10 22H2 属官方支持范围（见 §8） | Chromium 整包，安装体大约 **100MB+** |
+| per-user、无管理员 | Tauri NSIS **默认 current user**，装到 `%LOCALAPPDATA%`（[Windows Installer](https://v2.tauri.app/distribute/windows-installer/)） | 常见安装器偏 Program Files / 管理员 |
+| 插件已是 JS | 桌面 UI 可用 web 技术；**不必**再塞一个 Node | 第二套 Node，且容易从渲染进程误暴露 fs |
+
+**代价（必须承认）：** 团队要写 Rust；依赖 WebView2；NM host + named pipe + 单实例必须在 D02/D06 做原型（**待验证**）。不选 Tauri 的代价：安装包显著变大、沙箱叙事更弱、Node 侧更容易误开文件系统或 localhost HTTP。
+
+Sidecar（[Embedding External Binaries](https://v2.tauri.app/develop/sidecar/)）可用于把 `native-host.exe` 放进安装布局；host 也必须能被浏览器按 manifest `path` 直接拉起，不经过 Tauri 窗口。是否用 sidecar 打包 host 由 D13 决定，逻辑进程模型不变。
+
+### 3.2 安装包：仅 NSIS `setup.exe`，per-user，MVP 无 MSI
+
+Tauri 可打 `.msi`（WiX，仅 Windows 主机）和 `-setup.exe`（NSIS）。Epic #15 / D13 把「是否补充 MSI」交给 D01。
+
+**决定：** MVP 只发 NSIS per-user `setup.exe`。默认不要求管理员，安装目录在 `%LOCALAPPDATA%` 下的应用文件夹，**与用户档案目录分离**（档案见 [data-privacy.md](data-privacy.md#3-目录布局)）。
+
+企业若强需求 MSI，由后续版本/D13 增补，不作为首发承诺。`installMode=both` 会让安装器要管理员（官方说明），MVP 不采用。
+
+未持有 EV/OV 代码签名证书前 **不宣传已签名**。发布说明必须写 SmartScreen「未识别的应用」警告及用户如何核对 SHA-256。
+
+卸载：删除程序文件、快捷方式、本应用的 NM 注册；**默认保留** `%LOCALAPPDATA%\ResumePro\archive\`。删数据必须单独确认（D13）。
+
+### 3.3 仓库布局（同仓，插件留在根目录）
+
+当前 ZIP 是把仓库根（含 `manifest.json`）解压后「加载已解压的扩展程序」。**禁止**把插件挪到子目录，否则现有发行说明与用户解压路径全部作废。
+
+规划中的树（D01 **只写文档，不创建 crate**）：
+
+```text
+/                          现有插件（D01 零改动）
+/docs/desktop-mvp          本设计
+/docs/ai-repeat-validation.md   保持不动
+/desktop                   未来 Tauri 应用（D02+）：打出一个 GUI EXE
+/desktop/crates/data-service   库 crate，链进 Tauri 后端；不是第三个进程
+/desktop/crates/native-host    薄 host EXE（唯一额外二进制）
+/desktop/crates/protocol       （D05，库 crate）
+```
+
+**v1 进程数冻结为 2：** Tauri GUI EXE + `native-host.exe`。`data-service` 是 **库**，不是常驻第三个 service EXE。
+
+插件与桌面 **版本号不必相等**；共享的是 `protocolVersion`。桌面应用建议产品名 **Resume Pro Desktop**，NM host 名建议 `com.resumepro.desktop`（仅小写字母、数字、点、下划线，符合 Chrome `name` 规则）。
+
+### 3.4 进程模型（冻结：两个 EXE）
+
+```mermaid
+flowchart LR
+  subgraph Browser
+    CS[content.js / popup]
+    SW[background.js SW]
+    CS -->|runtime.sendMessage| SW
+  end
+  SW -->|"connectNative stdio\n4-byte length JSON"| HOST[native-host.exe]
+  HOST -->|"named pipe\ncurrent-user ACL"| APP[Tauri GUI EXE\nRust backend = UNIQUE WRITER]
+  UI[Tauri webview] -->|"in-process IPC"| APP
+  APP --> DB[(SQLite)]
+  APP --> ATT[attachments/]
+  APP --> SNAP[snapshots/]
+```
+
+规则：
+
+1. **唯一写入者 = Tauri GUI EXE 的 Rust 后端**（链接 `data-service` 库）。Webview 与 `native-host` 都是该后端的客户端。v1 **不允许**第三个常驻 writer/service EXE。
+2. **native-host 是翻译器：** 解码 NM 帧、校验 origin 与大小、只转发白名单 RPC、**持久化提交后再回包**。Host **不**打开 SQLite。
+3. Host 发现唯一写入者未运行时 **按需启动同一个 Tauri GUI EXE（可无可见窗口）**，再连 named pipe。多个 host（Chrome 与 Edge、或多次 `sendNativeMessage`）必须连到 **这一个** 实例。
+4. **单实例：** 命名 mutex + 命名管道。第二次启动 UI：激活已有窗口，不第二写入者。第二 host：只连接。
+5. **关主窗口 = 隐藏到托盘（若 Q3 接受）或保持后端**，不等于退出写入者。Idle 时钟只在 **无可见窗口 ∧ 无活 NM 端口 ∧ 无进行中的备份/提醒** 时启动。默认 **15 分钟** 后退出进程。D02 可做成设置项，**不得**默认为 0 或「直到重启」。彻底退出走明确「退出」。**v1 无开机启动。**
+6. **建议托盘图标**，否则用户以为已退出却留下 GUI 子系统进程（见开放问题 Q3）。
+7. **禁止** 未鉴权的 localhost HTTP 端口（D05 非目标原文）。配对也不走 HTTP，见 §3.7。
+8. Named pipe DACL = 当前用户 SID；消息仍要校验调用方/会话，不因为「本机」就信任。
+
+空闲行为：
+
+```text
+有可见窗口 或 活 NM 端口 或 备份/提醒进行中  →  进程保持
+以上皆无                               →  开始 15 min idle timer
+idle 到期                              →  Tauri EXE 退出
+用户点「退出」                          →  立即停并断开
+MV3 SW 回收导致 port 断开              →  视为「无活 NM」；**不得丢 outbox**（V4）
+```
+
+保存岗位的进程内时序（产品语义与 **先探测再入队** 见 [product-requirements.md §5.2](product-requirements.md)）：
+
+```mermaid
+sequenceDiagram
+  participant SW as Extension SW
+  participant H as native-host
+  participant APP as Tauri EXE UNIQUE WRITER
+  Note over SW: 仅当已注册 host 且已配对且协议兼容才写 outbox
+  SW->>H: stdio 帧 handshake
+  H->>APP: named pipe connect / 按需启动本 EXE（可隐藏）
+  APP-->>SW: protocol range, appVer, archiveId, generation
+  SW->>H: application.queryCandidates
+  H->>APP: whitelist RPC
+  APP-->>SW: exact[] + sameCompany[] 最小元数据
+  SW->>H: job.save envelope 64KiB
+  H->>APP: 事务 + 幂等键
+  Note over APP: 提交后才允许 host 回包
+  APP-->>H: resultId, applicationId
+  H-->>SW: stdout 长度前缀 JSON
+```
+
+### 3.5 为何 GUI 不能兼 NM host
+
+Chrome 把 host 的 **stdout 整段当作协议帧**。任何 `println!`、日志、Tauri/WebView 调试输出都会破坏 4 字节前缀（官方排错：「All output in stdout must adhere to the protocol; debug on stderr」）。因此：
+
+- `native-host.exe`：CRT 设二进制模式；只写长度前缀 JSON；日志走文件/stderr。
+- Tauri GUI EXE：WINDOWS 子系统，可有自己的 stdout，但 **不要** 注册为 NM host 的 `path`。Host 按需启动的是 **这个** EXE（可无窗口），不是第三个 writer。
+
+### 3.6 插件侧连接落点（D07 实现，D01 约束）
+
+今天 [`background.js`](../../background.js) 处理两件事：`chrome.action.onClicked` → `TOGGLE_MANAGER`，以及 `ENSURE_AI_HOST`（`offscreen.createDocument`）。D07 **追加** NM，不得覆盖 `onClicked`。
+
+D07 将：
+
+- 在 **service worker** 调用 `connectNative`（推荐）或受控的 `sendNativeMessage`；content script 不得直连。
+- 增加 `nativeMessaging` 权限——这是 **D07 的插件变更**，伴随版本号提升；**不是 D01，也不在 0.3.0 做**。
+- 持久化 outbox 使用新 key `desktopOutbox`；另存 `desktopClientInstanceId`（每扩展安装/Profile 一次生成的 UUID）。**禁止**占用已有 `templates`、`activeTemplateId`、`aiConfig`、`resumeProUpdateCache`、`resumeProDismissedVersion`。
+- 插件「确认已投递」按钮与 `submit.confirm` RPC 同属 D07（与 `job.save` 共用绑定/outbox；**不是**填写成功）。桌面手动确认仍归 D04。
+
+MV3 SW 空闲回收是否会断开 `connectNative`：**待验证**（V4）。缓解：短 RPC + 断线重连 + outbox；SW 回收看起来像「NM 断开」，**不得丢队列**。
+
+`sendNativeMessage` 每条拉起新 host 在本模型下 **可接受**（host 无状态，写入在 Tauri 后端），但冷启动更慢。D05 应规定：优先长连接，回落短连接，两者幂等语义相同。
+
+### 3.7 非 NM 配对引导（冻结）
+
+Chrome **不会启动** host，除非调用方 origin 已在该 host manifest 的 `allowed_origins` 里。因此插件 **不能** 把 `chrome.runtime.id` 经 NM 送给尚未认识它的 host。localhost HTTP 已禁止，所以配对必须走桌面 UI。
+
+**冻结流程：**
+
+1. D13 安装时向 Chrome **和** Edge 的 HKCU `NativeMessagingHosts\com.resumepro.desktop` 写入 manifest（host 已注册；`allowed_origins` 初始为空或仅含此前已配对 origin）。
+2. 用户在桌面「连接浏览器」中 **粘贴扩展 ID**（从 `chrome://extensions` / `edge://extensions` 复制）。Chrome 与 Edge **分别**粘贴、分别写入。
+3. 桌面把 `chrome-extension://<id>/` 写入对应浏览器的 host manifest（无通配符），提示 **重新加载扩展**（V3）。Chrome/Edge 是否无需重启即可重读 manifest：**待验证**（V3）；失败则文案要求重载或重启浏览器。
+4. **第一条 NM 消息不是配对消息**，而是 `handshake`。配对在 NM 能成功之前已经完成。
+5. 开发机隔离注册脚本（D06）可以预写测试 ID；生产 allowlist **不**接受任意扩展。
+
+降级：**已安装但未配对**（host 已注册，本 origin forbidden 或未列入）≠ 未安装。插件必须单独文案「请在桌面粘贴扩展 ID」，**不建长期 outbox**，**不说「未安装」**。移动 ZIP 目录导致路径哈希 ID 变化 = 需要重新粘贴，同样走未配对。
+
+---
+
+## 4. 协议原则（不是 D05 Schema）
+
+D05 必须包含的信封字段（此处冻结名字与枚举，不写 JSON Schema）：
+
+**请求：** `protocolVersion`、`messageId`、`clientInstanceId`、`messageType`、`occurredAt`、`payload`。
+
+**应答：** `{ protocolVersion, correlationId, resultId?, ok, error?: { code, retryable, message? }, payload }`。
+
+- `correlationId` = 请求 `messageId`。
+- `ok: true` 的写入应答必须有 `resultId`。
+- `ok: false` **没有** `resultId`，除非这是对 **已完成写入** 的幂等重放（此时 `ok: true` 并返回原 `resultId`）。
+- 成功时 `error` 省略或 `null`。
+
+逻辑形状：
+
+```json
+{
+  "protocolVersion": 1,
+  "messageId": "0193a0c2-7c1a-7d2e-b8c1-0f1e2d3c4b5a",
+  "clientInstanceId": "ext-instance-uuid",
+  "messageType": "job.save",
+  "occurredAt": "2026-09-06T12:00:00.000Z",
+  "payload": {}
+}
+```
+
+```json
+{
+  "protocolVersion": 1,
+  "correlationId": "0193a0c2-7c1a-7d2e-b8c1-0f1e2d3c4b5a",
+  "resultId": "res-uuid",
+  "ok": true,
+  "payload": { "applicationId": "app-uuid" }
+}
+```
+
+**MVP `messageType` 枚举（英文点号，冻结）：**
+
+| `messageType` | 方向 | 说明 |
+| --- | --- | --- |
+| `health` | 双向 | 探活，无业务写入 |
+| `handshake` | 双向 | 返回协议区间、app 版本、`archiveId`、`generation`、`capabilities`。**不是配对** |
+| `application.queryCandidates` | 插件→桌面 | 两层候选，最小元数据（见产品 §7） |
+| `job.save` | 插件→桌面 | 用户确认后的岗位保存 |
+| `fill.submit` | 插件→桌面 | 填写事件元数据 + 可选 `snapshotId`/`sha256`（**不含**快照字节） |
+| `snapshot.chunk` | 插件→桌面 | 快照文件分片；每帧业务 JSON ≤ 64 KiB，payload 含序号与数据块 |
+| `submit.confirm` | 插件→桌面 | 用户明确确认已投递（D07） |
+| `outbox.reconcile` | 插件→桌面 | 入参 messageId 列表，出参已存在的 `(messageId, resultId)`；供恢复后「关联」使用。**不是**通用查询 |
+
+无通用 SQL、无任意路径读写、无远程 shell、无「配对」NM 类型。
+
+`clientInstanceId`：插件在 `chrome.storage.local.desktopClientInstanceId` 生成一次 UUID（每个扩展安装 / 浏览器 Profile）。存储被清则新 ID，旧幂等键不再匹配，这是可接受的。
+
+原则：
+
+1. **握手成功**即返回当前 `(archiveId, generation)`。插件版本与桌面版本不必相同。仅当协议区间不兼容或桌面 kill switch 时握手失败并 **禁止业务写入**。`generation` 变化 **不是**握手失败。
+2. **至少一次传送，业务恰好一次：** 应答只在事务提交后发出。幂等键 `(clientInstanceId, messageId)`。相同载荷重放 → 原 `resultId`；同一键不同载荷 → 拒绝且可诊断（D03）。
+3. **64 KiB 是业务信封上限**（低于 Chrome host→浏览器 1 MB / 浏览器→host 64 MiB；Edge inbound 文档 4 GB 不提高产品上限）。附件与快照 **字节永不**放进 `job.save` / `fill.submit` 信封。
+4. **插件→桌面文件字节**走 `snapshot.chunk`（每块 ≤ 64 KiB）或用户可见的「改在桌面导入」。Outbox 存元数据 + `sha256` + 可选分片游标，**默认不把整份 blob 放进 `chrome.storage.local`**（配额约 10 MB，且已有更新检查 key）。单份快照 **> 2 MiB 拒绝**，明确失败，不得假成功。附件（eml/pdf）由 D09 在桌面本地拷贝，不经插件 NM。
+5. **`allowed_origins` 无通配符。** D01 不加 `key`。配对见 §3.7。
+6. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13，**双写** Chrome+Edge HKCU。
+7. 恢复：新目录、**保留 backup 的 `archiveId`、generation 必 +1**。握手 **成功** 并返回新身份；插件比对 outbox 上盖的旧 `(archiveId, generation)` 后暂停队列。用户选关联 / 丢弃 / 另存。**永不自动重放。** 关联若需知道哪些 messageId 已在库中，调用 `outbox.reconcile`。
+
+Host 校验顺序（逻辑）：
+
+1. 在 `argv[1…]` 中解析 `chrome-extension://<id>/` token（官方：origin 是传给 host 的 **第一个参数**，不是 `argv[0]` 的 exe 路径）。忽略 `--parent-window=*`（SW 下为 0）。要求该 origin ∈ **当前** host-manifest `allowed_origins`。Windows 上 `--parent-window` 与 origin 的历史顺序（Chrome 55 前曾把 parent-window 放前面）余下差异标 **待验证**（D06），实现应用「扫描 argv 找 origin token」，不要写死 `argv[1]`。
+2. 单帧 JSON 字节 ∈ (0, 64 KiB]。
+3. JSON 可解析；`protocolVersion` 兼容。
+4. `messageType` ∈ 上表。
+5. 转发 Tauri 后端；写成功才对 stdout 回帧。
+
+---
+
+## 5. 数据服务职责边界
+
+| 进程 | 允许 | 禁止 |
+| --- | --- | --- |
+| native-host.exe | NM 编解码、origin/大小、按需启动 **Tauri GUI EXE**、转发白名单 | 打开 SQLite、写附件、弹自己的业务 GUI、写 stdout 日志 |
+| Tauri GUI EXE（Rust 后端） | SQLite、附件、快照、幂等表、备份、idle、托盘、配对写 HKCU manifest | 第三个 writer 进程、监听 127.0.0.1 给网页、执行模型返回的命令 |
+| Tauri webview | 经 in-process IPC 调后端 | 直接写 `archive.db` |
+| 插件 SW | 探测后的 outbox、握手、白名单 RPC | 把 `aiConfig.apiKey` 放进 NM；未配对就持久化队列 |
+
+SQLite 作为嵌入式库（[sqlite.org](https://sqlite.org/)）：无独立服务器、单文件、跨平台文件格式。本项目用它做 **单用户本地档案**，不是多租户服务。WAL + 唯一写入者足够；D03 再定连接模式。附件不进 blob 表，只存相对路径 + sha256，避免把备份变成无法流式校验的巨型 DB。
+
+---
+
+## 6. API / Interface Changes（相对今天的插件）
+
+D01 **不改**插件。下游预期（供 D07 对照，不是现在实现）：
+
+| 时机 | 变化 |
+| --- | --- |
+| 现在 0.3.0 | 无 NM；SW = `onClicked` + `ENSURE_AI_HOST`；存储 `templates` / `activeTemplateId` / `aiConfig` + 更新检查二 key |
+| D07 | 追加 `nativeMessaging`；SW 增加 native port（保留 `onClicked`）；`desktopOutbox` + `desktopClientInstanceId`；侧边栏「保存岗位到本地」与「确认已投递」；桌面粘贴 ID 配对 |
+| 永不（v1） | 把桌面档案镜像进 `chrome.storage`；把插件 Key 复制进桌面备份；content script 直连 native；用第一条 NM 做配对 |
+
+桌面 IPC（Tauri 命令）只暴露与 UI 同权的业务 API，不暴露 `execute_sql(string)`。
+
+---
+
+## 7. Alternatives Considered
+
+### 7.1 Electron + better-sqlite3 + 仍要 NM host
+
+- 优点：渲染进程全是 Node/Chromium，招聘前端更熟。
+- 缺点：~100MB+ 运行时；native 模块与 Electron ABI；GUI 仍不能当 NM host；更容易从预加载脚本漏 fs。
+- **不选。**
+
+### 7.2 纯插件 + `chrome.storage` / IndexedDB 当档案
+
+- 优点：无安装器。
+- 缺点：无可靠大附件、无用户可复制的完整备份目录、卸载扩展易丢数据、无独立于浏览器的生命周期。Epic 要求桌面权威源。
+- **不选。**
+
+### 7.3 桌面开 localhost HTTP / WebSocket 给插件
+
+- 优点：实现快。
+- 缺点：本机任意进程可打；扩展页面 XSS 或恶意扩展可滥用；D05 明文禁止。
+- **不选。**
+
+### 7.4 一个 EXE 兼任 GUI 与 NM host
+
+- 优点：少一个二进制。
+- 缺点：stdout 争用；Tauri/WebView 日志会破坏帧；Windows 子系统（WINDOWS vs CONSOLE）冲突。
+- **不选。** 两个二进制，共享 crate。
+
+### 7.5 MSI / per-machine 作为 MVP 默认
+
+- 优点：企业镜像友好。
+- 缺点：要管理员；与「普通求职者 per-user」冲突；WiX 只能在 Windows 上打 MSI。
+- **MVP 不选；** D13 可按需加。
+
+---
+
+## 8. 最低运行时与 WebView2
+
+- 插件已要求 Chrome/Edge **116+**。
+- WebView2：官方支持 Windows 10 SAC 1709+ 与 Windows 11（[WebView2 简介 · 支持的 Windows](https://learn.microsoft.com/en-us/microsoft-edge/webview2/)）。Win11 预装 Evergreen Runtime；Win10 消费设备自 2022 年起大规模投放，**仍非 100%**（[Evergreen vs fixed](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/evergreen-vs-fixed-version)）。Tauri NSIS 默认可下载 bootstrapper。
+- 产品口径：**Windows 10 22H2+ x64**。ARM64 构建 **待验证**（D13）。不承诺 Windows 7（Tauri 文档虽提到 Win7 兼容开关，超出本 MVP）。
+- 用户数据用 Known Folder `FOLDERID_LocalAppData`（默认 `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`），经 `SHGetKnownFolderPath` 或等价 API，**禁止**硬编码 `C:\Users\某开发者\...`（[KNOWNFOLDERID](https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid)）。
+
+---
+
+## 9. Security & Privacy（架构切面）
+
+细节见 [data-privacy.md](data-privacy.md)。架构层硬约束：
+
+- NM origin 白名单（扫描 argv origin token）；业务信封 64 KiB；无通配；无 HTTP 配对。
+- Pipe ACL = 当前用户；拒绝其他会话。
+- 不把插件 `aiConfig` 发到桌面。桌面 Key 用 DPAPI / Credential Manager（D11）。
+- Host 与 Tauri 后端崩溃不得损坏 DB（SQLite 事务 + 备份）；失败返回 D05 错误码，不假成功。
+- 威胁：恶意扩展若进入 `allowed_origins` 可写档案 → 所以禁止通配、禁止把开发 ID 写进生产 manifest。
+
+---
+
+## 10. Observability
+
+- 日志：错误码 + 脱敏上下文（路径只留叶名、URL 已剥 token）。禁止简历正文、邮件正文、API Key、Authorization。
+- 用户可导出诊断包（D02）：日志 + 版本 + `archiveId`/`generation`/`schemaVersion` + 队列计数；不含附件与快照正文。
+- 指标（本地计数即可，不上报）：握手成功/失败、写入延迟、idle 退出次数、NM 帧拒绝原因。
+- 告警：无云端。UI 对连续失败显示错误码。
+
+冷启动目标（D06 验证，非 D01 实现）：host 已在、**Tauri GUI EXE（唯一写入者）** 已在时握手 **< 200 ms**；需要按需拉起该 EXE 时 **< 2 s**（**待验证**）。
+
+---
+
+## 11. Rollout Plan
+
+阶段出口对齐 Epic #15（**阶段** ≠ **执行波次**，波次见 [downstream-decisions.md §1](downstream-decisions.md#1-硬依赖图保持原样)）：
+
+| 阶段 | 内容 |
+| --- | --- |
+| P0 | 本 ADR 经负责人确认 |
+| P1 | D02 壳 + 单实例 + 数据目录；D03 数据层；D04 手动 UI。无 NM。执行上 D02/D03/D05 可先开工，D04 等 D02+D03 |
+| P2 | D05 契约 → D06 host → D07 插件连接（含配对 UX 与 `submit.confirm`）。开发机隔离注册脚本 |
+| P3 | D08 填写留档/分片快照；D09 证据收件箱 |
+| P4 | D10 待办提醒；D11 AI 建议 |
+| P5 | D12 备份恢复；D13 生产 NSIS；D14 干净账户安装验收 |
+
+回滚：卸载桌面保留档案；插件去掉 NM 调用后仍能填表（权限多一项 `nativeMessaging` 不破坏旧填写）。协议不兼容时拒绝写入，不自动迁移业务消息。
+
+功能开关：桌面「允许浏览器连接」默认开；关掉则 host 对业务 RPC 返回明确错误，插件显示未连接。v1 无远程 feature flag。
+
+---
+
+## 12. 风险
+
+| 严重度 | 风险 | 缓解 |
+| --- | --- | --- |
+| 高 | GUI stdout 污染 NM | 独立 host EXE；二进制模式；契约测试乱写 stdout |
+| 高 | 多写入者损坏 SQLite | mutex + **单一 Tauri GUI EXE / unique writer**；D02 验收第二实例 |
+| 中 | 未打包 ID 变化 / 未配对当未安装 | 桌面粘贴 ID；未配对单独降级；D01 不加 key |
+| 中 | MV3 SW 杀死 native port | 队列 + 重连；D06 原型 |
+| 中 | 部分 Win10 无 WebView2 | NSIS bootstrapper；文档说明 |
+| 低 | Rust 人力 | crate 边界小；UI 仍用 web |
+
+---
+
+## 13. Open Questions
+
+见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择) 第 1–4 项（栈、MSI、托盘、扩展 ID）。原型项见同文「需要后续原型验证」。
+
+---
+
+## 14. References
+
+- Chrome Native messaging: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+- Edge Native messaging: https://learn.microsoft.com/en-us/microsoft-edge/extensions/developer-guide/native-messaging
+- `chrome.runtime.sendNativeMessage` / `connectNative`（同上文档）
+- Tauri 2 Windows installer: https://v2.tauri.app/distribute/windows-installer/
+- Tauri 2 sidecar: https://v2.tauri.app/develop/sidecar/
+- KNOWNFOLDERID / `FOLDERID_LocalAppData`: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
+- WebView2 支持的 Windows: https://learn.microsoft.com/en-us/microsoft-edge/webview2/
+- WebView2 Evergreen vs Fixed: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/evergreen-vs-fixed-version
+- SQLite: https://sqlite.org/  · self-contained: https://www.sqlite.org/selfcontained.html
+- 本仓库 [`manifest.json`](../../manifest.json)、[`background.js`](../../background.js)
+- Epic #15、D02 #16、D05 #23、D06 #24、D13 #29

--- a/docs/desktop-mvp/adr-architecture.md
+++ b/docs/desktop-mvp/adr-architecture.md
@@ -194,38 +194,69 @@ D10 验收：启用后台提醒并授权后，**杀掉应用进程**，到期仍
 
 D05 必须包含的信封字段（此处冻结名字与枚举，不写 JSON Schema）：
 
-**请求：** `protocolVersion`、`messageId`、`clientInstanceId`、`messageType`、`occurredAt`、`payload`。
+**请求公共字段：** `protocolVersion`、`messageId`、`clientInstanceId`、`messageType`、`occurredAt`、`payload`。
+
+**档案身份字段：** `archiveId`、`restoreEpoch`。含义是调用方声称正在访问的 **当前档案身份**，桌面必须与自己的 current 指针比对。**禁止**用桌面当前身份替旧消息补上这两个字段。
+
+| `messageType` | `archiveId` / `restoreEpoch` |
+| --- | --- |
+| `health` | **禁止携带**（尚未、也不需要档案身份）。若携带 → `identity_not_allowed` |
+| `handshake` | **禁止携带**。身份只出现在应答。若携带 → `identity_not_allowed` |
+| `application.queryCandidates` | **必须携带**，且等于握手得到的当前身份 |
+| `job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm` | **必须携带**当前身份。另在 payload/outbox 保存不可变的 `sourceRestoreEpoch`（绑定时的来源 epoch） |
+| `outbox.reconcile` | **外层必须携带当前身份**；payload 每项才带旧 `sourceRestoreEpoch`。外层缺失或与 current 不符 → 整批拒绝，不得用 current 回填 |
+
+缺失必须字段 → `identity_missing`（`retryable=false` 直至客户端补上）。
+与 current 不符 → `restore_epoch_mismatch`（`retryable=false` 作为写入；不是成功重放）。
+协议区间不交 → `protocol_incompatible`。
+三种情况都 **不得**把请求改写成当前身份后再执行。
+
+握手后写入示例（字段名冻结）：
+
+```json
+{
+  "protocolVersion": 1,
+  "messageId": "0193a0c2-7c1a-7d2e-b8c1-0f1e2d3c4b5a",
+  "clientInstanceId": "ext-instance-uuid",
+  "messageType": "job.save",
+  "occurredAt": "2026-09-06T12:00:00.000Z",
+  "archiveId": "archive-uuid",
+  "restoreEpoch": "epoch-current-uuid",
+  "payload": { "sourceRestoreEpoch": "epoch-current-uuid" }
+}
+```
 
 **应答：** `{ protocolVersion, correlationId, resultId?, ok, error?: { code, retryable, message? }, payload }`。
 
-- `correlationId` = 请求 `messageId`。
+- `correlationId` = 请求 `messageId`（`snapshot.chunk` 则为 **该块** 的 `messageId`，见下）。
 - `ok: true` 的写入应答必须有 `resultId`。
-- `ok: false` **没有** `resultId`；已完成且当前身份/摘要相符的普通重放返回 `ok: true` 和原 resultId。历史对账结果在只读 payload 中，不授予旧消息写入权限。
+- `ok: false` **没有** `resultId`。仅当 **当前身份校验已通过** 且完整消息身份/摘要命中已提交回执时，普通重放才返回 `ok: true` 和原 `resultId`。
 - SaveIntent **不是** NM `messageType`。
 
 **MVP `messageType` 枚举：**
 
 | `messageType` | 方向 | 说明 |
 | --- | --- | --- |
-| `health` | 双向 | 探活 |
-| `handshake` | 双向 | 返回协议区间、app 版本、`archiveId`、`restoreEpoch`、`capabilities`。**不是配对** |
-| `application.queryCandidates` | 插件→桌面 | 两层候选，最小元数据 |
+| `health` | 双向 | 探活；无档案身份 |
+| `handshake` | 双向 | 返回协议区间、app 版本、当前 `archiveId`、`restoreEpoch`、`capabilities`。**不是配对** |
+| `application.queryCandidates` | 插件→桌面 | 两层候选；必须带当前身份 |
 | `job.save` | 插件→桌面 | 已绑定后的岗位保存 |
 | `fill.submit` | 插件→桌面 | 填写事件元数据 + 可选 `snapshotId`/`sha256`（**不含**快照字节） |
-| `snapshot.chunk` | 插件→桌面 | 完整 UTF-8 JSON（信封、序号、编码后的数据在内）≤ 64 KiB；发送前所有快照都已提交到扩展源 IDB |
+| `snapshot.chunk` | 插件→桌面 | **每块独立 `messageId`**；完整 UTF-8 JSON 信封 ≤ 64 KiB；发送前字节已在扩展源 IDB |
 | `submit.confirm` | 插件→桌面 | 用户明确确认已投递（D07） |
-| `outbox.reconcile` | 插件→桌面 | 当前身份信封 + 有界完整旧身份/摘要列表；只读当前档案的历史回执，逐项返回身份、核实状态及可用 resultId，见产品 §8.11 |
+| `outbox.reconcile` | 插件→桌面 | 当前身份在外层；payload 为有界旧身份/摘要列表；只读历史回执，见产品 §8.11 |
 
 原则：
 
 1. **握手成功**即返回当前 `(archiveId, restoreEpoch)`。仅协议不兼容或 kill switch 时握手失败。epoch 变化 **不是**握手失败。
-2. **至少一次传送，业务恰好一次：** 普通写入先校验当前 `(archiveId, restoreEpoch)`，再按 `(clientInstanceId, messageId, sourceRestoreEpoch)` 和 payloadSha256 处理事务回执，其中 sourceRestoreEpoch 是提交时的 epoch。epoch 不符返回 `restore_epoch_mismatch`，不是成功重放。历史回执随业务库备份；只读对账按完整旧身份查询，不按新 epoch 过滤，也不改当前 epoch。详见 [产品 §8.11](product-requirements.md#811-已提交消息回执与恢复对账)。
-3. **64 KiB 是完整序列化业务信封的 UTF-8 字节上限**（不含 NM 的 4 字节长度前缀），不是原始块大小。D05 建议 raw chunk ≤ 32 KiB，并限制其他字段；仍须实际编码后测量整帧，超限拒绝，不能假定 base64/JSON 没有开销。所有快照在线/离线均先持久化到扩展源 IDB，完整提交 ACK 前保留字节。D05/D08 测试整帧 65536/65537 字节、分片中断与完整 ACK 丢失。
-4. **`allowed_origins` 无通配符。** D01 不加 `key`。
-5. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13。
-6. 恢复：新目录、保留 backup `archiveId`、**新铸 restoreEpoch**。握手成功；插件暂停盖着旧 epoch 的绑定队列。意图重新走候选。
+2. **普通写入两段校验：** (a) 请求信封的 `(archiveId, restoreEpoch)` **必须等于**桌面 current；(b) 仅在 (a) 通过后，才按 `(clientInstanceId, messageId, sourceRestoreEpoch)` + `payloadSha256` 判定重放。「相同载荷返回原 resultId」**只适用于 (a) 已通过、且 sourceRestoreEpoch 也等于 current** 的普通写入。`sourceRestoreEpoch` ≠ current → `restore_epoch_mismatch`，**不得**当重放成功。旧 epoch 消息只能走 `outbox.reconcile` 只读对账。详见 [产品 §8.10–§8.11](product-requirements.md#810-插件队列saveintent-与-bound-outbox)。
+3. **64 KiB 是完整序列化业务信封的 UTF-8 字节上限**（不含 NM 的 4 字节长度前缀）。D05 建议 raw chunk ≤ 32 KiB；超限拒绝。
+4. **`snapshot.chunk` 块级身份：** 每个 chunk 有持久化的独立 `messageId`，不得与 `fill.submit`/`job.save` 或其它块共用。业务幂等键另含 `(clientInstanceId, snapshotId, chunkIndex, sourceRestoreEpoch)`。重启不得新铸块身份。`chunkCursor` = 已连续 ACK 的下一块下标；较后块的 ACK **不得**跳过中间未确认块。分片 ACK ≠ 完整快照 ACK。见产品 §8.5。
+5. **`allowed_origins` 无通配符。** D01 不加 `key`。
+6. 开发机注册脚本只用于隔离测试（D06）；生产注册归 D13。
+7. 恢复：新目录、保留 backup `archiveId`、**新铸 restoreEpoch**。握手成功；插件暂停 `sourceRestoreEpoch` ≠ current 的绑定队列。意图重新走候选。
 
-Host 校验顺序：扫描 argv 的 origin token ∈ 当前 manifest；单帧 ∈ (0, 64 KiB]；JSON 可解析；`messageType` ∈ 上表；写成功才回帧。
+Host 校验顺序：扫描 argv 的 origin token ∈ 当前 manifest；单帧 ∈ (0, 64 KiB]；JSON 可解析；`messageType` ∈ 上表；按上表检查身份字段；写成功才回帧。
 
 ---
 

--- a/docs/desktop-mvp/data-privacy.md
+++ b/docs/desktop-mvp/data-privacy.md
@@ -1,0 +1,286 @@
+# 数据归属、隐私与备份规则
+
+| 字段 | 值 |
+| --- | --- |
+| 标题 | 本地档案所有权、敏感分级与备份恢复 |
+| 作者 | D01 design PR |
+| 日期 | 2026-09-06 |
+| 状态 | Draft / Ready for review |
+| 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
+| 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [downstream-decisions.md](downstream-decisions.md) |
+
+本文回答：数据在哪、谁能写、什么永远不能存、备份装了什么、恢复如何换代。物理 schema 仍归 D03；备份格式版本归 D12。
+
+---
+
+## 1. Overview
+
+求职档案（申请、事件、附件、简历快照、待办、已确认的 AI 建议结果）**归用户本机上的桌面档案目录所有**。浏览器插件不是权威源：它持有可编辑的活模板和自己的 AI Key，并可在用户同意后向桌面投递岗位/填写事件。
+
+没有云账号、没有多设备同步。使用用户配置的云端模型时，必须展示外发范围；不得宣传「装了本地应用 = AI 全部在本地」。
+
+---
+
+## 2. 所有权与信任边界
+
+| 数据 | 所有者 | 权威副本 | 允许的副本 |
+| --- | --- | --- | --- |
+| 申请 / 事件 / 待办 / 证据 / 快照 | 用户 | Tauri 后端（`data-service` 库）管理的 archive 目录 | 用户导出的备份文件 |
+| 插件模板、`activeTemplateId` | 用户 | `chrome.storage.local` | 填写归档时生成的 **不可变快照** |
+| 插件 `aiConfig.apiKey` | 用户 | 仅扩展存储（今天明文） | **禁止**复制到桌面档案或备份 |
+| 桌面模型 Key（D11） | 用户 | OS 凭据库（DPAPI / Credential Manager） | **禁止**进 SQLite、附件、备份、日志 |
+| 离线 outbox | 用户 | 插件 `chrome.storage.local` 新 key | 不得含 Key；恢复后按 generation 暂停 |
+
+写入者：仅 Tauri GUI EXE 的 Rust 后端（`data-service` 库）。插件、webview、host 都是客户端。未安装或未配对时，插件不得把申请档案写进扩展存储冒充桌面库，也不得堆积无法消化的 durable outbox。
+
+---
+
+## 3. 目录布局
+
+安装目录 ≠ 用户数据目录。安装器默认 per-user，程序在 `%LOCALAPPDATA%` 下的应用文件夹（Tauri NSIS 默认行为，见 ADR）。档案必须再分一层，避免升级覆盖或卸载误删。
+
+用 Known Folder API 解析 `FOLDERID_LocalAppData`（文档默认路径 `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`），**禁止**把开发机绝对路径写进代码或文档示例以外的「产品默认」。示例只用环境变量：
+
+```text
+%LOCALAPPDATA%\ResumePro\
+  app\                 （或安装器选定的 INSTDIR，可与此分离）
+  archive\             current 档案
+    archive.db
+    archive.db-wal
+    attachments\
+    snapshots\
+    tmp\
+    meta.json          archiveId, generation, schemaVersion
+  archives-retired\    恢复前的旧档案（回滚点）
+  logs\
+  backups\             用户指定位置也可；默认不强制
+```
+
+设置页必须展示 **解析后的真实路径**，供中文/空格用户名核对（D02 验收）。目录不可写时失败并给出可操作提示，**禁止**静默改用 `%TEMP%`。
+
+WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位置，不要用安装目录旁的默认 `exe.WebView2`（安装目录升级可删）。
+
+相对路径入库；拒绝 `..`、盘符、UNC。附件文件名冲突时加后缀，不覆盖（D09）。
+
+---
+
+## 4. 敏感分级
+
+与 [字段目录](product-requirements.md#8-逻辑对象与字段目录) 一致，三类：
+
+| 级 | 含义 | 例子 | 存储 |
+| --- | --- | --- | --- |
+| `public-meta` | 流程元数据 | UUID、stage code、计数、耗时、插件版本 | 可进 DB/日志（日志仍截断） |
+| `PII` | 能识别求职者或雇主沟通内容 | 公司、姓名备注、邮件正文、简历快照、地点、发件人 | 可进档案与备份；**默认不进日志**；导出备份必须警告 |
+| `secret-forbidden` | 能造成账户接管 | 见下表 | **任何层都不得保存** |
+
+### 4.1 永远不得出现在档案、事件、快照、日志、备份、诊断导出中
+
+- 密码、支付口令
+- OTP / 短信验证码 / 邮箱验证码
+- API Key（插件与桌面）
+- Cookie、`Set-Cookie`
+- `Authorization` 头及其值
+- URL 中的令牌类查询参数（见 §7.1）
+- Native host 的机器专属绝对路径（备份排除；诊断可含「已配置/未配置」）
+- 网页密码框、`autocomplete=one-time-code` 的控件值
+
+插件填写路径已尽量不扫 `type=hidden|file|button|submit`；桌面留档仍要再剥一层。不确定是否为 secret 时：**丢弃该字段，不得「先存再看」。**
+
+### 4.2 插件活模板 vs 桌面快照
+
+- 活模板：仅 `chrome.storage.local`，用户可随时「重新导入 Excel」覆盖。
+- 快照：填写归档时拷贝，之后 **immutable**。改活模板不影响历史申请。
+- 不得为了「方便同步」把活模板全量写入桌面，除非用户在某次归档中明确保存快照。
+
+---
+
+## 5. 删除、回收与永久清除
+
+| 操作 | 申请行 | 事件 | 附件 blob | 可恢复 |
+| --- | --- | --- | --- | --- |
+| 列表归档 `archivedAt` | 保留，列表默认隐藏 | 保留 | 保留 | 是 |
+| 回收 `recycleState=recycled` | 保留 | **保留** | **保留** | 是（D12） |
+| 永久删除（二次确认） | 删除或墓碑 | 随申请移除 | **仅当引用计数为 0** 才删文件 | 否 |
+| 卸载程序 | 不触碰 archive | — | — | 档案仍在磁盘 |
+
+孤立附件检查可在维护任务中列出，**不自动删除**不确定项（D12）。永久删除文案必须写清：不可从本应用撤销；若有备份可从备份恢复。
+
+---
+
+## 6. 备份与恢复
+
+### 6.1 完整备份包含
+
+- SQLite **一致性快照**（备份前 checkpoint 或使用 SQLite backup API，D12 定）
+- `attachments/`、`snapshots/`
+- 事件、待办所在表（随 DB）
+- 非秘密设置（UI 偏好、是否允许浏览器连接）
+- `manifest`：格式版本、`archiveId`、`generation`、`schemaVersion`、文件清单、每文件 sha256
+
+### 6.2 明确排除
+
+- API Key、OS 凭据副本、任何 auth cache
+- 调试日志、诊断包
+- 机器专属 native-host 路径、注册表路径
+- `tmp/`、WebView2 cache、安装器自身
+
+### 6.3 加密
+
+**MVP 备份不加密。** 导出 UI 必须警告：文件含简历与邮件等 PII，应放在用户自己控制的位置。不得在发布说明或界面宣传「已加密」。若未来要加密，另开 issue，不在 D12 悄悄加上。
+
+### 6.4 写入与失败
+
+写到临时目录，校验哈希后原子改名发布。失败不得覆盖已有有效备份。磁盘满：保留原档案 + 至少一个旧有效备份。
+
+### 6.5 恢复
+
+```mermaid
+sequenceDiagram
+  participant U as 用户
+  participant UI as Desktop UI
+  participant DS as Tauri GUI EXE
+  participant P as 插件队列
+  U->>UI: 选择备份文件
+  UI->>DS: 校验大小/路径穿越/哈希/版本
+  DS-->>UI: 预览（申请数/事件数/附件数）
+  U->>UI: 确认恢复
+  DS->>DS: 把 current 档案移到 archives-retired
+  DS->>DS: 解压到新 archive 目录
+  DS->>DS: 切换 current 指针并提升 generation
+  DS-->>UI: 成功；旧目录可回滚
+  P->>DS: handshake
+  DS-->>P: 同一 archiveId + 已 +1 的 generation
+  Note over P: 握手成功；比较 outbox 盖章后暂停
+  U->>P: 关联 / 丢弃 / 另存
+```
+
+规则：
+
+1. 先预览再确认。
+2. 恢复到 **新档案目录** 再切换；**MVP 不做逐行 merge**。
+3. 旧档案保留为回滚点，直到用户显式删除。
+4. 损坏、截断、不支持版本、路径穿越：拒绝，current 不变。
+5. **保留 backup 的 `archiveId`（immutable），`generation` 必 +1。** 随后握手 **成功** 并返回新 `(archiveId, generation)`。插件比较 outbox 上盖的旧身份后暂停队列。握手失败仅用于协议不兼容 / kill switch，**不是**用来拦截旧队列。
+6. 恢复后不得瞬间重放全部待办通知（D10：休眠补报一次汇总，不轰炸）。
+
+存储量粗估（单用户一季）：DB 数 MB；每封 eml/PDF 数十 KB–数 MB；简历快照常见为数十–数百 KiB，产品上限 **2 MiB**（超过则拒绝，走桌面导入）。备份大小 ≈ DB + 附件 + 快照。不在 D01 承诺压缩比。
+
+---
+
+## 7. 插件采集边界
+
+只记录 **用户主动** 的：保存岗位、确认投递、确认填写留档。不监听全部输入、不装全局键盘记录、不保存整页 HTML、不保存浏览历史、不保存用户未点保存的页面。
+
+### 7.1 URL 脱敏与去重 URL
+
+去掉 `https://user:pass@host/` 用户信息与 fragment。
+
+**始终剥离**（大小写不敏感；写入 `sourceUrl` 与 `dedupeUrl`）：
+
+`token`、`access_token`、`refresh_token`、`id_token`、`session`、`sessionid`、`sid`、`auth`、`authorization`、`api_key`、`apikey`、`password`、`pwd`、`secret`、`signature`、`sig`。
+
+**单独的 `code` / `key` 不当成秘密**，除非同时出现上述令牌类邻居（例如同 URL 已有 `access_token` 或 `client_id`+`grant`）。许多 ATS 用 `?code=REQ42` / `?key=job-7` 表示岗位号；剥掉它们会让 10.4 精确层失效，或把不同岗位撞在同一 `dedupeUrl`。
+
+- `sourceUrl`：展示与存储；剥秘密，**保留**岗位号 `code`/`key`。
+- `dedupeUrl`：身份规范化（host 小写、无 userinfo、无 fragment、剥秘密列表）；同样 **保留** 裸 `code`/`key`。
+
+合成例：
+
+```text
+https://jobs.example.com/apply?code=REQ42&utm_source=mail&access_token=abc
+sourceUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
+dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
+```
+
+`utm_*` 是否从 `dedupeUrl` 再剥留给 D07 实现，但 **不得**剥 `code=REQ42`。令牌类不确定时仍宁可多剥。
+
+### 7.2 填写留档
+
+默认事件元数据见 [产品需求 §8.8](product-requirements.md#88-填写留档默认范围)。逐字段值默认关。用户拒绝留档：填表照常，不向桌面发送采集 payload。
+
+---
+
+## 8. AI 外发
+
+两条互不相通的 Key：
+
+| | 插件填写/解析 | 桌面通知整理（D11） |
+| --- | --- | --- |
+| 配置位置 | `chrome.storage.local.aiConfig`（今天明文） | Credential Manager / DPAPI |
+| 发往 | 用户填的 `apiUrl` | 用户另配的桌面接口 |
+| 内容 | 表单字段描述 + 相关简历分组（现有逻辑） | 证据正文/片段 + **最少**候选申请元数据 |
+| 确认 | 用户主动点「一键 AI 填写」即同意该次填写外发 | 发送前预览范围、服务商、模型 |
+
+共同规则：
+
+- 不把完整档案库送给模型。
+- 不把另一条申请的快照当作上下文，除非用户在消歧中选中。
+- 模型返回只是建议 JSON；正文里的「忽略以上指令」不得变成工具权限（D11）。
+- 网络慢可取消；不自动重复计费重试。
+- 失败不影响本地证据与手动阶段。
+
+插件 Key **永不**因「桌面也要用 AI」而被复制。用户若在桌面再配一次，那是第二条凭据。
+
+---
+
+## 9. 日志与诊断
+
+格式：`timestamp utc | errorCode | component | redactedContext`。
+
+允许：stage code、UUID、字节数、耗时、HTTP 状态码（桌面出站）、NM 拒绝原因（`origin_forbidden`、`oversize`、`unknown_type`）。
+
+禁止：简历字段值、邮件正文、主题可考虑截断哈希而非原文、Key、Cookie、完整 URL（只用剥过的 host+path 或 hash）。
+
+用户导出诊断：日志 + 版本 + 档案元数据 + 队列长度。默认不含附件。导出同样警告可能残留 PII（公司名等若曾入上下文）。
+
+现有插件诊断 [`formatFillDiagnostics`](../../content.js) 已用错误类别 allowlist；桌面应对齐该纪律。
+
+---
+
+## 10. 升级、卸载、多浏览器
+
+- 升级覆盖 INSTDIR，不碰 `archive\`；迁移前自动备份 DB（D03/D12）。
+- 卸载默认留档案；注册表 NM 项指向已删除 EXE 时必须清掉，避免「host not found」残留（D13）。
+- D13 **始终**写 Chrome **和** Edge 的 HKCU `NativeMessagingHosts` 键（见 ADR §2）。不得只写 Chrome 键再指望 Edge fallback。配对在桌面 UI 粘贴 ID，分别写入对应 manifest。
+- 无云同步：换电脑 = 备份恢复。恢复后握手成功并返回新 generation；插件暂停盖着旧 generation 的 outbox，不得静默写入。
+
+---
+
+## 11. 威胁模型（简表）
+
+| 威胁 | 严重度 | 缓解 |
+| --- | --- | --- |
+| 恶意扩展进入 allowed_origins | 高 | 无通配；生产不写任意 ID；host 扫描 argv 中的 origin token（不是 argv[0]） |
+| 本机其他用户读 named pipe | 高 | DACL 仅当前 SID |
+| 备份文件被上传到网盘 | 中 | 明文警告；不宣传加密 |
+| 日志泄漏简历 | 中 | allowlist；诊断默认无附件 |
+| 路径穿越写入 archive 外 | 高 | 相对路径规范化；拒绝 `..` |
+| HTML 邮件 XSS / 跟踪像素 | 中 | 清洗、不执行脚本、不加载远程图（D09） |
+| 模型提示注入 | 中 | 无工具权限；确认后才写库 |
+| 卸载误删档案 | 高 | 默认保留；单独确认 |
+
+---
+
+## 12. Observability 与合规口径
+
+- 不做云遥测。
+- MIT 开源；仓库不得提交真实简历、真实 Key、真实 eml。测试夹具必须合成或脱敏（D09/D14 已要求）。
+- 不宣称 GDPR 认证；产品是单机工具。若未来加云，另开 Epic。
+
+---
+
+## 13. Open Questions
+
+备份是否加密、填写留档是否默认含字段值：见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。本文按 **不加密、默认仅元数据** 撰写。
+
+---
+
+## 14. References
+
+- KNOWNFOLDERID `FOLDERID_LocalAppData`: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
+- SQLite 单文件格式: https://www.sqlite.org/onefile.html
+- Chrome NM `allowed_origins` 无通配符: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+- Credential Manager / DPAPI：D11 实现时对照 Windows 官方 `CredWrite` / `CryptProtectData` 文档（本 D01 不实现）
+- Epic #15 规则 5–8；D08 #22、D09 #21、D12 #28、D13 #29
+- [`content.js`](../../content.js) `STORAGE_KEYS`、`formatFillDiagnostics`；[`popup.js`](../../popup.js) `aiConfig`

--- a/docs/desktop-mvp/data-privacy.md
+++ b/docs/desktop-mvp/data-privacy.md
@@ -30,7 +30,7 @@
 | 插件 `aiConfig.apiKey` | 用户 | 仅扩展存储（今天明文） | **禁止**复制到桌面档案或备份 |
 | 桌面模型 Key（D11） | 用户 | OS 凭据库：Windows Credential Manager / DPAPI；macOS Keychain | **禁止**进 SQLite、附件、备份、日志 |
 | 保存意图 / 绑定 outbox | 用户 | `chrome.storage.local` 新 key | 不得含 Key；绑定项恢复后按 **restoreEpoch** 暂停 |
-| 离线快照字节 | 用户 | 扩展源 **IndexedDB**（SW/offscreen/扩展页） | ACK 后删除；不得写在 content script 的页面源 |
+| 所有待提交快照字节（在线/离线） | 用户 | 扩展源 **IndexedDB**（SW/offscreen/扩展页） | 完整快照持久化且总哈希 ACK 后才可删除；不得写在页面源 |
 
 写入者：仅 **应用进程**（`data-service` 库）。插件、WebView 子进程、NM host 都是客户端。从未配对时，插件不得把申请档案写进扩展存储冒充桌面库，也不得堆积意图。曾经配对但桌面不可用时，只允许 SaveIntent + IndexedDB 快照暂存，不得显示已保存。
 
@@ -69,7 +69,7 @@ macOS（`NSApplicationSupportDirectory` / `NSCachesDirectory`）：
 ~/Library/Caches/ResumePro/     缓存，卸载策略可更激进
 ```
 
-`restoreEpoch` **只**在 `current.json`（或等价指针文件），**不**进备份包、**不**进 `archive/meta.json` 的「可移植身份」。备份可以记录「当时指针曾是什么」作诊断，恢复时必须忽略并新铸。
+当前生效的 `restoreEpoch` 只由机器本地 `current.json`（或等价指针文件）决定，不把该指针文件或“可恢复的当前 epoch”放进备份。业务回执中的 `sourceRestoreEpoch` 是历史标识，可以随数据库备份用于只读对账；它不能成为恢复后的当前身份。每次成功恢复/回滚仍新铸当前 epoch，不能从历史回执恢复权限。
 
 WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁的默认文件夹。
 
@@ -103,7 +103,7 @@ WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁�
 ### 4.2 插件活模板 vs 桌面快照
 
 - 活模板：仅 `chrome.storage.local`，用户可随时「重新导入 Excel」覆盖。
-- 快照：填写归档确认时拷贝，之后 **immutable**。桌面不可用时字节进扩展源 IndexedDB；重试发原字节，禁止从活模板重生成。见 [产品需求 §8.5](product-requirements.md#85-resumesnapshot)。
+- 快照：填写归档确认时拷贝，之后 **immutable**。无论桌面是否在线，发送前先把完整字节提交到扩展源 IndexedDB；完整持久化/总哈希 ACK 前保留原字节，分片 ACK 不触发清理。见 [产品需求 §8.5](product-requirements.md#85-resumesnapshot)。
 - 不得为了「方便同步」把活模板全量写入桌面，除非用户在某次归档中明确保存快照。
 
 ---
@@ -127,9 +127,9 @@ WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁�
 
 - SQLite **一致性快照**（备份前 checkpoint 或使用 SQLite backup API，D12 定）
 - `attachments/`、`snapshots/`
-- 事件、待办所在表（随 DB）
+- 事件、待办、已提交消息回执（含 sourceRestoreEpoch 等完整历史身份，随 DB；不包含当前指针）
 - 非秘密设置（UI 偏好、是否允许浏览器连接）
-- `manifest`：格式版本、`archiveId`、`schemaVersion`、文件清单、每文件 sha256。**不含** `restoreEpoch`、机器 IPC 路径、凭据
+- `manifest`：格式版本、`archiveId`、`schemaVersion`、文件清单、每文件 sha256。**不含当前生效的** `restoreEpoch`、current.json、机器 IPC 路径或凭据；数据库历史回执按上一项保留。
 
 ### 6.2 明确排除
 
@@ -137,6 +137,7 @@ WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁�
 - 调试日志、诊断包
 - 机器专属 native-host 路径、注册表路径
 - `tmp/`、WebView2 cache、安装器自身
+- 导入任务内存中的 `sourcePathHint`：任务完成/失败/取消后清除，不持久化到 SQLite、事件、备份或诊断。保留安全文件名不等于保留原始绝对路径。
 
 ### 6.3 加密
 
@@ -158,9 +159,9 @@ sequenceDiagram
   UI->>APP: 校验大小/路径穿越/哈希/版本
   APP-->>UI: 预览（申请数/事件数/附件数）
   U->>UI: 确认恢复
-  APP->>APP: current 档案移到 archives-retired
-  APP->>APP: 解压到新 archive 目录
-  APP->>APP: 新铸 restoreEpoch，写入 current.json
+  APP->>APP: 在独立 staging 目录完整解压、校验并准备迁移；旧 current 不动
+  APP->>APP: 暂停写入，刷新新档案；新铸 restoreEpoch，原子替换 current.json
+  APP->>APP: 旧目录登记为 retired 回滚点；不在切换前搬走
   APP-->>UI: 成功；旧目录可回滚
   P->>APP: handshake
   APP-->>P: 同一 archiveId + 新 restoreEpoch
@@ -171,13 +172,13 @@ sequenceDiagram
 规则：
 
 1. 先预览再确认。
-2. 恢复到 **新档案目录** 再切换；**MVP 不做逐行 merge**。
+2. 在独立 staging/新档案目录完成解压、路径与哈希校验、迁移验证后才切换；切换前旧目录及 current.json 原封不动。暂停写入并持久化新档案后，以原子替换 current.json 作为提交点；失败保留旧指针。崩溃恢复必须识别提交点，不能组合旧目录与新 epoch。**MVP 不做逐行 merge**。
 3. 旧档案保留为回滚点，直到用户显式删除。
 4. 损坏、截断、不支持版本、路径穿越：拒绝，**current.json 不变**（旧 epoch 仍有效）。
 5. **保留 backup 的 `archiveId`。每次成功切换 current 指针新铸 `restoreEpoch`（UUID）。** 不从备份读取 epoch，不用 `generation+1`。握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。绑定队列盖章不符则暂停。意图无 epoch，恢复后重新候选。
 6. 再次恢复 **同一** 备份：再铸新 UUID，与上一次不同（走查 10.8 / 10.12）。
 7. 回滚到 retired 目录：视为一次新的指针切换，**再铸** epoch，不复用失败前的值。
-8. 桌面幂等 `(clientInstanceId, messageId, restoreEpoch)`。epoch 不符 → `restore_epoch_mismatch`，禁止当成功重放。
+8. 普通写入先校验当前 archiveId/restoreEpoch；epoch 不符返回 `restore_epoch_mismatch`。历史回执以 `(clientInstanceId, messageId, sourceRestoreEpoch)` 加摘要对账，不按新 epoch 过滤历史行。对账只读、不授权重放；未命中不等于从未执行，须用户核对。完整契约见 [产品 §8.11](product-requirements.md#811-已提交消息回执与恢复对账)。
 9. 恢复后不得瞬间重放全部待办通知；按产品 §5.4 重新登记系统调度。
 
 存储量粗估（单用户一季）：DB 数 MB；每封 eml/PDF 数十 KB–数 MB；简历快照常见为数十–数百 KiB，产品上限 **2 MiB**（超过则拒绝，走桌面导入）。备份大小 ≈ DB + 附件 + 快照。不在 D01 承诺压缩比。
@@ -194,22 +195,29 @@ sequenceDiagram
 
 **始终剥离**（大小写不敏感；写入 `sourceUrl` 与 `dedupeUrl`）：
 
-`token`、`access_token`、`refresh_token`、`id_token`、`session`、`sessionid`、`sid`、`auth`、`authorization`、`api_key`、`apikey`、`password`、`pwd`、`secret`、`signature`、`sig`。
+`token`、`access_token`、`refresh_token`、`id_token`、`session`、`sessionid`、`sid`、`auth`、`authorization`、`api_key`、`apikey`、`password`、`pwd`、`secret`、`signature`、`sig`；`code`、`key` 同样**默认剥离**，只有下述已审核岗位号规则可以例外。
 
-**单独的 `code` / `key` 不当成秘密**，除非同时出现上述令牌类邻居（例如同 URL 已有 `access_token` 或 `client_id`+`grant`）。许多 ATS 用 `?code=REQ42` / `?key=job-7` 表示岗位号；剥掉它们会让 10.4 精确层失效，或把不同岗位撞在同一 `dedupeUrl`。
+**不存在相邻 token 参数并不能证明安全。** OAuth 回调、密码重置、magic link 常只有一个 code/key。仅当确切 HTTPS host、明确岗位页路径、参数名以及岗位编号取值语法都命中版本化、已审核的站点规则时，才可保留该岗位号；没有规则时删除。规则不得覆盖登录/回调/重置/邀请/认证路径，不根据页面自称“岗位号”、模型建议或用户临时输入自动加入 allowlist。D07 必须用该站点的正反例证明规则，不在 D01 假造实际站点名单。
 
-- `sourceUrl`：展示与存储；剥秘密，**保留**岗位号 `code`/`key`。
-- `dedupeUrl`：身份规范化（host 小写、无 userinfo、无 fragment、剥秘密列表）；同样 **保留** 裸 `code`/`key`。
+- `sourceUrl` 与 `dedupeUrl` 使用同一秘密剥离策略；清洗必须在入意图队列、日志或数据库之前完成，不保留秘密参数的原始副本。
+- `dedupeUrl` 再移除 `utm_*` 等明确跟踪参数并规范化 host。删除参数后可能产生候选碰撞，因此 URL 只能用于提示，不变成自动合并的唯一身份。
 
 合成例：
 
 ```text
+无已审核站点规则：
 https://jobs.example.com/apply?code=REQ42&utm_source=mail&access_token=abc
-sourceUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
-dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
+sourceUrl  = https://jobs.example.com/apply?utm_source=mail
+dedupeUrl  = https://jobs.example.com/apply
+
+https://auth.example.com/callback?code=ONE_TIME_SECRET
+sourceUrl / dedupeUrl = https://auth.example.com/callback
+
+https://portal.example.com/reset?key=RESET_SECRET
+sourceUrl / dedupeUrl = https://portal.example.com/reset
 ```
 
-`utm_*` 是否从 `dedupeUrl` 再剥留给 D07 实现，但 **不得**剥 `code=REQ42`。令牌类不确定时仍宁可多剥。
+allowlist 正例必须与同 host 的认证路径反例一起验收；未知站点、重复参数、大小写变化、编码参数名、超长值和非法岗位号均须测试。不确定则删除，不以提高去重命中率为由保留凭据。
 
 ### 7.2 填写留档
 
@@ -289,7 +297,7 @@ dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
 
 ## 13. Open Questions
 
-备份是否加密、填写留档是否默认含字段值：见 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)。本文按 **不加密、默认仅元数据** 撰写。
+备份是否加密、填写留档是否默认含字段值：见 [downstream-decisions.md](downstream-decisions.md#4-需要项目负责人选择)。本文按 **不加密、默认仅元数据** 撰写。
 
 ---
 

--- a/docs/desktop-mvp/data-privacy.md
+++ b/docs/desktop-mvp/data-privacy.md
@@ -29,7 +29,7 @@
 | 插件模板、`activeTemplateId` | 用户 | `chrome.storage.local` | 填写归档时生成的 **不可变快照** |
 | 插件 `aiConfig.apiKey` | 用户 | 仅扩展存储（今天明文） | **禁止**复制到桌面档案或备份 |
 | 桌面模型 Key（D11） | 用户 | OS 凭据库：Windows Credential Manager / DPAPI；macOS Keychain | **禁止**进 SQLite、附件、备份、日志 |
-| 保存意图 / 绑定 outbox | 用户 | `chrome.storage.local` 新 key | 不得含 Key；绑定项恢复后按 **restoreEpoch** 暂停 |
+| 保存意图 / 绑定 outbox | 用户 | `chrome.storage.local` 新 key | 不得含 Key；绑定项以不可变 `sourceRestoreEpoch` 盖章；恢复后与 current 不符则暂停，信封不得被桌面改写成当前身份 |
 | 所有待提交快照字节（在线/离线） | 用户 | 扩展源 **IndexedDB**（SW/offscreen/扩展页） | 完整快照持久化且总哈希 ACK 后才可删除；不得写在页面源 |
 
 写入者：仅 **应用进程**（`data-service` 库）。插件、WebView 子进程、NM host 都是客户端。从未配对时，插件不得把申请档案写进扩展存储冒充桌面库，也不得堆积意图。曾经配对但桌面不可用时，只允许 SaveIntent + IndexedDB 快照暂存，不得显示已保存。
@@ -178,7 +178,7 @@ sequenceDiagram
 5. **保留 backup 的 `archiveId`。每次成功切换 current 指针新铸 `restoreEpoch`（UUID）。** 不从备份读取 epoch，不用 `generation+1`。握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。绑定队列盖章不符则暂停。意图无 epoch，恢复后重新候选。
 6. 再次恢复 **同一** 备份：再铸新 UUID，与上一次不同（走查 10.8 / 10.12）。
 7. 回滚到 retired 目录：视为一次新的指针切换，**再铸** epoch，不复用失败前的值。
-8. 普通写入先校验当前 archiveId/restoreEpoch；epoch 不符返回 `restore_epoch_mismatch`。历史回执以 `(clientInstanceId, messageId, sourceRestoreEpoch)` 加摘要对账，不按新 epoch 过滤历史行。对账只读、不授权重放；未命中不等于从未执行，须用户核对。完整契约见 [产品 §8.11](product-requirements.md#811-已提交消息回执与恢复对账)。
+8. 握手后写入与 `outbox.reconcile` 外层必须自带当前 `(archiveId, restoreEpoch)`；缺失或不匹配直接拒绝，**禁止**桌面代填。普通写入仅在当前身份校验通过、且 `sourceRestoreEpoch` 等于 current 时，才按消息身份+摘要返回原 `resultId`。旧 epoch 只走只读对账。`not_found` 不代表从未执行，不得自动重写。完整契约见 [产品 §8.10–§8.11](product-requirements.md#810-插件队列saveintent-与-bound-outbox)。
 9. 恢复后不得瞬间重放全部待办通知；按产品 §5.4 重新登记系统调度。
 
 存储量粗估（单用户一季）：DB 数 MB；每封 eml/PDF 数十 KB–数 MB；简历快照常见为数十–数百 KiB，产品上限 **2 MiB**（超过则拒绝，走桌面导入）。备份大小 ≈ DB + 附件 + 快照。不在 D01 承诺压缩比。

--- a/docs/desktop-mvp/data-privacy.md
+++ b/docs/desktop-mvp/data-privacy.md
@@ -5,7 +5,7 @@
 | 标题 | 本地档案所有权、敏感分级与备份恢复 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review |
+| 状态 | 可修订开工基线（PR 合并后生效） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [downstream-decisions.md](downstream-decisions.md) |
 
@@ -119,6 +119,8 @@ WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁�
 
 孤立附件检查可在维护任务中列出，**不自动删除**不确定项（D12）。永久删除文案必须写清：不可从本应用撤销；若有备份可从备份恢复。
 
+永久删除正文/附件不等于清除幂等身份：同一事务保留最小消息墓碑（无正文），至少覆盖来源 epoch 的可写生命周期。旧消息重试只能得到 previously_purged，不能把用户删除的记录重新创建。墓碑允许随备份保留，具体保留/清理测试归 D03/D12。
+
 ---
 
 ## 6. 备份与恢复
@@ -126,6 +128,7 @@ WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁�
 ### 6.1 完整备份包含
 
 - SQLite **一致性快照**（备份前 checkpoint 或使用 SQLite backup API，D12 定）
+- **整个档案的一致性屏障：** MVP 备份期间暂停业务写入、导入完成提交与永久删除；在同一屏障内取得 DB 快照并复制它引用的全部附件/简历文件到独立 staging，再解除屏障。发布前核对 DB 的每个文件引用均存在且摘要相符，缺失则备份失败，不发布残包。若后续改用不可变文件 pin，须证明同等一致性，不允许只保证 DB 快照一致。实现归 D12。
 - `attachments/`、`snapshots/`
 - 事件、待办、已提交消息回执（含 sourceRestoreEpoch 等完整历史身份，随 DB；不包含当前指针）
 - 非秘密设置（UI 偏好、是否允许浏览器连接）

--- a/docs/desktop-mvp/data-privacy.md
+++ b/docs/desktop-mvp/data-privacy.md
@@ -9,7 +9,7 @@
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) |
 | 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [downstream-decisions.md](downstream-decisions.md) |
 
-本文回答：数据在哪、谁能写、什么永远不能存、备份装了什么、恢复如何换代。物理 schema 仍归 D03；备份格式版本归 D12。
+本文回答：数据在哪、谁能写、什么永远不能存、离线快照字节放哪、备份装了什么、恢复如何隔离旧队列。物理 schema 仍归 D03；备份格式版本归 D12。目录与凭据有平台适配；档案文件格式跨平台。
 
 ---
 
@@ -28,37 +28,50 @@
 | 申请 / 事件 / 待办 / 证据 / 快照 | 用户 | Tauri 后端（`data-service` 库）管理的 archive 目录 | 用户导出的备份文件 |
 | 插件模板、`activeTemplateId` | 用户 | `chrome.storage.local` | 填写归档时生成的 **不可变快照** |
 | 插件 `aiConfig.apiKey` | 用户 | 仅扩展存储（今天明文） | **禁止**复制到桌面档案或备份 |
-| 桌面模型 Key（D11） | 用户 | OS 凭据库（DPAPI / Credential Manager） | **禁止**进 SQLite、附件、备份、日志 |
-| 离线 outbox | 用户 | 插件 `chrome.storage.local` 新 key | 不得含 Key；恢复后按 generation 暂停 |
+| 桌面模型 Key（D11） | 用户 | OS 凭据库：Windows Credential Manager / DPAPI；macOS Keychain | **禁止**进 SQLite、附件、备份、日志 |
+| 保存意图 / 绑定 outbox | 用户 | `chrome.storage.local` 新 key | 不得含 Key；绑定项恢复后按 **restoreEpoch** 暂停 |
+| 离线快照字节 | 用户 | 扩展源 **IndexedDB**（SW/offscreen/扩展页） | ACK 后删除；不得写在 content script 的页面源 |
 
-写入者：仅 Tauri GUI EXE 的 Rust 后端（`data-service` 库）。插件、webview、host 都是客户端。未安装或未配对时，插件不得把申请档案写进扩展存储冒充桌面库，也不得堆积无法消化的 durable outbox。
+写入者：仅 **应用进程**（`data-service` 库）。插件、WebView 子进程、NM host 都是客户端。从未配对时，插件不得把申请档案写进扩展存储冒充桌面库，也不得堆积意图。曾经配对但桌面不可用时，只允许 SaveIntent + IndexedDB 快照暂存，不得显示已保存。
 
 ---
 
 ## 3. 目录布局
 
-安装目录 ≠ 用户数据目录。安装器默认 per-user，程序在 `%LOCALAPPDATA%` 下的应用文件夹（Tauri NSIS 默认行为，见 ADR）。档案必须再分一层，避免升级覆盖或卸载误删。
+安装目录 ≠ 用户数据目录 ≠ 缓存目录。档案必须与程序文件分离，避免升级覆盖或卸载误删。
 
-用 Known Folder API 解析 `FOLDERID_LocalAppData`（文档默认路径 `%LOCALAPPDATA%` = `%USERPROFILE%\AppData\Local`），**禁止**把开发机绝对路径写进代码或文档示例以外的「产品默认」。示例只用环境变量：
+**禁止**把开发机绝对路径写进产品。设置页展示解析后的真实路径（中文/空格用户名）。目录不可写时失败，**禁止**静默改用临时目录。
+
+Windows（Known Folder `FOLDERID_LocalAppData`）：
 
 ```text
 %LOCALAPPDATA%\ResumePro\
-  app\                 （或安装器选定的 INSTDIR，可与此分离）
   archive\             current 档案
     archive.db
-    archive.db-wal
     attachments\
     snapshots\
     tmp\
-    meta.json          archiveId, generation, schemaVersion
-  archives-retired\    恢复前的旧档案（回滚点）
+    meta.json          archiveId, schemaVersion（不含 restoreEpoch）
+  current.json         机器本地指针：archiveDir, archiveId, restoreEpoch
+  archives-retired\
   logs\
-  backups\             用户指定位置也可；默认不强制
+  cache\               WebView2 用户数据等
 ```
 
-设置页必须展示 **解析后的真实路径**，供中文/空格用户名核对（D02 验收）。目录不可写时失败并给出可操作提示，**禁止**静默改用 `%TEMP%`。
+macOS（`NSApplicationSupportDirectory` / `NSCachesDirectory`）：
 
-WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位置，不要用安装目录旁的默认 `exe.WebView2`（安装目录升级可删）。
+```text
+~/Library/Application Support/ResumePro/
+  archive\  ... 同上结构 ...
+  current.json
+  archives-retired\
+  logs\
+~/Library/Caches/ResumePro/     缓存，卸载策略可更激进
+```
+
+`restoreEpoch` **只**在 `current.json`（或等价指针文件），**不**进备份包、**不**进 `archive/meta.json` 的「可移植身份」。备份可以记录「当时指针曾是什么」作诊断，恢复时必须忽略并新铸。
+
+WebView 用户数据放在上述 cache/数据根下，不要用安装目录旁的默认文件夹。
 
 相对路径入库；拒绝 `..`、盘符、UNC。附件文件名冲突时加后缀，不覆盖（D09）。
 
@@ -82,7 +95,7 @@ WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位
 - Cookie、`Set-Cookie`
 - `Authorization` 头及其值
 - URL 中的令牌类查询参数（见 §7.1）
-- Native host 的机器专属绝对路径（备份排除；诊断可含「已配置/未配置」）
+- NM host 的机器专属绝对路径（备份排除；诊断可含「已配置/未配置」）
 - 网页密码框、`autocomplete=one-time-code` 的控件值
 
 插件填写路径已尽量不扫 `type=hidden|file|button|submit`；桌面留档仍要再剥一层。不确定是否为 secret 时：**丢弃该字段，不得「先存再看」。**
@@ -90,7 +103,7 @@ WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位
 ### 4.2 插件活模板 vs 桌面快照
 
 - 活模板：仅 `chrome.storage.local`，用户可随时「重新导入 Excel」覆盖。
-- 快照：填写归档时拷贝，之后 **immutable**。改活模板不影响历史申请。
+- 快照：填写归档确认时拷贝，之后 **immutable**。桌面不可用时字节进扩展源 IndexedDB；重试发原字节，禁止从活模板重生成。见 [产品需求 §8.5](product-requirements.md#85-resumesnapshot)。
 - 不得为了「方便同步」把活模板全量写入桌面，除非用户在某次归档中明确保存快照。
 
 ---
@@ -116,7 +129,7 @@ WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位
 - `attachments/`、`snapshots/`
 - 事件、待办所在表（随 DB）
 - 非秘密设置（UI 偏好、是否允许浏览器连接）
-- `manifest`：格式版本、`archiveId`、`generation`、`schemaVersion`、文件清单、每文件 sha256
+- `manifest`：格式版本、`archiveId`、`schemaVersion`、文件清单、每文件 sha256。**不含** `restoreEpoch`、机器 IPC 路径、凭据
 
 ### 6.2 明确排除
 
@@ -139,19 +152,19 @@ WebView2 用户数据文件夹应放在 `%LOCALAPPDATA%\ResumePro\` 下可写位
 sequenceDiagram
   participant U as 用户
   participant UI as Desktop UI
-  participant DS as Tauri GUI EXE
-  participant P as 插件队列
+  participant APP as 应用进程
+  participant P as 插件绑定队列
   U->>UI: 选择备份文件
-  UI->>DS: 校验大小/路径穿越/哈希/版本
-  DS-->>UI: 预览（申请数/事件数/附件数）
+  UI->>APP: 校验大小/路径穿越/哈希/版本
+  APP-->>UI: 预览（申请数/事件数/附件数）
   U->>UI: 确认恢复
-  DS->>DS: 把 current 档案移到 archives-retired
-  DS->>DS: 解压到新 archive 目录
-  DS->>DS: 切换 current 指针并提升 generation
-  DS-->>UI: 成功；旧目录可回滚
-  P->>DS: handshake
-  DS-->>P: 同一 archiveId + 已 +1 的 generation
-  Note over P: 握手成功；比较 outbox 盖章后暂停
+  APP->>APP: current 档案移到 archives-retired
+  APP->>APP: 解压到新 archive 目录
+  APP->>APP: 新铸 restoreEpoch，写入 current.json
+  APP-->>UI: 成功；旧目录可回滚
+  P->>APP: handshake
+  APP-->>P: 同一 archiveId + 新 restoreEpoch
+  Note over P: 握手成功；比较绑定队列盖章后暂停
   U->>P: 关联 / 丢弃 / 另存
 ```
 
@@ -160,9 +173,12 @@ sequenceDiagram
 1. 先预览再确认。
 2. 恢复到 **新档案目录** 再切换；**MVP 不做逐行 merge**。
 3. 旧档案保留为回滚点，直到用户显式删除。
-4. 损坏、截断、不支持版本、路径穿越：拒绝，current 不变。
-5. **保留 backup 的 `archiveId`（immutable），`generation` 必 +1。** 随后握手 **成功** 并返回新 `(archiveId, generation)`。插件比较 outbox 上盖的旧身份后暂停队列。握手失败仅用于协议不兼容 / kill switch，**不是**用来拦截旧队列。
-6. 恢复后不得瞬间重放全部待办通知（D10：休眠补报一次汇总，不轰炸）。
+4. 损坏、截断、不支持版本、路径穿越：拒绝，**current.json 不变**（旧 epoch 仍有效）。
+5. **保留 backup 的 `archiveId`。每次成功切换 current 指针新铸 `restoreEpoch`（UUID）。** 不从备份读取 epoch，不用 `generation+1`。握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。绑定队列盖章不符则暂停。意图无 epoch，恢复后重新候选。
+6. 再次恢复 **同一** 备份：再铸新 UUID，与上一次不同（走查 10.8 / 10.12）。
+7. 回滚到 retired 目录：视为一次新的指针切换，**再铸** epoch，不复用失败前的值。
+8. 桌面幂等 `(clientInstanceId, messageId, restoreEpoch)`。epoch 不符 → `restore_epoch_mismatch`，禁止当成功重放。
+9. 恢复后不得瞬间重放全部待办通知；按产品 §5.4 重新登记系统调度。
 
 存储量粗估（单用户一季）：DB 数 MB；每封 eml/PDF 数十 KB–数 MB；简历快照常见为数十–数百 KiB，产品上限 **2 MiB**（超过则拒绝，走桌面导入）。备份大小 ≈ DB + 附件 + 快照。不在 D01 承诺压缩比。
 
@@ -207,7 +223,7 @@ dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
 
 | | 插件填写/解析 | 桌面通知整理（D11） |
 | --- | --- | --- |
-| 配置位置 | `chrome.storage.local.aiConfig`（今天明文） | Credential Manager / DPAPI |
+| 配置位置 | `chrome.storage.local.aiConfig`（今天明文） | Windows：Credential Manager / DPAPI；macOS：Keychain |
 | 发往 | 用户填的 `apiUrl` | 用户另配的桌面接口 |
 | 内容 | 表单字段描述 + 相关简历分组（现有逻辑） | 证据正文/片段 + **最少**候选申请元数据 |
 | 确认 | 用户主动点「一键 AI 填写」即同意该次填写外发 | 发送前预览范围、服务商、模型 |
@@ -243,7 +259,8 @@ dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
 - 升级覆盖 INSTDIR，不碰 `archive\`；迁移前自动备份 DB（D03/D12）。
 - 卸载默认留档案；注册表 NM 项指向已删除 EXE 时必须清掉，避免「host not found」残留（D13）。
 - D13 **始终**写 Chrome **和** Edge 的 HKCU `NativeMessagingHosts` 键（见 ADR §2）。不得只写 Chrome 键再指望 Edge fallback。配对在桌面 UI 粘贴 ID，分别写入对应 manifest。
-- 无云同步：换电脑 = 备份恢复。恢复后握手成功并返回新 generation；插件暂停盖着旧 generation 的 outbox，不得静默写入。
+- 无云同步：换电脑 = 备份恢复。恢复后握手成功并返回新 `restoreEpoch`；插件暂停盖着旧 epoch 的绑定队列，不得静默写入。
+- macOS 卸载 `.app` 默认不动 `~/Library/Application Support/ResumePro/`。
 
 ---
 
@@ -265,7 +282,7 @@ dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
 ## 12. Observability 与合规口径
 
 - 不做云遥测。
-- MIT 开源；仓库不得提交真实简历、真实 Key、真实 eml。测试夹具必须合成或脱敏（D09/D14 已要求）。
+- 当前插件仓库以 MIT 发布（[`LICENSE`](../../LICENSE)）。测试夹具必须合成或脱敏。后续桌面模块的产品许可 **尚未定案**，本文不把 MIT 写成未来所有模块的承诺。
 - 不宣称 GDPR 认证；产品是单机工具。若未来加云，另开 Epic。
 
 ---
@@ -281,6 +298,8 @@ dedupeUrl  = https://jobs.example.com/apply?code=REQ42&utm_source=mail
 - KNOWNFOLDERID `FOLDERID_LocalAppData`: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
 - SQLite 单文件格式: https://www.sqlite.org/onefile.html
 - Chrome NM `allowed_origins` 无通配符: https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
-- Credential Manager / DPAPI：D11 实现时对照 Windows 官方 `CredWrite` / `CryptProtectData` 文档（本 D01 不实现）
+- Credential Manager / DPAPI：D11 对照 Windows `CredWrite` / `CryptProtectData`（本 D01 不实现）
+- macOS Keychain：D11 对照 Keychain Services；本 D01 不实现
+- 扩展 IndexedDB：https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies
 - Epic #15 规则 5–8；D08 #22、D09 #21、D12 #28、D13 #29
 - [`content.js`](../../content.js) `STORAGE_KEYS`、`formatFillDiagnostics`；[`popup.js`](../../popup.js) `aiConfig`

--- a/docs/desktop-mvp/downstream-decisions.md
+++ b/docs/desktop-mvp/downstream-decisions.md
@@ -1,0 +1,233 @@
+# 下游任务映射与决策清单
+
+| 字段 | 值 |
+| --- | --- |
+| 标题 | D02–D14 如何消费 D01；定案 / 待选 / 待验证 |
+| 作者 | D01 design PR |
+| 日期 | 2026-09-06 |
+| 状态 | Draft / Ready for review |
+| 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) · [Epic #15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
+| 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [data-privacy.md](data-privacy.md) |
+
+本文 **不改变** Epic 硬依赖图。发现的张力只记录建议，不静默改计划。D01 的实现就是文档 PR；D02+ 是后续 issue/PR。
+
+---
+
+## 1. 硬依赖图（保持原样）
+
+来自 Epic #15 与规划 `map.json`：
+
+```mermaid
+flowchart TB
+  D01[D01 #17 设计] --> D02[D02 #16 桌面壳]
+  D01 --> D03[D03 #18 SQLite]
+  D01 --> D05[D05 #23 协议]
+  D02 --> D04[D04 #19 手动 UI]
+  D03 --> D04
+  D02 --> D06[D06 #24 NM host]
+  D03 --> D06
+  D05 --> D06
+  D04 --> D07[D07 #20 保存岗位]
+  D05 --> D07
+  D06 --> D07
+  D03 --> D08[D08 #22 填写留档]
+  D07 --> D08
+  D03 --> D09[D09 #21 证据收件箱]
+  D04 --> D09
+  D04 --> D10[D10 #26 待办]
+  D09 --> D11[D11 #25 AI 建议]
+  D10 --> D11
+  D03 --> D12[D12 #28 备份]
+  D07 --> D12
+  D09 --> D12
+  D02 --> D13[D13 #29 安装]
+  D06 --> D13
+  D07 --> D13
+  D12 --> D13
+  D08 --> D14[D14 #27 端到端]
+  D11 --> D14
+  D13 --> D14
+```
+
+**阶段出口**（Epic 标签，关闭一组 issue 的门）：
+
+| 阶段 | 出口 |
+| --- | --- |
+| P0 | D01 决策确认 |
+| P1 | D02–D04：离线手动管理申请 |
+| P2 | D05–D07：插件能保存岗位并补传（含配对与 `submit.confirm`） |
+| P3 | D08+D09：快照与回复证据 |
+| P4 | D10+D11：待办与 AI 建议 |
+| P5 | D12–D14：备份/安装/端到端 |
+
+**执行波次**（谁可以先开工，硬依赖不变）：第一波 D01；第二波 D02、D03、D05 可并行；第三波 D04（等 D02+D03）、D06（等 D02+D03+D05）；第四波 D07（等 D04+D05+D06），D09/D10 在 D04 后分别推进。D04 **不是**与 D02 并行的阶段出口。
+
+「可用 mock 提前开发」≠「依赖未验收就关闭 issue」。
+
+---
+
+## 2. D02–D14 消费映射
+
+| 工作 | Issue | 硬依赖 | 从 D01 消费的结论 | 本 issue 仍需自己定的 |
+| --- | --- | --- | --- | --- |
+| D02 桌面壳、单实例、数据目录 | [#16](https://github.com/TshyGO/resume-form-assistant-plugin/issues/16) | D01 | **一个 Tauri GUI EXE**（后端=唯一写入者）+ 薄 host；mutex+named pipe；关窗隐藏≠退出；**idle 默认 15 min**（无窗口∧无 NM∧无备份/提醒）；无开机启动；日志脱敏；设置页展示真实路径；不可写则失败；「粘贴扩展 ID」设置入口骨架 | 窗口/托盘控件细节；15 min 是否做成设置项 |
+| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象含 AttachmentBlob 与折叠函数；无公司+URL 唯一约束；事件 append-only；`currentStage` 为 projected；恢复保留 `archiveId`、generation+1；幂等键；附件库外；`occurredAt` 在 unknown 时为 null | `CREATE TABLE`、索引、迁移、仓储 API |
+| D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含可过滤的 `filling`；桌面侧确认投递；文案「尚未导入回复证据」；两层候选的桌面版；走查 10.1–10.6 手动子集 | 布局、快捷键、空状态 |
+| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 冻结信封与应答 `{protocolVersion,correlationId,resultId?,ok,error?,payload}`；`messageType` 枚举含 `snapshot.chunk` 与 `outbox.reconcile`；64 KiB 业务信封；握手成功返回身份；generation 变化不失败握手 | JSON Schema、错误码表、分片帧字段、契约测试向量 |
+| D06 NM host + 唯一写入者 | [#24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) | D02、D03、D05 | 薄 host、stdio 纯净、扫描 argv 找 origin token（忽略 `--parent-window`）、按需 **启动 Tauri EXE**、pipe ACL、提交后应答、开发隔离脚本 | 可执行实现、argv 顺序 **待验证**、冷启动超时 |
+| D07 保存岗位、配对、outbox、插件确认投递 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | 桌面粘贴 ID（非 NM 配对）；未安装/未配对 **无 durable 队列**；已配对未运行/离线才入队；两层候选；默认 `saved`；**插件 `submit.confirm` 归本 issue**；outbox 字段与 `clientInstanceId`；保留已有 storage key；SW 追加 NM 不得覆盖 `onClicked` | 退避参数、侧边栏文案打磨 |
+| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 默认仅元数据；`fill.submit` 不含字节；`snapshot.chunk`；>2 MiB 拒绝；三种「值」；失败/取消不改阶段 | 快照文件格式、字段值开关 |
+| D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind`=格式；`replyClass` 确认后才写；哈希警告不自动拆关联；导入≠改阶段 | MIME 解析、预览组件 |
+| D10 待办与提醒 | [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26) | D04 | 日期精度；idle 15 min 内可提醒；无偷偷开机启动；SW 断开 ≠ 丢出盒 | 调度实现、夏令时测试 |
+| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 建议写入 `replyClass` 而非 `kind`；确认后同一事务；回执≠通过 | 提示词、OCR、支持矩阵 |
+| D12 备份恢复回收 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；**保留 archiveId、generation+1**；握手成功后暂停旧队列；回收 vs 永久删（refCount） | 归档格式、原子发布 |
+| D13 安装升级 | [#29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29) | D02、D06、D07、D12 | NSIS-only；**双写 Edge+Chrome HKCU**，不靠 fallback；配对写当前 origin；卸载留数据 | NSIS hooks、SHA-256 |
+| D14 端到端门禁 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含配对走查、插件确认投递、恢复+旧队列；真实 NM | 验收记录模板 |
+
+### 2.1 依赖图上的张力（不改图，只提示阅读顺序）
+
+1. **D08 硬依赖是 D03+D07，但信封上限与分片在 D05。** D05 处于更早波次（P2 vs P3），时间上会先存在。建议 D08 实现者把 D01+D05 当必读；不必把 D05 加进 D08 硬依赖以免打乱图。
+2. **D12 硬依赖无 D05，但 generation 握手是协议。** D12 经 D07（依赖 D05）间接覆盖。恢复测试必须用真实握手，不能只改 DB 字段。
+3. **D10「窗口关闭但后台运行」依赖 D02 进程模型。** 图上 D10 只依赖 D04。建议 D10 阅读 ADR；若托盘被否决，D10 须写明「关窗即无提醒」。
+4. **Epic #15 与 D13 都把 MSI 交给 D01。** 本文建议 NSIS-only，与两者兼容，不是矛盾。
+5. **D13「开发 ID 不稳定时的安全注册」与「D01 不加 key」。** 兼容：桌面粘贴 ID 写入当前 origin，不是通配，也不是改插件 `key`，更不是第一条 NM。
+6. **插件「确认已投递」归 D07**（不改硬依赖）。D08 仍只做 fill/snapshot。D04 保留无插件路径的桌面确认。
+
+未发现必须改依赖边的冲突。若负责人改选 Electron 或加 `key`，必须先改本 D01 与 D05，再动 D02/D07/D13。
+
+---
+
+## 3. 本次建议定案
+
+负责人确认前视为「建议冻结」。确认后下游不得自行改成互不兼容的栈。
+
+1. 桌面权威源；插件未装桌面时填写/模板/插件 AI 仍可用。
+2. 十条产品规则（填写≠投递、回执≠通过、未导入≠未回信、UUID 身份、AI 只建议、队列幂等、不采集秘密、卸载不静默删、手动永远可用、v1 无邮箱/云/多平台）。
+3. Stage 折叠函数（§6.2）；MVP **投影 `filling`**；`stage_corrected` 是普通 set-absolute。
+4. 回复证据：`kind` 格式 vs `replyClass` 语义；`replyEvidenceState` 按 §6.3 从已关联已确认的 `replyClass` 投影（仅 auto_ack → auto_ack；任一人工作类 → human_reply；两者都有 → mixed；unknown/空不计）。
+5. **两个 EXE**：Tauri GUI（后端=唯一写入者）+ `native-host.exe`。`data-service` 是库。禁止未鉴权 HTTP。禁止第三个常驻写入进程。
+6. 同仓、插件留根目录。
+7. Idle 默认 15 分钟（无窗口 ∧ 无 NM ∧ 无备份/提醒）。关窗 ≠ 退出。
+8. 信封与 `messageType` 枚举；64 KiB 业务信封；`snapshot.chunk`；`outbox.reconcile`；握手成功返回身份。
+9. D01/0.3.0 不加 `nativeMessaging`、不加 `key`。配对 = 桌面粘贴 ID；第一条 NM 不是配对。
+10. Outbox 仅在已注册+已配对+协议 OK、**且用户已确认使用已有/新建并派发写入** 时持久化。handshake/候选查询是读，取消不入队。未安装/未配对无 durable 队列。
+11. 恢复：保留 `archiveId`，generation 必 +1。
+12. 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库。
+13. 填写留档默认元数据；快照 ≤ 2 MiB。
+14. NSIS per-user；D13 双写 Edge+Chrome HKCU。
+15. 插件 `submit.confirm` 归 D07。两层候选。URL 裸 `code`/`key` 保留作岗位号。
+16. 最低：Windows 10 22H2+ x64，Chrome/Edge 116+。
+
+---
+
+## 4. 需要项目负责人选择
+
+只列真正要拍板的项。每项：推荐、理由、不选的代价。
+
+### 4.1 Tauri 2 vs Electron
+
+- **推荐：** Tauri 2 + Rust。
+- **理由：** 唯一写入者与 NM host 本就要原生 EXE；Tauri 可共享 crate；NSIS per-user 对齐 D13；避免第二套 Node 与 `better-sqlite3` ABI。见 [ADR §3.1](adr-architecture.md#31-桌面栈tauri-2--rust-数据服务不用-electron)。
+- **不选代价：** Electron 安装包大约 100MB+ 量级、native 模块重建、误暴露 fs 的风险更高。若选 Electron，D02/D03/D13 工作量与 ADR 整页作废，P1 推迟。
+
+### 4.2 NSIS-only vs NSIS+MSI
+
+- **推荐：** 仅 NSIS `setup.exe`。
+- **理由：** 无管理员、装到 `%LOCALAPPDATA%`；求职者个人机是目标；MSI 需 WiX 且常 per-machine。
+- **不选代价：** 双安装器测试矩阵（D13/D14）明显变大；`both` 模式会要管理员。企业需求出现再加 MSI，不挡首发。
+
+### 4.3 托盘 + 后台 idle vs 关窗口即杀服务
+
+- **推荐：** 关窗口隐藏到托盘；后端=唯一写入者继续跑；无窗口∧无 NM∧无备份/提醒后 **15 min** idle 退出；托盘含「打开」「退出」。
+- **理由：** 写入者就是 GUI EXE，没有第三个 service。无托盘时用户以为已退出，任务管理器里仍有该 EXE。D06 主窗口未开仍要能保存岗位；D10 提醒依赖这段存活期。
+- **不选代价：**
+  - 关窗即杀：每次保存冷启动；关窗期间无提醒。
+  - 无托盘但保持进程：无名 GUI 进程引发不信任，必须把「退出」做进设置页。
+
+### 4.4 未打包扩展配对 vs 加 manifest `key`
+
+- **推荐：** **不加 `key`**。桌面 UI **粘贴扩展 ID** 写入 per-user host manifest（Chrome / Edge 分开）。**第一条 NM 不是配对。** Chrome 重读时机 **待验证**。
+- **理由：** NM 在 origin 进入 `allowed_origins` 之前根本不会启动 host，无法用 NM 引导配对。现网 ZIP 路径哈希 ID 不稳定；加 `key` 会孤儿化模板和 API Key。
+- **不选代价：** 加 `key` 需 ID 迁移向导，越出 D01/D07。商店上架时再处理商店 ID。
+
+### 4.5 填写留档默认仅元数据 vs 默认含字段值
+
+- **推荐：** 默认仅元数据（计数、耗时、脱敏 URL、模板名、snapshot id）；字段值需显式打开。
+- **理由：** 规则 7；字段值是 PII；默认关可降低备份敏感度。追溯「用了哪版简历」靠快照文件，不靠事件里的逐字段 JSON。
+- **不选代价：** 默认含值会让 64 KiB 更容易被打满、备份全是简历正文、误采密码框的后果更重。
+
+### 4.6 备份不加密 vs 加密
+
+- **推荐：** MVP **不加密**，警告含 PII。
+- **理由：** 加密要口令丢失策略、密钥存储、测试矩阵；宣传加密却口令写在旁边等于零。Epic 允许 D01 决定。
+- **不选代价：** 做加密则 D12 范围膨胀，D14 必须测错口令/损坏密文；不做则用户把备份丢网盘会裸奔——用警告和「不要宣传加密」管理预期。
+
+### 4.7 64 KiB 信封 vs 其他上限
+
+- **推荐：** 双向 64 KiB JSON。
+- **理由：** D05 原建议；远低于 Chrome host→浏览器 1 MB。业务信封只走元数据；快照字节走 `snapshot.chunk`（每块仍 ≤ 64 KiB）。
+- **不选代价：** 提到 1 MB 会诱使把附件 base64 进 JSON。再缩小可能让候选列表过紧。改数字只在 D05 做，不改「文件不进业务信封」。
+
+---
+
+## 5. 需要后续原型验证
+
+不得在无原型的情况下把下列写成「已实现事实」。失败则更新 D01/D05 与受影响 issue，而不是在实现 PR 里偷偷换模型。
+
+| ID | 项 | 谁验证 | 失败时的后退 |
+| --- | --- | --- | --- |
+| V1 | named pipe + 单实例 mutex：第二 UI 只激活窗口；第二 host 不第二写入者 | D02、D06 | 改用 Tauri 单实例插件或锁文件，仍保持唯一写入者 |
+| V2 | host 按需启动 **Tauri GUI EXE**（可隐藏、无控制台）、中文/空格路径、单实例互斥 | D06 | 禁止第三个 service；失败则文案「请先打开一次桌面」 |
+| V3 | Chrome/Edge 更新 HKCU host manifest 的 `allowed_origins` 后，是否无需重启即可 `connectNative` | D06、D13 | 配对成功后提示「重新加载扩展或重启浏览器」 |
+| V4 | MV3 service worker 与 `connectNative` 生命周期 | D07 | 以 `sendNativeMessage` 短连接 + outbox 为主路径 |
+| V5 | 64 KiB 在真实 NM 栈上的拒绝行为（截断 vs 错误） | D05、D06 | 调整错误码；不提高业务上限去「试试能不能传附件」 |
+| V6 | 部分 Windows 10 22H2 无 WebView2 时 NSIS bootstrapper | D13 | 文档改为手动安装 Runtime 链接 |
+| V7 | ARM64 | D13 | 首发仅 x64 |
+| V8 | idle 超时与仍有未完成备份/提醒的交互 | D02、D10、D12 | 有任务时推迟 idle；文档化 |
+
+---
+
+## 6. 本 D01 的 PR Plan
+
+**本 issue 的唯一实现 = 文档 PR**（`docs/desktop-mvp/*`）。不提交 `/desktop` 源码、不改 `manifest.json`、不注册 NM、不碰 [`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)。
+
+建议 PR 标题：`docs(d01): freeze desktop MVP product and architecture baseline`。
+
+关闭 #17 的条件：负责人在 PR 或 issue 中确认 §4 七项（或写下与推荐不同的选择）。未确认则下游只做可丢弃原型。
+
+### 6.1 后续 PR / issue（现在不实现）
+
+| 后续 | 预期产物 | 依赖 D01 的哪些冻结点 |
+| --- | --- | --- |
+| D02 | `/desktop` Tauri 壳（唯一写入者）、单实例、15 min idle、粘贴 ID 设置页骨架 | 两 EXE 拓扑、目录、托盘决议 |
+| D03 | `data-service` **库**、折叠函数、AttachmentBlob、合成夹具 | 字段目录、幂等、archiveId 不变 |
+| D04 | 申请列表/详情/时间线；桌面确认投递 | 阶段折叠、filling 过滤、两层候选 |
+| D05 | `crates/protocol` Schema + 契约测试 | 信封、messageType、分片、reconcile |
+| D06 | `native-host.exe` + 开发注册脚本 | origin 扫描、按需启动 GUI EXE |
+| D07 | 插件 NM、粘贴 ID 配对、outbox、保存岗位、**确认已投递** | 未配对无队列、两层候选、storage key |
+| D08 | `fill.submit` + `snapshot.chunk` | 2 MiB 上限、失败不改阶段 |
+| D09 | 导入/预览/关联 | kind vs replyClass |
+| D10 | 待办调度 | 15 min idle 内提醒 |
+| D11 | 建议面板 + OS 凭据 | 写入 replyClass |
+| D12 | 备份包 + 恢复向导 | 保留 archiveId、generation+1 |
+| D13 | NSIS、**双写** HKCU、卸载留数据 | 不靠 Edge→Chrome fallback |
+| D14 | 安装验收记录 | 配对 + 确认投递 + 恢复队列 |
+
+每个后续 PR 必须写明「只完成 Dx 的哪一部分」，禁止一个大 PR 关闭整个 Epic。
+
+---
+
+## 7. Open Questions（汇总）
+
+仅负责人项，细节在 §4。原型项在 §5，不占用负责人带宽。
+
+若负责人否决推荐，更新顺序：本文件 + ADR 或产品需求中对应段落 → 评论 #17 → 再改下游 issue 正文。禁止只在实现里偏离。
+
+---
+
+## 8. References
+
+- Epic: https://github.com/TshyGO/resume-form-assistant-plugin/issues/15
+- D01: https://github.com/TshyGO/resume-form-assistant-plugin/issues/17
+- D02 #16 · D03 #18 · D04 #19 · D05 #23 · D06 #24 · D07 #20 · D08 #22 · D09 #21 · D10 #26 · D11 #25 · D12 #28 · D13 #29 · D14 #27
+- 规划对照：`output/playwright/desktop-planning/map.json`（仅内部创建记录，不是用户文档）

--- a/docs/desktop-mvp/downstream-decisions.md
+++ b/docs/desktop-mvp/downstream-decisions.md
@@ -73,16 +73,16 @@ flowchart TB
 | 工作 | Issue | 硬依赖 | 从 D01 消费的结论 | 本 issue 仍需自己定的 |
 | --- | --- | --- | --- | --- |
 | D02 桌面壳、单实例、数据目录 | [#16](https://github.com/TshyGO/resume-form-assistant-plugin/issues/16) | D01 | **应用进程 = 唯一写入者**；Windows + **macOS 原型为完成条件之一**；平台目录 API；单实例；关窗 ≠ 退出；托盘/菜单栏；无开机启动；粘贴 ID 设置页骨架；不把 `*.exe` 写进协议 | 窗口细节；IPC 具体 API（pipe vs unix socket） |
-| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象跨平台；无公司+URL 唯一约束；折叠函数；`restoreEpoch` 不在备份内；幂等键含 epoch；`sendMode` 字段；`occurredAt` unknown 时为 null | `CREATE TABLE`、索引、迁移 |
+| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象跨平台；无公司+URL 唯一约束；折叠函数；当前 epoch 指针不备份，历史回执含 sourceRestoreEpoch；正式/建议 class 与 sendMode 分开；sourcePathHint 仅内存；`occurredAt` unknown 时为 null | `CREATE TABLE`、索引、迁移 |
 | D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含 `filling`；文案「尚未导入回复证据」；`classified` 不是「人工回复」；两层候选 | 布局、快捷键 |
-| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 信封；握手返回 `restoreEpoch` 而非 generation；幂等三元组；`snapshot.chunk`；`outbox.reconcile`；64 KiB；SaveIntent **不是** NM 类型 | JSON Schema、错误码（含 `restore_epoch_mismatch`）、分片帧 |
+| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 信封；握手返回 `restoreEpoch` 而非 generation；当前身份校验 + 完整旧身份/摘要的只读对账；`snapshot.chunk` 整帧预算；64 KiB；SaveIntent **不是** NM 类型 | JSON Schema、错误码（含 `restore_epoch_mismatch`）、分片帧 |
 | D06 NM host | [#24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) | D02、D03、D05 | 薄 host 或同二进制 host 模式；stdout 纯净；扫描 argv origin；按需启动 **应用进程**；Win 注册表 + Mac 用户级目录 | 可执行实现、冷启动、Mac 路径实测 |
 | D07 保存岗位、配对、队列 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | **SaveIntent vs Bound outbox**；从未配对不建意图；曾经配对桌面不可用可建意图；禁止待同步=已保存；粘贴 ID；`submit.confirm`；storage key 清单 | 退避、侧边栏文案、10 s 去重点击 |
-| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 确认时生成不可变字节；桌面不可用 → 扩展源 IndexedDB；重试用原字节；>2 MiB 拒绝；可能申请 `unlimitedStorage` | 快照 JSON 格式、字段值开关 |
+| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 确认时生成不可变字节；无论在线/离线，发送前完整字节 → 扩展源 IndexedDB，完整 ACK 前保留；重试用原字节；>2 MiB 拒绝；可能申请 `unlimitedStorage` | 快照 JSON 格式、字段值开关 |
 | D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind` 格式；`replyClass` 业务类型；`sendMode` 发送方式；导入≠改阶段 | MIME、预览 |
 | D10 待办与提醒 | [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26) | D04 | **系统调度通知**；杀进程后仍尽量弹；未授权则列表+汇总；退出取消未触发项并告知；无偷偷开机启动；Win 5 分钟窗口写进文案 | 具体 Toast/UNUserNotification 封装、夏令时 |
-| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 同时建议 `replyClass` 与 `sendMode`；不确定则 unknown；Keychain/DPAPI | 提示词、OCR |
-| D12 备份恢复 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；保留 archiveId；**新铸 restoreEpoch**；备份不含 epoch；回滚再铸 | 归档格式、原子发布 |
+| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 持久化 suggestedReplyClass/suggestedSendMode；确认前不写正式分类，不确定为 unknown；Keychain/DPAPI | 提示词、OCR |
+| D12 备份恢复 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；保留 archiveId；**新铸 restoreEpoch**；备份不含当前指针但包含历史回执；新目录验证后原子切换，回滚再铸 | 归档格式、原子发布 |
 | D13 安装升级 | [#29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29) | D02、D06、D07、D12 | Win NSIS per-user + 双写 HKCU；Mac `.app`/`.dmg` + 用户级 NativeMessagingHosts；卸载留档案；签名/公证如实写 | NSIS hooks、公证流水线、SHA-256 |
 | D14 端到端 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含意图队列、离线快照、杀进程提醒、重复恢复、ATS 自动面试信；Win 必测；Mac 覆盖随正式版决议，但 D02 原型不能缺 | 验收记录模板 |
 
@@ -112,8 +112,8 @@ flowchart TB
 6. Stage 折叠函数；`filling` 投影。
 7. `replyClass` ≠ `sendMode`；`replyEvidenceState` 用 `classified` 而非「人工回复」。
 8. SaveIntent vs Bound outbox；从未配对不建意图；禁止待同步=已保存。
-9. 快照确认时生成；离线字节在扩展源 IndexedDB；重试不从新模板生成。
-10. 握手返回 `restoreEpoch`；每次切换 current 新铸；幂等含 epoch。
+9. 快照确认时生成；所有字节先持久化到扩展源 IndexedDB；重试不从新模板生成。
+10. 握手返回当前 restoreEpoch；每次成功切换新铸；普通写入校验当前身份，恢复对账只读完整历史回执。
 11. 提醒走用户授权的系统调度；不偷偷开机启动。
 12. D01/0.3.0 不加 `nativeMessaging`、不加 `key`。
 13. 插件 Key 留扩展存储；桌面 Key 进 OS 凭据库。
@@ -203,9 +203,9 @@ flowchart TB
 
 **D03（数据层，无 UI）：**
 
-- 按字段目录建库：Application/Event/Todo/Evidence（含 `sendMode`）/Snapshot/AttachmentBlob。
-- `current.json` 持 `restoreEpoch`；备份夹具 **不含** epoch。
-- 合成测试：同岗位两条申请；恢复两次同一备份 → 两个 epoch；幂等三元组。
+- 按字段目录建库：Application/Event/Todo/Evidence（含 sendMode）/AiSuggestion（含独立建议分类）/Snapshot/AttachmentBlob/提交回执。
+- `current.json` 持当前 restoreEpoch 且不备份；备份夹具保留业务历史回执的 sourceRestoreEpoch。
+- 合成测试：同岗位两条申请；恢复两次同一备份 → 两个当前 epoch；历史回执不丢失、旧写入仍被拒绝、不同 Profile 同 messageId 不串结果。
 - 不写迁移到「已发布库」（还没有）。
 
 **D05（契约，无生产 host）：**

--- a/docs/desktop-mvp/downstream-decisions.md
+++ b/docs/desktop-mvp/downstream-decisions.md
@@ -73,18 +73,18 @@ flowchart TB
 | 工作 | Issue | 硬依赖 | 从 D01 消费的结论 | 本 issue 仍需自己定的 |
 | --- | --- | --- | --- | --- |
 | D02 桌面壳、单实例、数据目录 | [#16](https://github.com/TshyGO/resume-form-assistant-plugin/issues/16) | D01 | **应用进程 = 唯一写入者**；Windows + **macOS 原型为完成条件之一**；平台目录 API；单实例；关窗 ≠ 退出；托盘/菜单栏；无开机启动；粘贴 ID 设置页骨架；不把 `*.exe` 写进协议 | 窗口细节；IPC 具体 API（pipe vs unix socket） |
-| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象跨平台；无公司+URL 唯一约束；折叠函数；当前 epoch 指针不备份，历史回执含 sourceRestoreEpoch；正式/建议 class 与 sendMode 分开；sourcePathHint 仅内存；`occurredAt` unknown 时为 null | `CREATE TABLE`、索引、迁移 |
-| D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含 `filling`；文案「尚未导入回复证据」；`classified` 不是「人工回复」；两层候选 | 布局、快捷键 |
-| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 信封；握手返回 `restoreEpoch` 而非 generation；当前身份校验 + 完整旧身份/摘要的只读对账；`snapshot.chunk` 整帧预算；64 KiB；SaveIntent **不是** NM 类型 | JSON Schema、错误码（含 `restore_epoch_mismatch`）、分片帧 |
+| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象跨平台；无公司+URL 唯一约束；**`eventSequence` 与阶段投影同事务**；`imported_unclassified`；当前 epoch 指针不备份，历史回执含 sourceRestoreEpoch；正式/建议 class 与 sendMode 分开；sourcePathHint 仅内存；`occurredAt` unknown 时为 null | `CREATE TABLE`、索引、迁移 |
+| D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含 `filling`；`none_imported` vs `imported_unclassified` 文案；`classified` 不是「人工回复」；时间线按 `eventSequence` | 布局、快捷键 |
+| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 信封 **含/禁** 档案身份（见 ADR §4）；握手返回当前 epoch；普通写入先校验 current 再幂等；块级 `snapshot.chunk` messageId；`outbox.reconcile` 外层当前身份；64 KiB 整帧；SaveIntent **不是** NM 类型 | JSON Schema、错误码（`identity_missing` / `identity_not_allowed` / `restore_epoch_mismatch`）、分片帧 |
 | D06 NM host | [#24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) | D02、D03、D05 | 薄 host 或同二进制 host 模式；stdout 纯净；扫描 argv origin；按需启动 **应用进程**；Win 注册表 + Mac 用户级目录 | 可执行实现、冷启动、Mac 路径实测 |
-| D07 保存岗位、配对、队列 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | **SaveIntent vs Bound outbox**；从未配对不建意图；曾经配对桌面不可用可建意图；禁止待同步=已保存；粘贴 ID；`submit.confirm`；storage key 清单 | 退避、侧边栏文案、10 s 去重点击 |
-| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 确认时生成不可变字节；无论在线/离线，发送前完整字节 → 扩展源 IndexedDB，完整 ACK 前保留；重试用原字节；>2 MiB 拒绝；可能申请 `unlimitedStorage` | 快照 JSON 格式、字段值开关 |
-| D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind` 格式；`replyClass` 业务类型；`sendMode` 发送方式；导入≠改阶段 | MIME、预览 |
+| D07 保存岗位、配对、队列 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | **SaveIntent vs Bound outbox**；`sourceRestoreEpoch` 不可变；信封带 **current** 身份；旧 epoch 只对账不重放；从未配对不建意图；禁止待同步=已保存；粘贴 ID；`submit.confirm` | 退避、侧边栏文案、10 s 去重点击 |
+| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 写前 IDB；**每块持久化 `chunkMessageId`**；`chunkCursor` 只按连续 ACK 前进；分片 ACK ≠ 完整 ACK；>2 MiB 拒绝 | 快照 JSON 格式、字段值开关 |
+| D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind` 格式；`replyClass` 业务类型；`sendMode` 发送方式；导入后未分类 → `imported_unclassified`；导入≠改阶段 | MIME、预览 |
 | D10 待办与提醒 | [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26) | D04 | **系统调度通知**；杀进程后仍尽量弹；未授权则列表+汇总；退出取消未触发项并告知；无偷偷开机启动；Win 5 分钟窗口写进文案 | 具体 Toast/UNUserNotification 封装、夏令时 |
-| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 持久化 suggestedReplyClass/suggestedSendMode；确认前不写正式分类，不确定为 unknown；Keychain/DPAPI | 提示词、OCR |
-| D12 备份恢复 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；保留 archiveId；**新铸 restoreEpoch**；备份不含当前指针但包含历史回执；新目录验证后原子切换，回滚再铸 | 归档格式、原子发布 |
+| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 持久化 suggestedReplyClass/suggestedSendMode；确认前证据可为 `imported_unclassified`；不确定为 unknown；Keychain/DPAPI | 提示词、OCR |
+| D12 备份恢复 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；保留 archiveId；**新铸 restoreEpoch**；备份含 `eventSequence` 与历史回执，不含当前指针；旧 epoch 只对账 | 归档格式、原子发布 |
 | D13 安装升级 | [#29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29) | D02、D06、D07、D12 | Win NSIS per-user + 双写 HKCU；Mac `.app`/`.dmg` + 用户级 NativeMessagingHosts；卸载留档案；签名/公证如实写 | NSIS hooks、公证流水线、SHA-256 |
-| D14 端到端 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含意图队列、离线快照、杀进程提醒、重复恢复、ATS 自动面试信；Win 必测；Mac 覆盖随正式版决议，但 D02 原型不能缺 | 验收记录模板 |
+| D14 端到端 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含意图队列、离线快照、块级重试、杀进程提醒、重复恢复、未分类证据文案、同时间戳事件顺序、ATS 自动面试信；Win 必测 | 验收记录模板 |
 
 ### 2.1 依赖图上的张力（不改图）
 
@@ -109,11 +109,11 @@ flowchart TB
 3. 应用进程 = 唯一写入者；NM host = 翻译器（可多实例）；WebView 子进程不是写入者。
 4. 桌面权威源；未装桌面时填写仍可用。
 5. 十条产品规则（填写≠投递、回执≠通过、未导入≠未回信、UUID、AI 只建议、意图/绑定队列、不采集秘密、卸载不静默删、手动永远可用、无邮箱/云同步）。
-6. Stage 折叠函数；`filling` 投影。
-7. `replyClass` ≠ `sendMode`；`replyEvidenceState` 用 `classified` 而非「人工回复」。
+6. Stage 折叠按 `eventSequence`；`fill_started` 不改阶段；`filling` 仅 completed/partial。
+7. `replyClass` ≠ `sendMode`；已导入未分类 = `imported_unclassified`，禁止「尚未导入」。
 8. SaveIntent vs Bound outbox；从未配对不建意图；禁止待同步=已保存。
 9. 快照确认时生成；所有字节先持久化到扩展源 IndexedDB；重试不从新模板生成。
-10. 握手返回当前 restoreEpoch；每次成功切换新铸；普通写入校验当前身份，恢复对账只读完整历史回执。
+10. 握手后请求必须带当前 `archiveId`/`restoreEpoch`；Bound `sourceRestoreEpoch` 不可变；普通写入先校验 current；旧 epoch 只对账。
 11. 提醒走用户授权的系统调度；不偷偷开机启动。
 12. D01/0.3.0 不加 `nativeMessaging`、不加 `key`。
 13. 插件 Key 留扩展存储；桌面 Key 进 OS 凭据库。
@@ -167,22 +167,31 @@ flowchart TB
 
 ## 5. 需要后续原型验证
 
-失败则更新 D01/D05 与受影响 issue，禁止在实现 PR 里偷偷换模型。
+禁止在实现 PR 里偷偷换模型。失败后的 **统一同步顺序**（不是每项都改 D05）：
 
-| ID | 项 | 谁验证 | 失败时的后退 |
-| --- | --- | --- | --- |
-| V1 | Win named pipe / Mac unix socket + 单实例 | D02、D06 | Tauri 单实例插件或锁文件，仍唯一写入者 |
-| V2 | host 按需启动应用进程（无控制台；Mac `.app` 路径） | D06 | 文案「请先打开一次桌面」；禁止第三个 writer |
-| V3 | 更新 host manifest 后能否不重启就 `connectNative` | D06、D13 | 提示重载扩展或重启浏览器 |
-| V4 | MV3 SW 与 `connectNative` | D07 | `sendNativeMessage` + 队列 |
-| V5 | 64 KiB 真实拒绝行为 | D05、D06 | 调错误码，不靠加大信封传附件 |
-| V6 | Win10 无 WebView2 的 bootstrapper | D13 | 文档改手动安装 Runtime |
-| V7 | Windows ARM64、macOS Intel universal | D13 | 首发 Win x64 + Mac Apple Silicon |
-| V8 | 系统调度通知：杀进程后是否仍弹；Win 5 分钟窗口；Mac 重启后 | D10 | 打开应用汇总；文案写明限制 |
-| V9 | 未打包 Win32 计划 Toast / AUMID | D10 | Compat 库或改为仅应用内提醒 |
-| V10 | macOS 用户级 Edge NativeMessagingHosts 实际路径 | D06、D13 | 对照 Edge 文档实测后改 D13 |
-| V11 | macOS 公证与 Gatekeeper 对 helper 拉起 | D13 | 预览构建写明「右键打开」 |
-| V12 | 扩展源 IndexedDB 在 SW 重启后读回快照 | D08 | 失败则离线留档明确不可用，同步改 D08/D14 验收 |
+1. 修改下表「权威文档」中的条款（产品/ADR/隐私，以实际受影响者为准）；
+2. 在 [#17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) 记下决策（通过/降级/推迟）；
+3. 更新「受影响 issue」的验收/范围句子；
+4. 再调整实现计划或后续 PR。
+
+不得只改 issue 而留下旧设计。保持原有依赖 DAG。
+
+| ID | 项 | 权威文档 | 受影响 issue | 失败后的处理 |
+| --- | --- | --- | --- | --- |
+| V1 | Win named pipe / Mac unix socket + 单实例 | [ADR §3.4](adr-architecture.md#34-进程角色平台无关契约)、[§3.9](adr-architecture.md#39-跨平台适配边界d02-起就要列测试) | D02 #16、D06 #24 | 改用 Tauri 单实例插件或锁文件，**仍**唯一写入者。一般 **不动** D05 |
+| V2 | host 按需启动应用进程 | ADR §3.4、§3.9 | D06 #24、D07 #20 | 文案「请先打开一次桌面」；禁止第三个 writer。一般不动 D05 |
+| V3 | 更新 host manifest 后能否不重启就 connectNative | ADR §3.7 | D06 #24、D13 #29、D07 #20 | 配对成功后强制「重载扩展或重启浏览器」。不动 D05 信封 |
+| V4 | MV3 SW 与 `connectNative` | ADR §3.6；产品 §5.2 | D07 #20 | 回落到 `sendNativeMessage` + 队列。若短连接语义变化才改 D05 样例 |
+| V5 | 64 KiB 真实拒绝行为 | ADR §4 原则 3 | D05 #23、D06 #24、D08 #22 | 调错误码与 raw chunk 预算，**不**靠加大信封传附件 |
+| V6 | Win10 无 WebView2 bootstrapper | ADR §3.2、§8 | D13 #29、D02 #16 | 文档改手动安装 Runtime 链接。不动 D05 |
+| V7 | Windows ARM64、macOS Intel universal | ADR §8；产品 §12 | D13 #29、D14 #27 | 首发收缩为 Win x64 + Mac Apple Silicon。不动 D05 |
+| V8 | 系统调度通知：杀进程/关机窗口/Mac 重启 | 产品 [§5.4](product-requirements.md#54-提醒与进程生命周期共同语义)；ADR §3.8 | D10 #26、D14 #27 | 缩小承诺为「打开应用汇总」；**不**改 D05 |
+| V9 | 未打包 Win32 计划 Toast / AUMID | ADR §3.8 | D10 #26 | Compat 库或仅应用内提醒。不改 D05 |
+| V10 | macOS 用户级 Edge NativeMessagingHosts 路径 | ADR §2、§3.7、§3.9 | D06 #24、D13 #29 | 以实测路径改 ADR/D13。不改 D05 |
+| V11 | macOS 公证与 Gatekeeper 对 helper | ADR §3.2、§8 | D13 #29 | 预览构建写明「右键打开」。不改 D05 |
+| V12 | 扩展源 IndexedDB 在 SW 重启后读回快照 | 产品 [§8.5](product-requirements.md#85-resumesnapshot)；隐私快照节 | D08 #22、D07 #20、D14 #27 | 若 IDB 不可靠：离线留档明确不可用，改产品 §8.5 与 D08/D14 验收。仅当分片帧字段变化才改 D05 |
+
+走查 10.24 是本纪律的反例：V8 失败时去改 D05 是错误同步。
 
 ---
 
@@ -203,15 +212,16 @@ flowchart TB
 
 **D03（数据层，无 UI）：**
 
-- 按字段目录建库：Application/Event/Todo/Evidence（含 sendMode）/AiSuggestion（含独立建议分类）/Snapshot/AttachmentBlob/提交回执。
-- `current.json` 持当前 restoreEpoch 且不备份；备份夹具保留业务历史回执的 sourceRestoreEpoch。
-- 合成测试：同岗位两条申请；恢复两次同一备份 → 两个当前 epoch；历史回执不丢失、旧写入仍被拒绝、不同 Profile 同 messageId 不串结果。
+- 按字段目录建库：Application（含 `lastEventSequence`）/Event（含 `eventSequence`）/Todo/Evidence（含 sendMode）/AiSuggestion/Snapshot/AttachmentBlob/提交回执。
+- `current.json` 持当前 restoreEpoch 且不备份；备份夹具保留业务历史回执的 sourceRestoreEpoch 与原 eventSequence。
+- 合成测试：同岗位两条申请；同时间戳三事件折叠稳定；恢复两次同一备份 → 两个当前 epoch；旧写入拒绝、对账 not_found 不自动重写。
 - 不写迁移到「已发布库」（还没有）。
 
 **D05（契约，无生产 host）：**
 
-- JSON Schema：握手含 `restoreEpoch`；错误码含 `restore_epoch_mismatch`。
-- 样例：意图不是消息类型；`job.save` 成功/重放/epoch 冲突/超限。
+- JSON Schema：health/handshake **无**档案身份；其余握手后类型 **必须**有 `archiveId`/`restoreEpoch`。
+- 错误码：`identity_missing`、`identity_not_allowed`、`restore_epoch_mismatch`、`conflict`。
+- 样例：`job.save` 成功/当前身份下重放/旧 epoch 拒绝；`snapshot.chunk` 每块独立 messageId、cursor 连续、完整 ACK 分离；`outbox.reconcile` 外层当前身份。
 - 契约测试两端可复用。不注册 NM、不打安装包。
 
 ---

--- a/docs/desktop-mvp/downstream-decisions.md
+++ b/docs/desktop-mvp/downstream-decisions.md
@@ -5,11 +5,13 @@
 | 标题 | D02–D14 如何消费 D01；定案 / 待选 / 待验证 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review |
+| 状态 | Draft / Ready for review（**未冻结**） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) · [Epic #15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
 | 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [data-privacy.md](data-privacy.md) |
 
-本文 **不改变** Epic 硬依赖图。发现的张力只记录建议，不静默改计划。D01 的实现就是文档 PR；D02+ 是后续 issue/PR。
+本文 **不改变** Epic 硬依赖图。跨平台工作仍按相同职责拆分（D02 壳、D06 host、D13 安装），不另开「Mac 专项」阻塞边。若未来要拆 issue，只在 PR 里建议，不直接建 `blocked-by`。
+
+D01 的实现就是文档 PR；D02+ 是后续 issue/PR。确认前不得宣称架构已冻结。
 
 ---
 
@@ -49,18 +51,18 @@ flowchart TB
   D13 --> D14
 ```
 
-**阶段出口**（Epic 标签，关闭一组 issue 的门）：
+**阶段出口**（Epic 标签）：
 
 | 阶段 | 出口 |
 | --- | --- |
 | P0 | D01 决策确认 |
-| P1 | D02–D04：离线手动管理申请 |
-| P2 | D05–D07：插件能保存岗位并补传（含配对与 `submit.confirm`） |
-| P3 | D08+D09：快照与回复证据 |
-| P4 | D10+D11：待办与 AI 建议 |
-| P5 | D12–D14：备份/安装/端到端 |
+| P1 | D02–D04：离线手动管理申请（D02 含 macOS 原型） |
+| P2 | D05–D07：插件能保存岗位并补传（含意图队列与 `submit.confirm`） |
+| P3 | D08+D09：快照（含 IndexedDB 暂存）与回复证据 |
+| P4 | D10+D11：系统调度待办与 AI 建议 |
+| P5 | D12–D14：备份/安装/端到端（Win + Mac 覆盖范围随正式版决议） |
 
-**执行波次**（谁可以先开工，硬依赖不变）：第一波 D01；第二波 D02、D03、D05 可并行；第三波 D04（等 D02+D03）、D06（等 D02+D03+D05）；第四波 D07（等 D04+D05+D06），D09/D10 在 D04 后分别推进。D04 **不是**与 D02 并行的阶段出口。
+**执行波次**不变：第一波 D01；第二波 D02、D03、D05 可并行；第三波 D04、D06；第四波 D07，D09/D10 在 D04 后分别推进。
 
 「可用 mock 提前开发」≠「依赖未验收就关闭 issue」。
 
@@ -70,158 +72,155 @@ flowchart TB
 
 | 工作 | Issue | 硬依赖 | 从 D01 消费的结论 | 本 issue 仍需自己定的 |
 | --- | --- | --- | --- | --- |
-| D02 桌面壳、单实例、数据目录 | [#16](https://github.com/TshyGO/resume-form-assistant-plugin/issues/16) | D01 | **一个 Tauri GUI EXE**（后端=唯一写入者）+ 薄 host；mutex+named pipe；关窗隐藏≠退出；**idle 默认 15 min**（无窗口∧无 NM∧无备份/提醒）；无开机启动；日志脱敏；设置页展示真实路径；不可写则失败；「粘贴扩展 ID」设置入口骨架 | 窗口/托盘控件细节；15 min 是否做成设置项 |
-| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象含 AttachmentBlob 与折叠函数；无公司+URL 唯一约束；事件 append-only；`currentStage` 为 projected；恢复保留 `archiveId`、generation+1；幂等键；附件库外；`occurredAt` 在 unknown 时为 null | `CREATE TABLE`、索引、迁移、仓储 API |
-| D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含可过滤的 `filling`；桌面侧确认投递；文案「尚未导入回复证据」；两层候选的桌面版；走查 10.1–10.6 手动子集 | 布局、快捷键、空状态 |
-| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 冻结信封与应答 `{protocolVersion,correlationId,resultId?,ok,error?,payload}`；`messageType` 枚举含 `snapshot.chunk` 与 `outbox.reconcile`；64 KiB 业务信封；握手成功返回身份；generation 变化不失败握手 | JSON Schema、错误码表、分片帧字段、契约测试向量 |
-| D06 NM host + 唯一写入者 | [#24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) | D02、D03、D05 | 薄 host、stdio 纯净、扫描 argv 找 origin token（忽略 `--parent-window`）、按需 **启动 Tauri EXE**、pipe ACL、提交后应答、开发隔离脚本 | 可执行实现、argv 顺序 **待验证**、冷启动超时 |
-| D07 保存岗位、配对、outbox、插件确认投递 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | 桌面粘贴 ID（非 NM 配对）；未安装/未配对 **无 durable 队列**；已配对未运行/离线才入队；两层候选；默认 `saved`；**插件 `submit.confirm` 归本 issue**；outbox 字段与 `clientInstanceId`；保留已有 storage key；SW 追加 NM 不得覆盖 `onClicked` | 退避参数、侧边栏文案打磨 |
-| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 默认仅元数据；`fill.submit` 不含字节；`snapshot.chunk`；>2 MiB 拒绝；三种「值」；失败/取消不改阶段 | 快照文件格式、字段值开关 |
-| D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind`=格式；`replyClass` 确认后才写；哈希警告不自动拆关联；导入≠改阶段 | MIME 解析、预览组件 |
-| D10 待办与提醒 | [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26) | D04 | 日期精度；idle 15 min 内可提醒；无偷偷开机启动；SW 断开 ≠ 丢出盒 | 调度实现、夏令时测试 |
-| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 建议写入 `replyClass` 而非 `kind`；确认后同一事务；回执≠通过 | 提示词、OCR、支持矩阵 |
-| D12 备份恢复回收 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；**保留 archiveId、generation+1**；握手成功后暂停旧队列；回收 vs 永久删（refCount） | 归档格式、原子发布 |
-| D13 安装升级 | [#29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29) | D02、D06、D07、D12 | NSIS-only；**双写 Edge+Chrome HKCU**，不靠 fallback；配对写当前 origin；卸载留数据 | NSIS hooks、SHA-256 |
-| D14 端到端门禁 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含配对走查、插件确认投递、恢复+旧队列；真实 NM | 验收记录模板 |
+| D02 桌面壳、单实例、数据目录 | [#16](https://github.com/TshyGO/resume-form-assistant-plugin/issues/16) | D01 | **应用进程 = 唯一写入者**；Windows + **macOS 原型为完成条件之一**；平台目录 API；单实例；关窗 ≠ 退出；托盘/菜单栏；无开机启动；粘贴 ID 设置页骨架；不把 `*.exe` 写进协议 | 窗口细节；IPC 具体 API（pipe vs unix socket） |
+| D03 SQLite 数据层 | [#18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18) | D01 | 逻辑对象跨平台；无公司+URL 唯一约束；折叠函数；`restoreEpoch` 不在备份内；幂等键含 epoch；`sendMode` 字段；`occurredAt` unknown 时为 null | `CREATE TABLE`、索引、迁移 |
+| D04 无 AI 管理 UI | [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) | D02、D03 | 阶段码含 `filling`；文案「尚未导入回复证据」；`classified` 不是「人工回复」；两层候选 | 布局、快捷键 |
+| D05 协议契约 | [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) | D01 | 信封；握手返回 `restoreEpoch` 而非 generation；幂等三元组；`snapshot.chunk`；`outbox.reconcile`；64 KiB；SaveIntent **不是** NM 类型 | JSON Schema、错误码（含 `restore_epoch_mismatch`）、分片帧 |
+| D06 NM host | [#24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) | D02、D03、D05 | 薄 host 或同二进制 host 模式；stdout 纯净；扫描 argv origin；按需启动 **应用进程**；Win 注册表 + Mac 用户级目录 | 可执行实现、冷启动、Mac 路径实测 |
+| D07 保存岗位、配对、队列 | [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20) | D04、D05、D06 | **SaveIntent vs Bound outbox**；从未配对不建意图；曾经配对桌面不可用可建意图；禁止待同步=已保存；粘贴 ID；`submit.confirm`；storage key 清单 | 退避、侧边栏文案、10 s 去重点击 |
+| D08 快照与填写留档 | [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22) | D03、D07 | 确认时生成不可变字节；桌面不可用 → 扩展源 IndexedDB；重试用原字节；>2 MiB 拒绝；可能申请 `unlimitedStorage` | 快照 JSON 格式、字段值开关 |
+| D09 证据收件箱 | [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21) | D03、D04 | `kind` 格式；`replyClass` 业务类型；`sendMode` 发送方式；导入≠改阶段 | MIME、预览 |
+| D10 待办与提醒 | [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26) | D04 | **系统调度通知**；杀进程后仍尽量弹；未授权则列表+汇总；退出取消未触发项并告知；无偷偷开机启动；Win 5 分钟窗口写进文案 | 具体 Toast/UNUserNotification 封装、夏令时 |
+| D11 AI 建议 | [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25) | D09、D10 | 同时建议 `replyClass` 与 `sendMode`；不确定则 unknown；Keychain/DPAPI | 提示词、OCR |
+| D12 备份恢复 | [#28](https://github.com/TshyGO/resume-form-assistant-plugin/issues/28) | D03、D07、D09 | 不加密；新目录；保留 archiveId；**新铸 restoreEpoch**；备份不含 epoch；回滚再铸 | 归档格式、原子发布 |
+| D13 安装升级 | [#29](https://github.com/TshyGO/resume-form-assistant-plugin/issues/29) | D02、D06、D07、D12 | Win NSIS per-user + 双写 HKCU；Mac `.app`/`.dmg` + 用户级 NativeMessagingHosts；卸载留档案；签名/公证如实写 | NSIS hooks、公证流水线、SHA-256 |
+| D14 端到端 | [#27](https://github.com/TshyGO/resume-form-assistant-plugin/issues/27) | D08、D11、D13 | 含意图队列、离线快照、杀进程提醒、重复恢复、ATS 自动面试信；Win 必测；Mac 覆盖随正式版决议，但 D02 原型不能缺 | 验收记录模板 |
 
-### 2.1 依赖图上的张力（不改图，只提示阅读顺序）
+### 2.1 依赖图上的张力（不改图）
 
-1. **D08 硬依赖是 D03+D07，但信封上限与分片在 D05。** D05 处于更早波次（P2 vs P3），时间上会先存在。建议 D08 实现者把 D01+D05 当必读；不必把 D05 加进 D08 硬依赖以免打乱图。
-2. **D12 硬依赖无 D05，但 generation 握手是协议。** D12 经 D07（依赖 D05）间接覆盖。恢复测试必须用真实握手，不能只改 DB 字段。
-3. **D10「窗口关闭但后台运行」依赖 D02 进程模型。** 图上 D10 只依赖 D04。建议 D10 阅读 ADR；若托盘被否决，D10 须写明「关窗即无提醒」。
-4. **Epic #15 与 D13 都把 MSI 交给 D01。** 本文建议 NSIS-only，与两者兼容，不是矛盾。
-5. **D13「开发 ID 不稳定时的安全注册」与「D01 不加 key」。** 兼容：桌面粘贴 ID 写入当前 origin，不是通配，也不是改插件 `key`，更不是第一条 NM。
-6. **插件「确认已投递」归 D07**（不改硬依赖）。D08 仍只做 fill/snapshot。D04 保留无插件路径的桌面确认。
+1. D08 应读 D05 分片信封；不必把 D05 加进 D08 硬依赖。
+2. D12 恢复测试必须用真实握手（经 D07→D05），不能只改 DB。
+3. D10 应读 ADR §3.8；提醒不再依赖「15 分钟 idle」。
+4. D13 同时承担 Win + Mac 交付物，工作量变大，但 **不拆新阻塞 issue**（建议：D13 内两个小 PR）。
+5. 插件确认投递仍归 D07。
 
-未发现必须改依赖边的冲突。若负责人改选 Electron 或加 `key`，必须先改本 D01 与 D05，再动 D02/D07/D13。
+未改 `blocked-by`。若负责人改选 Electron，先改 D01/D05 再动 D02/D13。
+
+**建议但本次不创建：** 若 Mac 公证把 D13 拖死，可另开「D13b macOS 公证」平行 PR，仍挂在 #29 下，不新增 DAG 节点。
 
 ---
 
 ## 3. 本次建议定案
 
-负责人确认前视为「建议冻结」。确认后下游不得自行改成互不兼容的栈。
+负责人确认前视为建议。确认后下游不得自行改成互不兼容的栈。
 
-1. 桌面权威源；插件未装桌面时填写/模板/插件 AI 仍可用。
-2. 十条产品规则（填写≠投递、回执≠通过、未导入≠未回信、UUID 身份、AI 只建议、队列幂等、不采集秘密、卸载不静默删、手动永远可用、v1 无邮箱/云/多平台）。
-3. Stage 折叠函数（§6.2）；MVP **投影 `filling`**；`stage_corrected` 是普通 set-absolute。
-4. 回复证据：`kind` 格式 vs `replyClass` 语义；`replyEvidenceState` 按 §6.3 从已关联已确认的 `replyClass` 投影（仅 auto_ack → auto_ack；任一人工作类 → human_reply；两者都有 → mixed；unknown/空不计）。
-5. **两个 EXE**：Tauri GUI（后端=唯一写入者）+ `native-host.exe`。`data-service` 是库。禁止未鉴权 HTTP。禁止第三个常驻写入进程。
-6. 同仓、插件留根目录。
-7. Idle 默认 15 分钟（无窗口 ∧ 无 NM ∧ 无备份/提醒）。关窗 ≠ 退出。
-8. 信封与 `messageType` 枚举；64 KiB 业务信封；`snapshot.chunk`；`outbox.reconcile`；握手成功返回身份。
-9. D01/0.3.0 不加 `nativeMessaging`、不加 `key`。配对 = 桌面粘贴 ID；第一条 NM 不是配对。
-10. Outbox 仅在已注册+已配对+协议 OK、**且用户已确认使用已有/新建并派发写入** 时持久化。handshake/候选查询是读，取消不入队。未安装/未配对无 durable 队列。
-11. 恢复：保留 `archiveId`，generation 必 +1。
-12. 插件 Key 留在扩展存储；桌面 Key 进 OS 凭据库。
-13. 填写留档默认元数据；快照 ≤ 2 MiB。
-14. NSIS per-user；D13 双写 Edge+Chrome HKCU。
-15. 插件 `submit.confirm` 归 D07。两层候选。URL 裸 `code`/`key` 保留作岗位号。
-16. 最低：Windows 10 22H2+ x64，Chrome/Edge 116+。
+1. Windows **与** macOS 都是目标平台；实现 Windows 优先；**D02 完成条件包含 macOS 原型**。Linux / Safari 非首版。
+2. 业务模型、SQLite、事件、建议、NM 消息平台无关。适配边界见 ADR §3.9。
+3. 应用进程 = 唯一写入者；NM host = 翻译器（可多实例）；WebView 子进程不是写入者。
+4. 桌面权威源；未装桌面时填写仍可用。
+5. 十条产品规则（填写≠投递、回执≠通过、未导入≠未回信、UUID、AI 只建议、意图/绑定队列、不采集秘密、卸载不静默删、手动永远可用、无邮箱/云同步）。
+6. Stage 折叠函数；`filling` 投影。
+7. `replyClass` ≠ `sendMode`；`replyEvidenceState` 用 `classified` 而非「人工回复」。
+8. SaveIntent vs Bound outbox；从未配对不建意图；禁止待同步=已保存。
+9. 快照确认时生成；离线字节在扩展源 IndexedDB；重试不从新模板生成。
+10. 握手返回 `restoreEpoch`；每次切换 current 新铸；幂等含 epoch。
+11. 提醒走用户授权的系统调度；不偷偷开机启动。
+12. D01/0.3.0 不加 `nativeMessaging`、不加 `key`。
+13. 插件 Key 留扩展存储；桌面 Key 进 OS 凭据库。
+14. 填写留档默认元数据；业务信封 64 KiB；快照文件 ≤ 2 MiB。
+15. 备份不加密；Windows NSIS per-user；macOS dmg。
+16. 当前插件 MIT ≠ 未来桌面模块许可已定。
 
 ---
 
 ## 4. 需要项目负责人选择
 
-只列真正要拍板的项。每项：推荐、理由、不选的代价。
+只列真正要拍板的项。
 
-### 4.1 Tauri 2 vs Electron
+### 4.1 首个对外「正式桌面 MVP」是否必须双平台同时交付
 
-- **推荐：** Tauri 2 + Rust。
-- **理由：** 唯一写入者与 NM host 本就要原生 EXE；Tauri 可共享 crate；NSIS per-user 对齐 D13；避免第二套 Node 与 `better-sqlite3` ABI。见 [ADR §3.1](adr-architecture.md#31-桌面栈tauri-2--rust-数据服务不用-electron)。
-- **不选代价：** Electron 安装包大约 100MB+ 量级、native 模块重建、误暴露 fs 的风险更高。若选 Electron，D02/D03/D13 工作量与 ADR 整页作废，P1 推迟。
-
-### 4.2 NSIS-only vs NSIS+MSI
-
-- **推荐：** 仅 NSIS `setup.exe`。
-- **理由：** 无管理员、装到 `%LOCALAPPDATA%`；求职者个人机是目标；MSI 需 WiX 且常 per-machine。
-- **不选代价：** 双安装器测试矩阵（D13/D14）明显变大；`both` 模式会要管理员。企业需求出现再加 MSI，不挡首发。
-
-### 4.3 托盘 + 后台 idle vs 关窗口即杀服务
-
-- **推荐：** 关窗口隐藏到托盘；后端=唯一写入者继续跑；无窗口∧无 NM∧无备份/提醒后 **15 min** idle 退出；托盘含「打开」「退出」。
-- **理由：** 写入者就是 GUI EXE，没有第三个 service。无托盘时用户以为已退出，任务管理器里仍有该 EXE。D06 主窗口未开仍要能保存岗位；D10 提醒依赖这段存活期。
+- **推荐：** **正式标签要求 Windows 与 macOS 都能安装、配对、保存岗位、备份恢复**（D14 两端各有一份记录）。允许 Windows 在 P1–P2 先做内部试用。 **不允许**「Windows 全部做完再移植 Mac」——D02 缺 Mac 原型即未完成。
+- **理由：** 产品已明确有 Mac 用户。公证/签名会拖时间，所以实现顺序仍 Windows 优先，但正式承诺不能把 Mac 留成口头。
 - **不选代价：**
-  - 关窗即杀：每次保存冷启动；关窗期间无提醒。
-  - 无托盘但保持进程：无名 GUI 进程引发不信任，必须把「退出」做进设置页。
+  - 若选「Windows 正式 + Mac 仅预览」：Mac 用户拿到的是无公证/无 D14 的构建，支持成本高，但 Windows 求职季能先用上。
+  - 若选「必须同一天双平台 GA」：公证失败会挡住 Windows 用户。
 
-### 4.4 未打包扩展配对 vs 加 manifest `key`
+### 4.2 Tauri 2 vs Electron
 
-- **推荐：** **不加 `key`**。桌面 UI **粘贴扩展 ID** 写入 per-user host manifest（Chrome / Edge 分开）。**第一条 NM 不是配对。** Chrome 重读时机 **待验证**。
-- **理由：** NM 在 origin 进入 `allowed_origins` 之前根本不会启动 host，无法用 NM 引导配对。现网 ZIP 路径哈希 ID 不稳定；加 `key` 会孤儿化模板和 API Key。
-- **不选代价：** 加 `key` 需 ID 迁移向导，越出 D01/D07。商店上架时再处理商店 ID。
+- **推荐：** Tauri 2。
+- **理由：** 较小运行时（系统 WebView）、Rust 后端与 host/SQLite 共享、Win+Mac 原生目录/凭据/通知适配面集中。Electron **可以** per-user 安装、**可以**做 NM stdio、**不是**天然必须管理员。见 [ADR §3.1](adr-architecture.md#31-桌面栈推荐-tauri-2electron-是可行备选不是禁区)。
+- **不选代价：** 改 Electron 则 D02 脚手架与体积预期作废，产品/协议仍能用。两端都带 Chromium，更新面更大。
 
-### 4.5 填写留档默认仅元数据 vs 默认含字段值
+### 4.3 后台提醒：系统调度 vs 常驻进程
 
-- **推荐：** 默认仅元数据（计数、耗时、脱敏 URL、模板名、snapshot id）；字段值需显式打开。
-- **理由：** 规则 7；字段值是 PII；默认关可降低备份敏感度。追溯「用了哪版简历」靠快照文件，不靠事件里的逐字段 JSON。
-- **不选代价：** 默认含值会让 64 KiB 更容易被打满、备份全是简历正文、误采密码框的后果更重。
+- **推荐：** 用户启用并授权后，把到期待办登记为 **系统调度通知**；应用进程仍可空闲退出。主动退出默认取消未触发项并告知。
+- **理由：** 闲置 15 分钟退出无法支撑次日面试。常驻进程耗电、关机后仍没了，还容易滑向偷偷开机启动。
+- **不选代价：**
+  - 常驻不退出：关窗期间能提醒，但关机/重启仍要另做调度，等于两套。
+  - 只做应用内待办、不弹系统通知：实现简单，用户会错过次日面试。
 
-### 4.6 备份不加密 vs 加密
+### 4.4 备份不加密 vs 加密
 
 - **推荐：** MVP **不加密**，警告含 PII。
-- **理由：** 加密要口令丢失策略、密钥存储、测试矩阵；宣传加密却口令写在旁边等于零。Epic 允许 D01 决定。
-- **不选代价：** 做加密则 D12 范围膨胀，D14 必须测错口令/损坏密文；不做则用户把备份丢网盘会裸奔——用警告和「不要宣传加密」管理预期。
+- **理由：** 加密要口令丢失策略；宣传加密却口令写旁边等于零。
+- **不选代价：** D12/D14 膨胀；或不加密时用户把备份丢网盘会裸奔——用警告管理预期。
 
-### 4.7 64 KiB 信封 vs 其他上限
+### 4.5 Windows 是否另发 MSI
 
-- **推荐：** 双向 64 KiB JSON。
-- **理由：** D05 原建议；远低于 Chrome host→浏览器 1 MB。业务信封只走元数据；快照字节走 `snapshot.chunk`（每块仍 ≤ 64 KiB）。
-- **不选代价：** 提到 1 MB 会诱使把附件 base64 进 JSON。再缩小可能让候选列表过紧。改数字只在 D05 做，不改「文件不进业务信封」。
+- **推荐：** 仅 NSIS per-user。macOS 仍是 dmg，不受本项影响。
+- **理由：** 求职者个人机；MSI/WiX 测试矩阵大。
+- **不选代价：** D13/D14 双安装器。企业需求可后续加。
+
+配对方式、64 KiB、填写留档默认仅元数据：作为建议定案，不占用拍板名额。
 
 ---
 
 ## 5. 需要后续原型验证
 
-不得在无原型的情况下把下列写成「已实现事实」。失败则更新 D01/D05 与受影响 issue，而不是在实现 PR 里偷偷换模型。
+失败则更新 D01/D05 与受影响 issue，禁止在实现 PR 里偷偷换模型。
 
 | ID | 项 | 谁验证 | 失败时的后退 |
 | --- | --- | --- | --- |
-| V1 | named pipe + 单实例 mutex：第二 UI 只激活窗口；第二 host 不第二写入者 | D02、D06 | 改用 Tauri 单实例插件或锁文件，仍保持唯一写入者 |
-| V2 | host 按需启动 **Tauri GUI EXE**（可隐藏、无控制台）、中文/空格路径、单实例互斥 | D06 | 禁止第三个 service；失败则文案「请先打开一次桌面」 |
-| V3 | Chrome/Edge 更新 HKCU host manifest 的 `allowed_origins` 后，是否无需重启即可 `connectNative` | D06、D13 | 配对成功后提示「重新加载扩展或重启浏览器」 |
-| V4 | MV3 service worker 与 `connectNative` 生命周期 | D07 | 以 `sendNativeMessage` 短连接 + outbox 为主路径 |
-| V5 | 64 KiB 在真实 NM 栈上的拒绝行为（截断 vs 错误） | D05、D06 | 调整错误码；不提高业务上限去「试试能不能传附件」 |
-| V6 | 部分 Windows 10 22H2 无 WebView2 时 NSIS bootstrapper | D13 | 文档改为手动安装 Runtime 链接 |
-| V7 | ARM64 | D13 | 首发仅 x64 |
-| V8 | idle 超时与仍有未完成备份/提醒的交互 | D02、D10、D12 | 有任务时推迟 idle；文档化 |
+| V1 | Win named pipe / Mac unix socket + 单实例 | D02、D06 | Tauri 单实例插件或锁文件，仍唯一写入者 |
+| V2 | host 按需启动应用进程（无控制台；Mac `.app` 路径） | D06 | 文案「请先打开一次桌面」；禁止第三个 writer |
+| V3 | 更新 host manifest 后能否不重启就 `connectNative` | D06、D13 | 提示重载扩展或重启浏览器 |
+| V4 | MV3 SW 与 `connectNative` | D07 | `sendNativeMessage` + 队列 |
+| V5 | 64 KiB 真实拒绝行为 | D05、D06 | 调错误码，不靠加大信封传附件 |
+| V6 | Win10 无 WebView2 的 bootstrapper | D13 | 文档改手动安装 Runtime |
+| V7 | Windows ARM64、macOS Intel universal | D13 | 首发 Win x64 + Mac Apple Silicon |
+| V8 | 系统调度通知：杀进程后是否仍弹；Win 5 分钟窗口；Mac 重启后 | D10 | 打开应用汇总；文案写明限制 |
+| V9 | 未打包 Win32 计划 Toast / AUMID | D10 | Compat 库或改为仅应用内提醒 |
+| V10 | macOS 用户级 Edge NativeMessagingHosts 实际路径 | D06、D13 | 对照 Edge 文档实测后改 D13 |
+| V11 | macOS 公证与 Gatekeeper 对 helper 拉起 | D13 | 预览构建写明「右键打开」 |
+| V12 | 扩展源 IndexedDB 在 SW 重启后读回快照 | D08 | 失败则离线留档明确不可用，同步改 D08/D14 验收 |
 
 ---
 
 ## 6. 本 D01 的 PR Plan
 
-**本 issue 的唯一实现 = 文档 PR**（`docs/desktop-mvp/*`）。不提交 `/desktop` 源码、不改 `manifest.json`、不注册 NM、不碰 [`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)。
+**本 issue 的唯一实现 = 文档 PR**（`docs/desktop-mvp/*`）+ 同步后的相关 issue 正文。不提交 `/desktop`、不改 `manifest.json`、不注册 NM、不碰 [`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)、不改 [`LICENSE`](../../LICENSE)。
 
-建议 PR 标题：`docs(d01): freeze desktop MVP product and architecture baseline`。
+关闭 #17 的条件：负责人在 PR 或 issue 中确认 §4（或写下不同选择）。未确认则下游只做可丢弃原型，**不得宣称冻结**。
 
-关闭 #17 的条件：负责人在 PR 或 issue 中确认 §4 七项（或写下与推荐不同的选择）。未确认则下游只做可丢弃原型。
+### 6.1 确认后 D02 / D03 / D05 如何开工
 
-### 6.1 后续 PR / issue（现在不实现）
+**D02（壳，可与 D03/D05 并行）：**
 
-| 后续 | 预期产物 | 依赖 D01 的哪些冻结点 |
-| --- | --- | --- |
-| D02 | `/desktop` Tauri 壳（唯一写入者）、单实例、15 min idle、粘贴 ID 设置页骨架 | 两 EXE 拓扑、目录、托盘决议 |
-| D03 | `data-service` **库**、折叠函数、AttachmentBlob、合成夹具 | 字段目录、幂等、archiveId 不变 |
-| D04 | 申请列表/详情/时间线；桌面确认投递 | 阶段折叠、filling 过滤、两层候选 |
-| D05 | `crates/protocol` Schema + 契约测试 | 信封、messageType、分片、reconcile |
-| D06 | `native-host.exe` + 开发注册脚本 | origin 扫描、按需启动 GUI EXE |
-| D07 | 插件 NM、粘贴 ID 配对、outbox、保存岗位、**确认已投递** | 未配对无队列、两层候选、storage key |
-| D08 | `fill.submit` + `snapshot.chunk` | 2 MiB 上限、失败不改阶段 |
-| D09 | 导入/预览/关联 | kind vs replyClass |
-| D10 | 待办调度 | 15 min idle 内提醒 |
-| D11 | 建议面板 + OS 凭据 | 写入 replyClass |
-| D12 | 备份包 + 恢复向导 | 保留 archiveId、generation+1 |
-| D13 | NSIS、**双写** HKCU、卸载留数据 | 不靠 Edge→Chrome fallback |
-| D14 | 安装验收记录 | 配对 + 确认投递 + 恢复队列 |
+- 用 Tauri 2 建 `/desktop`（仍是后续 PR，不在 D01）。
+- Windows：能启动、单实例、LocalAppData 目录、关窗≠退出、粘贴 ID 页骨架。
+- **同一 PR 序列里必须出现 macOS 构建：** Application Support 目录、单实例、无窗口启动至少在开发机跑通。缺 Mac 原型不能关 D02。
+- 不实现申请 UI、不注册生产 NM。
 
-每个后续 PR 必须写明「只完成 Dx 的哪一部分」，禁止一个大 PR 关闭整个 Epic。
+**D03（数据层，无 UI）：**
+
+- 按字段目录建库：Application/Event/Todo/Evidence（含 `sendMode`）/Snapshot/AttachmentBlob。
+- `current.json` 持 `restoreEpoch`；备份夹具 **不含** epoch。
+- 合成测试：同岗位两条申请；恢复两次同一备份 → 两个 epoch；幂等三元组。
+- 不写迁移到「已发布库」（还没有）。
+
+**D05（契约，无生产 host）：**
+
+- JSON Schema：握手含 `restoreEpoch`；错误码含 `restore_epoch_mismatch`。
+- 样例：意图不是消息类型；`job.save` 成功/重放/epoch 冲突/超限。
+- 契约测试两端可复用。不注册 NM、不打安装包。
 
 ---
 
 ## 7. Open Questions（汇总）
 
-仅负责人项，细节在 §4。原型项在 §5，不占用负责人带宽。
+仅 §4。原型项在 §5。
 
-若负责人否决推荐，更新顺序：本文件 + ADR 或产品需求中对应段落 → 评论 #17 → 再改下游 issue 正文。禁止只在实现里偏离。
+若负责人否决推荐：先改本文件 + 对应专文 → 评论 #17 → 再改下游 issue。禁止只在实现里偏离。
 
 ---
 
@@ -230,4 +229,4 @@ flowchart TB
 - Epic: https://github.com/TshyGO/resume-form-assistant-plugin/issues/15
 - D01: https://github.com/TshyGO/resume-form-assistant-plugin/issues/17
 - D02 #16 · D03 #18 · D04 #19 · D05 #23 · D06 #24 · D07 #20 · D08 #22 · D09 #21 · D10 #26 · D11 #25 · D12 #28 · D13 #29 · D14 #27
-- 规划对照：`output/playwright/desktop-planning/map.json`（仅内部创建记录，不是用户文档）
+- 规划对照：`output/playwright/desktop-planning/map.json`（内部创建记录，不是用户文档）

--- a/docs/desktop-mvp/downstream-decisions.md
+++ b/docs/desktop-mvp/downstream-decisions.md
@@ -5,7 +5,7 @@
 | 标题 | D02–D14 如何消费 D01；定案 / 待选 / 待验证 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review（**未冻结**） |
+| 状态 | 可修订开工基线（PR 合并后生效） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) · [Epic #15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
 | 并列 | [product-requirements.md](product-requirements.md) · [adr-architecture.md](adr-architecture.md) · [data-privacy.md](data-privacy.md) |
 
@@ -199,7 +199,9 @@ flowchart TB
 
 **本 issue 的唯一实现 = 文档 PR**（`docs/desktop-mvp/*`）+ 同步后的相关 issue 正文。不提交 `/desktop`、不改 `manifest.json`、不注册 NM、不碰 [`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)、不改 [`LICENSE`](../../LICENSE)。
 
-关闭 #17 的条件：负责人在 PR 或 issue 中确认 §4（或写下不同选择）。未确认则下游只做可丢弃原型，**不得宣称冻结**。
+本轮负责人已授权收尾后合并；合并即完成 D01 开工基线交付，可关闭 #17 并推进 D02/D03/D05。现有推荐作为工作假设，不代表永久不可修改的规格；发布覆盖/签名/备份加密在对应交付 issue 确认。不得为预先穷尽实现细节而持续扩大 D01。
+
+实现约束收口：D03/D07/D12 保留防止永久删除后复活的幂等墓碑；D12 保证数据库与附件在同一备份屏障内取样并校验引用；D03/D04/D11 将历史补录与更新当前进度分离。验收样例分别是“ACK 丢失→永久删除→重试不重建”“备份中删除附件不产生残包”“Offer 后补录测评不回退”。这些归实现 issue 的测试，不继续在 D01 扩写算法。
 
 ### 6.1 确认后 D02 / D03 / D05 如何开工
 

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -1,0 +1,675 @@
+# 桌面求职管理 MVP — 产品需求
+
+| 字段 | 值 |
+| --- | --- |
+| 标题 | MVP 产品需求与对象模型 |
+| 作者 | D01 design PR |
+| 日期 | 2026-09-06 |
+| 状态 | Draft / Ready for review |
+| 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) · [Epic #15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
+| 并列 | [adr-architecture.md](adr-architecture.md) · [data-privacy.md](data-privacy.md) · [downstream-decisions.md](downstream-decisions.md) |
+
+本文定义 **做什么、不做什么、对象怎么命名**。物理表结构归 [D03 #18](https://github.com/TshyGO/resume-form-assistant-plugin/issues/18)；通信信封归 [D05 #23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23)。D01 不写 `CREATE TABLE` 或完整 JSON Schema。
+
+---
+
+## 1. Overview
+
+求职者已经在用 Resume Pro 插件填写网申，但填完之后不知道「哪份投了、用了哪版简历、后来邮件是哪一岗」。本 MVP 把产品扩成 **浏览器填写入口 + Windows 本地求职档案**：插件继续独立填表；桌面主程序保存申请、事件、附件、当次简历快照和待办。桌面档案是申请数据的权威源；插件通过受限 Native Messaging 写入，离线时入队。
+
+当前仓库 **没有** 申请对象、填写事件日志或桌面连接（见 [README 现状表](README.md#现状以仓库代码为准不以-readme-宣传为准)）。填写仍是用户点击触发；[`form-agent.js`](../../form-agent.js) 只在确认后点击安全「新增/添加」按钮，从不提交表单。本需求保持该安全边界，并加上「填写完成 ≠ 已投递」。
+
+---
+
+## 2. Background & Motivation
+
+### 2.1 当前状态
+
+- 插件 v0.3.0：多模板、AI 匹配填写、PDF/Word 解析、辅助新增条目。数据在 `chrome.storage.local`。
+- AI 配置（含明文 `apiKey`）只存在扩展存储，经 offscreen worker 发往用户自己的 OpenAI 兼容接口。
+- 没有「投递了没有」「面试约在哪天」「这封 HR 邮件属于哪一岗」的本地档案。
+- 秋招场景下一公司多岗、同岗重复投、自动回执与面试通知混在一起，靠记忆或表格容易串记录。
+
+### 2.2 痛点
+
+1. 填完表不等于网站已保存或已提交，插件今天也无法知道网站是否接受。
+2. 邮箱里的自动回执容易被当成「通过筛选」。
+3. 没把邮件导入工具 ≠ 对方没回；UI 若写成「未回复」会误导。
+4. 按公司名或 URL 去重会把两个岗位或两次投递合成一条，后续通知无法消歧。
+
+### 2.3 目标用户
+
+在 Windows 上使用 Chrome 或 Edge、已用 Resume Pro 填写网申的 **中文个人求职者**。不假设企业 IT、不假设多设备、不假设会写代码。能接受「先装桌面程序再从网页保存岗位」；不装桌面时原插件能力必须仍可用。
+
+---
+
+## 3. Goals & Non-Goals
+
+### 3.1 Goals（首版必须）
+
+- 不装插件、不接 AI，也能在桌面手动走完：建档 → 确认投递 → 测评 → 多轮面试 → Offer/拒绝。
+- 从网页 **主动** 保存岗位到本地；填写后可选择留档当次快照与填写事件；投递必须另一次明确确认。
+- 导入 `.eml` / `.txt` / PNG / JPEG / PDF 与粘贴文本；预览；可选 AI 建议；确认后事务性更新阶段/事件/待办。
+- 同公司多岗位、同岗位多次申请可区分；疑似重复只提示，不自动合并。
+- 完整备份与恢复；升级/卸载默认不删档案。
+- 插件原填写路径在桌面缺失、离线、AI 失败时仍可用。
+
+### 3.2 Non-Goals（首版明确不做）
+
+与 Epic #15 一致，D01 **不得重开**：
+
+- 邮箱 OAuth / IMAP 轮询 / 自动拉取
+- 自动提交网申、代发邮件、任意网页 Agent
+- 云账号、云同步、多设备同步、团队协作
+- Mac / Linux 成品
+- 扩展商店上架与静默自动更新（检查更新仍可沿用插件现有 GitHub Release 提示）
+- `.msg` / Outlook 虚拟拖拽对象（不支持时提示导出 `.eml` 或粘贴正文）
+- 把当前开发者机器路径写进产品
+- 在 D01 修改插件权限、存储、功能或把 `manifest.json` 版本从 `0.3.0` 改掉
+
+---
+
+## 4. 十条冻结产品规则
+
+来自 Epic #15，D01 只落实为可执行规则，不重新辩论。
+
+1. **填写完成 ≠ 已投递。** `fill_completed` / `fill_partial` 不得把阶段推到 `submitted`。
+2. **自动回执 ≠ 通过筛选 / ≠ 人工回复。** `auto_ack` 证据不把阶段推到 `interview`，也不暗示「已通过」。
+3. **没有导入邮件 ≠ 没有收到回信。** UI 文案必须是「尚未导入回复证据」，禁止「对方未回复」。
+4. **同公司多岗、重复申请必须可区分。** 禁止按公司或 URL 自动合并；身份是申请 UUID。
+5. **AI 只建议。** 确认后才事务性写事件/阶段/待办；模型输出不得替换原始证据字节。
+6. **桌面档案是 source of truth。** 插件离线队列 + 幂等 + `archiveId`/`generation` 检查。
+7. **只记录用户主动使用插件的操作。** 禁止密码、OTP、API Key、Cookie；禁止全局键鼠采集。
+8. **升级 / 卸载 / 恢复不得静默删除申请和附件。**
+9. **AI 或网络失败时，手动管理必须仍可用。**
+10. **无邮箱连接、无自动投递、无通用 web agent、无云账号、无多设备同步、v1 无 Mac/Linux 成品。**
+
+---
+
+## 5. 核心用户流程
+
+### 5.1 纯手动（无插件、无 AI）
+
+1. 桌面「新建申请」：公司、岗位、链接、地点、备注。默认阶段 `saved`。
+2. 用户明确「确认已投递」→ 事件 `submit_confirmed`，阶段投影为 `submitted`。
+3. 手动记录测评、面试（含轮次）、Offer、拒绝、撤回、结束。
+4. 导入文件到证据收件箱，手动关联申请。
+5. 手动待办：测评截止、面试时间、待回复。
+
+此流程是 [D04 #19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) 的验收闭环，不断网、不调外部 API。
+
+### 5.2 插件辅助
+
+1. 用户在招聘页点「保存岗位到本地」（**D07**）。侧边栏展示提取的公司/岗位/地点/URL，缺项手补，不捏造。
+2. 桌面按 **两层候选**（§7）返回最小元数据；用户选「使用已有」或「新建」。默认阶段 `saved`。
+3. 用户照常使用现有「一键 AI 填写」/「AI 辅助新增条目」。填写本身不依赖桌面。
+4. 可选：将本次填写事件 + 简历快照归档到已绑定申请（D08；快照字节走分片，见 ADR §4）。
+5. 用户另点「确认已投递」（**插件按钮归 D07**，`submit.confirm`，与填写成功无关），或之后在桌面（D04）/证据确认（D11）推进阶段。
+
+**Outbox 顺序（冻结）：** 先探测 host 注册 / 本 origin 是否已配对 / 协议是否兼容。未安装、未配对：不建长期队列。协议不兼容：不入队，提示升级。`handshake` 与 `application.queryCandidates` 是 **读**，不写 outbox。**只在用户确认「使用已有」或「新建」之后、派发写入**（`job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm`）时才持久化 outbox 行，并盖上握手得到的 `(archiveId, generation)`。用户点「取消」：什么都不入队。已配对但 EXE 未运行或离线或拉起失败：此时才 durable 入队 +「待同步」。
+
+```mermaid
+sequenceDiagram
+  participant U as 用户
+  participant CS as content.js
+  participant SW as background.js
+  participant H as native-host.exe
+  participant APP as Tauri EXE
+  U->>CS: 保存岗位到本地（确认字段）
+  CS->>CS: 剥离 URL 秘密参数
+  CS->>SW: runtime.sendMessage
+  SW->>SW: 探测：host 注册？本 origin 已配对？
+  alt 未安装或未配对
+    SW-->>U: 安装说明 / 粘贴扩展 ID（不写 outbox）
+  else 已安装已配对
+    SW->>H: Native Messaging handshake（读，不是配对，不入队）
+    alt 协议不兼容
+      SW-->>U: 提示升级（不入队）
+    else 握手成功
+      SW->>SW: 比对已有 outbox 上的 archiveId/generation
+      alt 身份不匹配
+        SW-->>U: 暂停旧队列：关联 / 丢弃 / 另存
+      else 身份匹配或队列空
+        alt EXE 未运行
+          H->>APP: 按需启动 Tauri EXE（可隐藏）
+        end
+        SW->>H: application.queryCandidates（读，不入队）
+        APP-->>SW: exact[] + sameCompany[]
+        U->>CS: 使用已有 / 新建 / 取消
+        alt 取消
+          Note over SW: 不写 outbox
+        else 使用已有或新建
+          SW->>SW: 此时才写入 outbox（固定 messageId，盖上当前 archiveId/generation）
+          SW->>H: job.save
+          APP-->>SW: 提交后的 resultId
+          SW->>SW: 删除对应 outbox 项
+          SW-->>U: 桌面已保存（stage=saved，非已投递）
+        end
+      end
+    end
+  end
+```
+
+「桌面已保存」只在持久化应答之后显示。已入队但未提交时显示「待同步」，不得假成功。取消选择器不会留下 `job.save` 队列项。
+
+### 5.3 证据 + AI 建议
+
+1. 导入 eml/txt/png/jpeg/pdf 或粘贴文本 → 本地副本 + 预览。
+2. 可先不关联申请。
+3. 可选调用桌面 AI：展示外发范围 → 结构化建议 → 用户确认/修改后确认/拒绝/暂存。
+4. 确认时同一事务写事件、阶段投影、待办，并引用原始证据。
+
+```mermaid
+flowchart TD
+  A[网页或手动] --> B{是否已有申请 UUID}
+  B -->|新建| C[Application stage=saved]
+  B -->|绑定已有| D[已有 Application]
+  C --> E[可选填写留档]
+  D --> E
+  E --> F{用户确认已投递?}
+  F -->|否| G[停留 saved / filling]
+  F -->|是| H[Event submit_confirmed / stage=submitted]
+  H --> I[导入证据]
+  I --> J{用户确认 AI 或手动改阶段?}
+  J -->|否| K[证据已存 阶段不变]
+  J -->|是| L[同一事务: Event + stage 投影 + Todo]
+```
+
+---
+
+## 6. 阶段模型
+
+### 6.1 稳定 stage code
+
+Code 稳定，供存储、协议、过滤使用；展示名可本地化。MVP 中文如下。
+
+| code | 展示名 | 含义 |
+| --- | --- | --- |
+| `saved` | 已收藏 | 已建档，尚未确认投递。插件保存岗位的默认值 |
+| `filling` | 填写中 | MVP **会**投影。已有成功/部分填写事件且尚未 `submit_confirmed`。D04 必须能按此过滤 |
+| `submitted` | 已投递 | 仅由 `submit_confirmed` 在 `saved`/`filling` 上进入；从更后阶段回来必须走 `stage_corrected` |
+| `assessment` | 测评 | 笔试/在线测评等 |
+| `interview` | 面试 | 任意轮次的面试；轮次不是独立 stage |
+| `offer` | Offer | 录用意向/Offer |
+| `rejected` | 拒绝 | 被拒（当前阶段可以是 `rejected`） |
+| `withdrawn` | 撤回 | 用户主动撤回（当前阶段可以是 `withdrawn`） |
+| `closed` | 结束 | **当前阶段**之一（入职、放弃收尾）。拒绝/撤回事件仍留在时间线，不与 `closed` 同时作为 current |
+
+面试轮次是面试事件/待办上的 **整数 + 可选标签**（`round=1`，「一面」），不是新的 stage code。
+
+### 6.2 阶段折叠函数（冻结，D03 必须实现）
+
+`currentStage` 是按 `recordedAt` 升序（并列用 `id`）折叠事件得到的投影，并在写入那条事件的 **同一事务** 内更新。禁止普通编辑无声改阶段。纠错追加 `stage_corrected`（`from`/`to`/`actor`/`reason`），**不改写**历史事件。
+
+`stage_corrected` 只是又一条 **set-absolute** 事件：它成为当前值是因为它排在后面，**不是**因为纠错永远压过未来事件。10.6 在纠错之后补 `interview_recorded` 仍然生效。
+
+每个 `eventType` 的折叠效应只有四种：`set-absolute` / `never-regress` / `advance` / `no-op`。
+
+| `eventType` | 效应 |
+| --- | --- |
+| `application_created` | `set-absolute saved` |
+| `application_updated` | `no-op` |
+| `job_saved` | `never-regress`：current ∈ {∅, `saved`} → `saved`；已是更后阶段 → `no-op` |
+| `fill_started` / `fill_completed` / `fill_partial` | `advance`：仅 `saved` → `filling`；其他 current `no-op`。**绝不**→`submitted` |
+| `fill_failed` / `fill_cancelled` | `no-op`（失败/取消不标「填写中」） |
+| `submit_confirmed` | 仅当 current ∈ {`saved`,`filling`} 时 `set-absolute submitted`；否则 `no-op`（从 `interview` 等退回须用户 `stage_corrected`） |
+| `assessment_recorded` | `set-absolute assessment` |
+| `interview_recorded` | `set-absolute interview` |
+| `interview_rescheduled` | 仅当 current ∈ {`saved`,`filling`,`submitted`,`assessment`} 时设 `interview`；若 current ∈ {`interview`,`offer`,`rejected`,`withdrawn`,`closed`} 则 `no-op`（从拒绝等恢复须 `stage_corrected` 或 `interview_recorded`） |
+| `offer_recorded` / `rejected` / `withdrawn` / `closed` | `set-absolute` 对应 code |
+| `stage_corrected` | `set-absolute` payload.`to` |
+| `evidence_*` / `note_*` / `todo_*` | `no-op` |
+
+建议的正向路径（UI 可跳步，但必须写对应事件）：
+
+```text
+saved → filling → submitted → assessment → interview → offer
+                                              ↘ rejected | withdrawn | closed
+任意阶段 --stage_corrected--> 任意阶段（需原因）
+```
+
+### 6.3 第二维度：回复证据状态
+
+与流程阶段独立。`replyEvidenceState` 只折叠 **已关联到该申请、且已确认** 的证据上的 `replyClass`（不是 `kind`，也不是未确认的 AI 建议）。证据本身不蕴含阶段。
+
+对一条申请，令 `C` 为上述 `replyClass` 的集合，并 **忽略** `unknown` 与空：
+
+| `C` 的内容 | `replyEvidenceState` |
+| --- | --- |
+| 没有非空、非 `unknown` 的 `replyClass` | `none_imported` |
+| 只有 `auto_ack` | `auto_ack` |
+| 含 `{human_reply, assessment_invite, interview_invite, action_required, offer, reject, other}` 之一，且 **没有** `auto_ack` | `human_reply` |
+| 同时有 `auto_ack` 与上一行任一人工作类 | `mixed` |
+
+| code | 展示 | 规则 |
+| --- | --- | --- |
+| `none_imported` | 尚未导入回复证据 | 默认。禁止写成「对方未回复」 |
+| `auto_ack` | 已导入自动回执 | 不移动到 `interview`，不暗示通过筛选 |
+| `human_reply` | 已导入人工回复 | 含面试/测评/Offer/拒信等人工类；仍需用户确认才改 **阶段** |
+| `mixed` | 回执与人工回复均有 | 列表可用摘要，详情看时间线 |
+
+---
+
+## 7. 重复、关联与冲突
+
+身份：**Application UUID**。D03 **不得** 对 `(company, url)` 或 `(company, title)` 建禁止重复的唯一约束。
+
+规范化（逻辑规则，算法细节 D07/D03 实现）：
+
+- 公司名：去首尾空白、全半角、常见后缀（有限词表，如「有限公司」）折叠后再比；原始字符串始终保留。
+- 岗位名：去首尾空白、压缩空白。
+- URL：去掉 fragment；剥离已知密钥查询参数（见 [data-privacy.md](data-privacy.md#71-url-脱敏)）；host 小写。
+
+保存时两层查询（同一最小元数据形状：id、公司、岗位、阶段、URL、更新时间；不把整库同步给插件）：
+
+1. **精确层（走查 10.4）：** 规范化三元组 `(company, title, url)` 命中 → 「可能是同一岗位的重复投递」。默认仍由用户选使用已有 / 新建。
+2. **同公司提示层（走查 10.1）：** 规范化公司相同，但 title 或 URL 不同 → 「同公司其他岗位」列表。**默认新建**，永不自动绑定。同公司命中是 **提示不是身份**。
+
+其余规则：
+
+3. UI 另可取消。同公司两个岗位 = 两条申请。
+4. 对同一 posting 再投一次 = 用户说新建就是两条。
+5. 内容哈希用于 **重复通知警告**，不因同哈希自动撤销用户选择的不同关联。
+6. 误关联：改关联保留原始附件字节，追加 `association_changed`（from/to application id）。
+7. 阶段折叠：见 §6.2。
+
+---
+
+## 8. 逻辑对象与字段目录
+
+下表是逻辑字段，不是 SQL。每列：含义、是否必填、来源、可变性、敏感级。
+
+**来源：** `user` / `plugin` / `import` / `system` / `ai_suggest`（建议确认前不写入正式字段）。
+
+**可变性：** `immutable` / `mutable` / `append-only` / `projected`（由事件折叠得出，禁止直接 UPDATE）。
+
+**敏感级：** `public-meta` / `PII` / `secret-forbidden`。`secret-forbidden` 的值若出现在输入中必须丢弃或剥离，不得入库、不得进日志、不得进备份。
+
+### 8.1 ArchiveMeta
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `archiveId` | 本档案实例 UUID。恢复 **保留 backup 的值**，不新铸 | 是 | system | immutable | public-meta |
+| `generation` | 单调递增；每次恢复 **必 +1** | 是 | system | mutable（仅系统提升） | public-meta |
+| `schemaVersion` | 逻辑/物理 schema 版本 | 是 | system | mutable（迁移） | public-meta |
+| `createdAt` | 档案创建 UTC | 是 | system | immutable | public-meta |
+| `displayName` | 用户可见档案名 | 否 | user | mutable | public-meta |
+
+同一时刻桌面只把 **一个** 档案标为 current。插件握手拿到的就是 current 的 `archiveId`+`generation`。
+
+### 8.2 Application
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `id` | 申请 UUID | 是 | system | immutable | public-meta |
+| `company` | 公司名（原始） | 是 | user/plugin | mutable | PII |
+| `companyNormalized` | 去重查询用 | 是 | system | mutable（随 company） | PII |
+| `title` | 岗位名（原始）。与公司连用可识别雇主关系，按 PII 处理 | 是 | user/plugin | mutable | PII |
+| `titleNormalized` | 去重查询用 | 是 | system | mutable | PII |
+| `sourceUrl` | 展示/存储用 URL（剥秘密参数，保留 ATS `code`/`key` 岗位号，见隐私 §7.1） | 否 | user/plugin | mutable | PII |
+| `dedupeUrl` | 身份规范化 URL（更窄剥离集） | 否 | system | mutable | PII |
+| `location` | 地点 | 否 | user/plugin | mutable | PII |
+| `notes` | 备注 | 否 | user | mutable | PII |
+| `currentStage` | 阶段投影（§6.2 折叠） | 是 | system | projected | public-meta |
+| `replyEvidenceState` | 由 `replyClass` 投影，不是文件类型 | 是 | system | projected | public-meta |
+| `createdAt` / `updatedAt` | UTC | 是 | system | created immutable | public-meta |
+| `archivedAt` | 列表归档（非回收） | 否 | user | mutable | public-meta |
+| `recycleState` | `active` / `recycled` / `purged` | 是 | user/system | mutable | public-meta |
+| `origin` | `manual` / `plugin` | 是 | system | immutable | public-meta |
+
+元数据编辑建议追加 `application_updated` 事件（from/to），D03 定物理形状。回收不是永久删除，见 [data-privacy.md](data-privacy.md#5-删除回收与永久清除)。
+
+### 8.3 Event
+
+事件 **append-only**。错误用新事件表达，不用 UPDATE 覆盖载荷。
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `id` | 事件 UUID | 是 | system | immutable | public-meta |
+| `applicationId` | 所属申请；未绑定证据事件可空 | 视类型 | system | immutable | public-meta |
+| `eventType` | 见下表 | 是 | system | immutable | public-meta |
+| `occurredAt` | 业务发生时间。`occurredPrecision=unknown` 时 **必须为 null**，禁止填午夜伪造 | 当 precision≠`unknown` | user/import/plugin | immutable | public-meta |
+| `recordedAt` | 写入时间 UTC | 是 | system | immutable | public-meta |
+| `occurredPrecision` | `datetime` / `date` / `unknown` | 是 | system | immutable | public-meta |
+| `timeZone` | 有意义时区；未知则空 | 否 | user/import | immutable | public-meta |
+| `source` | `manual` / `plugin` / `import` / `ai_confirmed` | 是 | system | immutable | public-meta |
+| `sourceRequestId` | 插件 `messageId` 或导入批次 | 否 | plugin/import | immutable | public-meta |
+| `payloadVersion` | 载荷 schema | 是 | system | immutable | public-meta |
+| `payload` | 结构化；禁止 secret | 是 | 视类型 | immutable | PII 或 public-meta |
+| `actor` | `user` / `plugin` / `system` | 是 | system | immutable | public-meta |
+
+**时间语义（D10 必须遵守）：** 存储 UTC 时间戳；只有日期的通知不得伪造「当天 00:00」为精确时刻。`occurredPrecision=date` 时 UI 只显示日期。
+
+MVP 事件类型（可在 D03 增补，但下列语义冻结）：
+
+| `eventType` | 典型 payload | 折叠效应（正式定义见 §6.2） |
+| --- | --- | --- |
+| `application_created` | 初始字段快照 | set-absolute `saved` |
+| `application_updated` | from/to 字段 | no-op |
+| `job_saved` | 插件提交的岗位元数据 | never-regress |
+| `fill_started` / `fill_completed` / `fill_partial` | 字段计数、耗时、URL、template、snapshotId、outcome | advance `saved`→`filling` |
+| `fill_failed` / `fill_cancelled` | 同上 outcome | no-op |
+| `submit_confirmed` | 确认方式（插件 D07 或桌面 D04） | 仅 saved/filling → `submitted` |
+| `stage_corrected` | from/to/reason | set-absolute `to` |
+| `assessment_recorded` | 名称、截止 | set-absolute `assessment` |
+| `interview_recorded` | round、时间 | set-absolute `interview` |
+| `interview_rescheduled` | round、from/to 时间 | 仅 saved/filling/submitted/assessment → `interview`；其余 no-op |
+| `offer_recorded` / `rejected` / `withdrawn` / `closed` | 原因可选 | set-absolute 对应 code |
+| `evidence_imported` | evidenceId | no-op |
+| `evidence_associated` / `association_changed` | evidenceId, from/to app | no-op |
+| `note_added` | 文本 | no-op |
+| `todo_created` / `todo_completed` | todoId | no-op |
+
+### 8.4 ReplyEvidence 与 AttachmentBlob
+
+附件字节在库外。`kind` 是 **获取/格式**，`replyClass` 是 **语义**（确认后才写）。`replyEvidenceState` 按 §6.3 从已关联、已确认的 `replyClass` 投影（`unknown`/空不计数）。一封面试邮件可以同时是 `kind=eml` 与 `replyClass=interview_invite`，此时该申请的 `replyEvidenceState=human_reply`。
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `evidenceId` | UUID | 是 | system | immutable | public-meta |
+| `applicationId` | 可空（收件箱未关联） | 否 | user | mutable（改关联） | public-meta |
+| `kind` | 获取格式：`eml` / `screenshot` / `pdf` / `paste` / `unknown` | 是 | import/system | immutable | public-meta |
+| `replyClass` | 语义：`auto_ack` / `human_reply` / `assessment_invite` / `interview_invite` / `action_required` / `offer` / `reject` / `other` / `unknown`；确认前可空 | 否 | user / ai_suggest+confirm | mutable 至确认 | public-meta |
+| `blobSha256` | 指向 AttachmentBlob | 是 | system | immutable | public-meta |
+| `originalFilename` | 导入时文件名 | 否 | import | immutable | PII |
+| `importedAt` | UTC | 是 | system | immutable | public-meta |
+| `sourcePathHint` | 仅导入瞬间；**不作为长期依赖** | 否 | import | immutable | PII |
+| `subject` / `fromAddr` / `sentAt` | 邮件头（若可解析） | 否 | import | immutable | PII |
+| `bodyExtract` | 本地提取的纯文本/清洗 HTML 转文本 | 否 | import | immutable | PII |
+
+**AttachmentBlob**（ER 中的字节实体）：
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `sha256` | 内容哈希，主键 | 是 | system | immutable | public-meta |
+| `sizeBytes` | 字节数 | 是 | system | immutable | public-meta |
+| `storedRelPath` | 档案目录内相对路径 | 是 | system | immutable | public-meta |
+| `refCount` | 引用该 blob 的 evidence 数 | 是 | system | mutable | public-meta |
+| `mime` | MIME | 否 | import | immutable | public-meta |
+
+同一字节被多条申请引用时不复制文件。`refCount=0` 才允许永久删除。HTML 邮件：清洗展示，不执行脚本、不加载远程图片/跟踪像素、不自动打开链接（D09）。
+
+### 8.5 ResumeSnapshot
+
+插件实时模板继续只活在 `chrome.storage.local`。桌面快照是填写归档时的 **拷贝**，之后不可变。改插件模板不得改写历史快照。
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `snapshotId` | UUID | 是 | system | immutable | public-meta |
+| `applicationId` | 所属申请 | 是 | plugin/user | immutable | public-meta |
+| `templateName` | 当时模板名 | 是 | plugin | immutable | public-meta |
+| `templateVersion` | 插件侧版本/修订标记；无则用内容哈希短码 | 否 | plugin | immutable | public-meta |
+| `sha256` | 快照内容摘要 | 是 | system | immutable | public-meta |
+| `storedRelPath` | 快照文件 | 是 | system | immutable | public-meta |
+| `createdAt` | UTC | 是 | system | immutable | public-meta |
+| `byteSize` | 用于超限判断 | 是 | system | immutable | public-meta |
+
+快照内容是 PII。默认填写留档 **不把逐字段值塞进 `fill.submit` 信封**；快照文件由用户在归档时确认后经 `snapshot.chunk` 传输（每块 ≤ 64 KiB），或改在桌面导入。单份快照 **> 2 MiB 拒绝**，明确失败。Outbox 只存 `snapshotId`/`sha256`/分片游标，不把整份 blob 放进 `chrome.storage.local`。
+
+### 8.6 Todo
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `id` | UUID | 是 | system | immutable | public-meta |
+| `applicationId` | 所属申请 | 是 | user/ai_confirmed | immutable | public-meta |
+| `title` | 待办标题 | 是 | user/ai_suggest+confirm | mutable | PII |
+| `duePrecision` | `datetime` / `date` / `none` | 是 | user | mutable | public-meta |
+| `dueAtUtc` | 仅 precision=datetime | 否 | user | mutable | public-meta |
+| `dueDate` | 仅 precision=date（日历日） | 否 | user | mutable | public-meta |
+| `timeZone` | 显示与提醒用 | 否 | user | mutable | public-meta |
+| `remindAtUtc` | 本地提醒时刻 | 否 | user | mutable | public-meta |
+| `status` | `open` / `done` / `cancelled` | 是 | user | mutable | public-meta |
+| `interviewRound` | 可选轮次 | 否 | user | mutable | public-meta |
+| `sourceEventId` | 创建来源 | 否 | system | immutable | public-meta |
+
+提醒能力依赖进程模型：窗口关闭但 Tauri EXE 后端仍在（托盘/idle 窗口期内）时可提醒；彻底退出或关机后 **v1 不保证** 提醒，且 **不得** 偷偷注册开机启动（D10 / ADR）。Idle 默认 15 分钟，见 ADR §3.4。
+
+### 8.7 AiSuggestion
+
+与已确认事件分离。确认前正式阶段/待办不变。
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `id` | UUID | 是 | system | immutable | public-meta |
+| `evidenceId` | 所分析证据 | 是 | system | immutable | public-meta |
+| `status` | `pending` / `confirmed` / `modified_confirmed` / `rejected` / `deferred` | 是 | user | mutable | public-meta |
+| `candidateApplicationIds` | 消歧列表，可多条 | 是 | ai_suggest | immutable | public-meta |
+| `suggestedStage` | 可空 | 否 | ai_suggest | immutable | public-meta |
+| `suggestedRound` | 可空 | 否 | ai_suggest | immutable | public-meta |
+| `suggestedTodos` | 结构化待办草案 | 否 | ai_suggest | immutable | PII |
+| `excerptRefs` | 证据片段引用 | 否 | ai_suggest | immutable | PII |
+| `uncertainties` | 模型自报不确定点 | 否 | ai_suggest | immutable | public-meta |
+| `modelLabel` | 用户配置的模型名 | 否 | system | immutable | public-meta |
+| `promptScope` | 外发范围摘要（非原文密钥） | 否 | system | immutable | public-meta |
+
+禁止字段：API Key、完整档案库、未选中申请的简历快照。D11 建议的分类写入 `ReplyEvidence.replyClass`（与 `kind` 分离），确认前不改正式阶段。
+
+### 8.8 填写留档默认范围
+
+默认写入 `fill_*` 事件的 payload：
+
+- outcome：`started` / `completed` / `partial` / `failed` / `cancelled`
+- `fieldCount`、`filledCount`、`unconfirmedCount`
+- 耗时（扫描/匹配/填写/总计，毫秒）
+- 脱敏后的 URL
+- `templateName` / `templateVersion` / `snapshotId`（若用户同意保存快照）
+- 插件版本、`messageId`
+
+**逐字段值默认 OFF**，需用户在当次或设置里明确打开。打开后仍禁止密码/OTP/支付框。
+
+必须区分三种「值」（D08 验收）：
+
+| 概念 | 插件能否知道 | 默认是否落盘 |
+| --- | --- | --- |
+| AI 返回值 | 能（匹配结果） | 默认否 |
+| 已写入控件 | 能（`setElementValue` 成功；辅助模式还有短时读回） | 默认否；计数默认是 |
+| 网站已接受/服务端已保存 | **不能**。读回 ≠ 服务端持久化（见 [`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)） | 永不自动标记；仅 `submit_confirmed` 表示用户声称已投递 |
+
+现有诊断 [`content.js` `formatFillDiagnostics`](../../content.js) 已不允许复制接口地址、Key、简历内容；桌面事件应保持同一 allowlist 精神。
+
+### 8.9 对象关系
+
+```mermaid
+erDiagram
+  ArchiveMeta ||--o{ Application : contains
+  Application ||--o{ Event : timeline
+  Application ||--o{ Todo : has
+  Application ||--o{ ResumeSnapshot : snapshots
+  Application ||--o{ ReplyEvidence : associated
+  ReplyEvidence }o--|| AttachmentBlob : blobSha256
+  ReplyEvidence ||--o{ AiSuggestion : suggestions
+  Event }o--o| ResumeSnapshot : may_cite
+  Event }o--o| ReplyEvidence : may_cite
+  Todo }o--o| Event : sourced_from
+```
+
+### 8.10 Plugin Outbox（逻辑对象，存在 `chrome.storage.local.desktopOutbox`）
+
+仅在 **host 已注册 ∧ 本 origin 已配对 ∧ 协议兼容 ∧ 用户已确认派发写入**（`job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm`）之后持久化。handshake 与候选查询不入队。每条记录盖上当时握手到的档案身份。
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `messageId` | 幂等键之一 | 是 | plugin | immutable | public-meta |
+| `clientInstanceId` | 每扩展安装/Profile 一次的 UUID（`desktopClientInstanceId`） | 是 | plugin | immutable | public-meta |
+| `messageType` | 与 ADR 枚举相同 | 是 | plugin | immutable | public-meta |
+| `archiveId` | 入队时握手到的档案 | 是 | handshake | immutable | public-meta |
+| `generation` | 入队时握手到的代 | 是 | handshake | immutable | public-meta |
+| `payload` | 业务载荷，**无** Key/密码 | 是 | plugin | immutable | PII |
+| `createdAt` | 入队 UTC | 是 | plugin | immutable | public-meta |
+| `bytes` | payload 序列化字节数 | 是 | plugin | immutable | public-meta |
+| `chunkCursor` | `snapshot.chunk` 已确认的最后序号；非分片则为空 | 否 | plugin | mutable | public-meta |
+
+恢复后：握手 **成功** 并返回新 `(archiveId, generation)`；插件比较每条 outbox 上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。关联通过 `outbox.reconcile` 查询哪些 `messageId` 已在恢复库中。服务端幂等是安全网，不是「静默重放许可」。
+
+---
+
+## 9. 降级模式
+
+| 模式 | 插件填写/模板/AI | 保存岗位 / 确认投递 | 桌面档案 | AI 建议 |
+| --- | --- | --- | --- | --- |
+| 未安装桌面 | 与今天相同 | 说明如何安装；**不建 durable outbox**；不得说已保存 | 无 | 无 |
+| 已安装但未配对 | 正常 | 说明在桌面粘贴扩展 ID；**不建 durable outbox**；**不得**说「未安装」 | 本地手动可用 | 桌面侧可用 |
+| 已安装已配对但未运行 | 正常 | host 按需启动 Tauri EXE；失败则 **durable 入队** +「待同步」 | 拉起后可用 | 拉起后可用 |
+| 离线（无互联网） | 本地匹配仍可用；上游 AI 失败 | 已配对则可入队 | 导入/待办/改阶段全部可用 | 禁用并给出原因 |
+| AI 不可用 | 现有：保留已验证本地匹配 | 与 AI 无关 | 手动阶段/证据可用 | 建议失败开放 |
+| 协议不兼容 | 填写不受影响 | **不入队**；提示升级 | 本地手动可用 | 本地手动可用 |
+| `generation` 不匹配 | 填写不受影响 | 握手成功；**暂停旧队列**；关联/丢弃/另存 | 以桌面 current 为准 | 正常 |
+
+队列容量满：停止新增留档并提示，不静默丢旧项，**不阻止**原有填表（D07）。
+
+---
+
+## 10. 合成走查（强制）
+
+下列使用合成数据，不读取真实简历或邮箱。每个走查列出对象、阶段、事件、证据、待办和用户选择。
+
+### 10.1 同公司两岗 + 无岗位名的面试邮件
+
+**设定：** 用户投了「星河科技 / 后端开发」和「星河科技 / 测试开发」。HR 来信主题「面试邀请」，正文无岗位名。
+
+| 步骤 | 用户选择 | 对象变化 |
+| --- | --- | --- |
+| 1 | 插件保存岗 A | `app-A` UUID1，company=星河科技，title=后端开发，stage=`saved`，Event `job_saved`+`application_created` |
+| 2 | 确认投递 A | Event `submit_confirmed`，stage=`submitted` |
+| 3 | 保存岗 B（同公司不同 title/URL） | **精确三元组不命中**；同公司提示层列出 `app-A`（「同公司其他岗位」）。默认 **新建**。用户选新建 → `app-B` UUID2，stage=`saved`。不自动绑定 |
+| 4 | 确认投递 B | `app-B` → `submitted` |
+| 5 | 导入面试邮件 | Evidence `ev-1`，`applicationId=null`，`kind=eml`，`replyClass` 空，收件箱可见 |
+| 6 | 可选 AI | 建议 `candidateApplicationIds=[UUID1,UUID2]`，`replyClass=interview_invite`，`uncertainties` 含「无岗位名」；**不自动选** |
+| 7 | 用户把 `ev-1` 关联到 `app-A` 并确认「面试 一面」 | Event `evidence_associated`、`interview_recorded`（round=1）；`replyClass=interview_invite`；`app-A` stage=`interview`（set-absolute）；**`app-A.replyEvidenceState=human_reply`**（§6.3：`interview_invite` ∈ 人工类且无 `auto_ack`）；Todo「一面」；`app-B` 的 `replyEvidenceState` 仍 `none_imported` |
+
+禁止：只因公司名相同把邮件归到最近一条申请。
+
+### 10.2 导入自动回执
+
+**设定：** `app-A` 已是 `submitted`。导入「我们已收到您的申请」。
+
+- Evidence `ev-ack`，`kind=eml`；用户或确认后的 AI 写入 `replyClass=auto_ack`。
+- Event `evidence_imported`（+ 可选 `evidence_associated`）。
+- `replyEvidenceState=auto_ack`。
+- **stage 仍为 `submitted`。** 不创建面试待办。
+- UI：详情显示「已导入自动回执」，不显示「通过筛选」。
+
+若用户强行把阶段改到 `interview`，必须走 `stage_corrected` 并填写原因，时间线同时保留回执事件。
+
+### 10.3 面试改期
+
+**设定：** `app-A` 已有 `interview_recorded` round=1，occurredAt=2026-09-20 14:00+08，Todo 未完成。
+
+- 导入「改至 9 月 22 日 10:00」→ `ev-2`。
+- AI 建议 `interview_rescheduled`，from/to 明确；用户确认。
+- 同一事务：Event `interview_rescheduled`；Todo 的 `dueAtUtc` 更新；旧提醒计划撤销；stage 保持 `interview`。
+- 时间线顺序：原面试事件 → 改期事件。两者都保留。`occurredPrecision=datetime`，时区 +08。
+
+不得把原事件的 `occurredAt` 覆盖掉。
+
+### 10.4 对同一 posting 重复申请
+
+**设定：** `app-A` 已投递 URL `https://jobs.example.com/req/42`。用户再次从同一页保存。
+
+- **精确层** 规范化三元组命中 `app-A`（同一 posting）。同公司提示层可同时列出，但不替代精确警告。
+- 提示：「可能重复。使用已有申请，或作为再一次投递新建？」
+- 用户选 **新建** → `app-C` 新 UUID，相同 company/title/URL，stage=`saved`。
+- 两条申请列表并存；后续通知必须消歧（走查 10.1 同类）。
+
+用户选「使用已有」则只追加 `job_saved`（或忽略重复保存），不新建 UUID。
+
+### 10.5 重复通知
+
+**设定：** 同一封面试邮件被导入两次（或转发副本，哈希相同）。
+
+- 第一次：`ev-1`，sha256=H，关联 `app-A`。
+- 第二次：计算 H 已存在，UI 警告「内容与已有证据相同」。
+- 用户仍可：忽略导入 / 仍导入并关联到 `app-B`（用户有意的不同链接）。
+- **不**因同哈希自动撤销 `app-A` 的关联，也 **不**自动跳过用户选择。
+- 物理上可复用同一 `AttachmentBlob`，两条 evidence 元数据可并存（D09/D03）。
+
+### 10.6 误标拒绝后恢复面试
+
+**设定：** 用户（或确认过的 AI）把 `app-A` 标为 `rejected`。后来发现是面试通知。
+
+- 已有 Event `rejected`，stage 投影 `rejected`。
+- 用户「纠正阶段」→ `interview`，原因「误把面试信标为拒信」。
+- Event `stage_corrected` {from:`rejected`, to:`interview`, actor:`user`, reason}。
+- 折叠后 current=`interview`（`stage_corrected` 是后一条 set-absolute）。时间线：**拒绝事件与纠错事件都在**。
+- 可再补 `interview_recorded`（仍 set-absolute `interview`）与 Todo。若曾有拒绝相关 Todo，用户手动取消；系统不猜。
+- 若纠错 **之后** 又来一条更晚的 `assessment_recorded`，折叠会把 current 设为 `assessment`——纠错 **不**永远压过未来事件。
+- 若再次纠回 `rejected`，再追加一条 `stage_corrected`，不删除前两条。
+
+### 10.7 桌面未安装 / 未运行 / 离线 / AI 宕机
+
+| 场景 | 期望 |
+| --- | --- |
+| 未安装 | 填写、模板、插件 AI 与今天一致。保存入口说明安装；**不写 durable outbox**；不假装已保存 |
+| 已安装未配对 | 同上填写。入口说明到桌面粘贴扩展 ID（Chrome/Edge 各一次）。**不写 durable outbox**。**不得**显示「未安装」 |
+| 已安装已配对未运行 | host 按需启动 Tauri EXE（可隐藏）。成功则保存；失败则 durable 入队 +「待同步」，**禁止**显示「桌面已保存」 |
+| 离线 | 桌面列表/详情/导入/待办/改阶段可用。插件 AI 走现有错误路径。**仅已配对**的保存请求入队 |
+| AI 宕机 | 桌面建议失败开放。证据与手动改阶段不受影响。插件「取消 AI 等待（保留本地匹配）」保持 |
+
+### 10.8 恢复档案后的旧插件队列
+
+**设定：** 插件 outbox 有 `messageId=M1` 的 `job.save`，记录上盖着 `archiveId=A1, generation=3`。用户用该档案的备份恢复。
+
+- 恢复预览 → 确认 → **解压到新档案目录**，current 指针切换，**`archiveId` 仍为 backup 中的 A1**，`generation` **必** 从 3 增到 4；旧目录保留为回滚点。
+- 插件下次 **握手成功**，返回 `(A1, 4)`。握手不因 generation 变化失败。
+- 插件比较 M1 上盖的 `(A1, 3)` ≠ 当前 `(A1, 4)` → **暂停**旧队列（不清掉存储）。
+- UI 三选：
+  - **关联：** 采用新握手身份；调用 `outbox.reconcile([M1,…])`；已在恢复库中的 messageId 不再重放；未包含的项需用户逐条确认后作为新写入（默认不自动重放）。
+  - **丢弃：** 删除旧队列项，不写入。
+  - **另存：** 把队列项当作对新 generation 的新申请（新 `messageId` 或用户确认的强制新写），仍走两层候选。
+- **禁止** 把 generation=3 的项在用户确认前自动打进 generation=4。服务端幂等只防止确认后的重复提交。
+
+---
+
+## 11. UI 文案约束（产品级）
+
+| 禁止 | 必须 |
+| --- | --- |
+| 「对方未回复」 | 「尚未导入回复证据」 |
+| 「已通过筛选」（仅因回执） | 「已导入自动回执」 |
+| 填写成功后自动显示「已投递」 | 「填写完成（未确认投递）」 |
+| 「本地应用 = AI 全部离线」 | 使用云端模型时展示外发范围与服务商 |
+| 未持久化应答显示「桌面已保存」 | 「待同步」/ 错误码 |
+| 把未配对说成「未安装」 | 「请在桌面主程序粘贴扩展 ID」 |
+
+空列表、存储失败、目录不可写必须可操作，禁止静默切到临时目录（D02）。
+
+---
+
+## 12. 最低环境与发行（产品口径）
+
+| 项 | MVP 口径 |
+| --- | --- |
+| OS | Windows 10 22H2 或更新，64 位。Windows 11 含 WebView2；Win10 大多数已有 Runtime，安装器仍应能引导安装（见 ADR） |
+| 浏览器 | Chrome / Edge **116+**（与当前 `minimum_chrome_version` 一致） |
+| 权限 | 日常使用不要求管理员；per-user 安装 |
+| 签名 | 未持有代码签名证书前 **不宣传已签名**；文档必须写明 SmartScreen 对未签名 `setup.exe` 的警告 |
+| 离线 | 档案、导入、待办、手动阶段：可用。云端 AI：不可用并说明原因 |
+| 插件分发 | 继续独立 ZIP；不装桌面也能填表 |
+
+负载预期：单用户、一季秋招约数十至数百条申请，不是服务器 QPS。列表查询目标：数百条申请过滤/搜索在本地 **100 ms 量级**（D03/D04 验证，非 D01 实现）。
+
+---
+
+## 13. 风险（产品）
+
+| 严重度 | 风险 | 缓解 |
+| --- | --- | --- |
+| 高 | 用户把填写成功当成已投递 | 默认 `saved`；独立确认；文案冻结 |
+| 高 | 按公司自动合并导致通知串岗 | UUID 身份；候选提示；AI 强制消歧 |
+| 中 | 未打包扩展 ID 漂移 / 把未配对当成未安装 | 桌面粘贴 ID；未配对单独降级且不入队 |
+| 中 | 快照大于业务信封 | `snapshot.chunk`；> 2 MiB 拒绝；outbox 不存整 blob |
+| 低 | 托盘图标被用户视为广告 | 负责人可关托盘；见开放问题 |
+
+---
+
+## 14. Open Questions
+
+产品侧需负责人确认的项并入 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)（填写留档默认范围、托盘、备份加密等）。本文不单开重复列表。
+
+---
+
+## 15. References
+
+- Epic [#15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15)、D01 [#17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17)、D04 [#19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19)、D07 [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20)、D08 [#22](https://github.com/TshyGO/resume-form-assistant-plugin/issues/22)、D09 [#21](https://github.com/TshyGO/resume-form-assistant-plugin/issues/21)、D10 [#26](https://github.com/TshyGO/resume-form-assistant-plugin/issues/26)、D11 [#25](https://github.com/TshyGO/resume-form-assistant-plugin/issues/25)
+- 当前插件：[`manifest.json`](../../manifest.json)、[`content.js`](../../content.js)、[`form-agent.js`](../../form-agent.js)、[`docs/ai-repeat-validation.md`](../ai-repeat-validation.md)
+- 架构与隐私：[adr-architecture.md](adr-architecture.md)、[data-privacy.md](data-privacy.md)

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -80,7 +80,7 @@
 
 1. **填写完成 ≠ 已投递。** `fill_completed` / `fill_partial` 不得把阶段推到 `submitted`。
 2. **自动回执 ≠ 通过筛选 / ≠ 人工回复。** `auto_ack` 证据不把阶段推到 `interview`，也不暗示「已通过」。
-3. **没有导入邮件 ≠ 没有收到回信。** UI 文案必须是「尚未导入回复证据」，禁止「对方未回复」。
+3. **没有导入邮件 ≠ 没有收到回信。** `none_imported` 才显示「尚未导入回复证据」；已导入未分类必须「已导入，待分类」。禁止「对方未回复」。
 4. **同公司多岗、重复申请必须可区分。** 禁止按公司或 URL 自动合并；身份是申请 UUID。
 5. **AI 只建议。** 确认后才事务性写事件/阶段/待办；模型输出不得替换原始证据字节。
 6. **桌面档案是 source of truth。** 插件离线队列分 **意图 / 已绑定消息**；幂等与 `archiveId`/`restoreEpoch` 检查。
@@ -130,7 +130,8 @@
 | `clientInstanceId` | 每个扩展安装 / Profile 一次 | 清存储后新 ID |
 | `messageId`（绑定消息） | 用户完成「使用已有 / 新建」并派发 `job.save` / `fill.submit` / `submit.confirm` 时 | 不可变。重试沿用，不新铸 |
 | 申请 UUID | 选「使用已有」= 候选 id；选「新建」= **桌面提交成功后**返回的新 UUID。意图阶段 **没有** 申请 UUID | 不可变 |
-| `archiveId` / `restoreEpoch` | **成功握手**时盖到绑定消息上。意图不盖当前身份 | 绑定后不可变；恢复后旧消息因 epoch 不匹配而暂停 |
+| 信封 `archiveId` / `restoreEpoch` | 每次握手后的 **当前**身份；写入与 `outbox.reconcile` 外层必须带上 | 随握手更新；不得用桌面 current 替旧消息补写 |
+| Bound `sourceRestoreEpoch` | 绑定/派发写入时盖章，等于当时 current | **不可变**。与 current 不符则暂停，禁止当普通写入重放 |
 
 #### 5.2.3 分模式行为
 
@@ -149,7 +150,7 @@
 - **取消候选选择器：** 若此次从「桌面已可用」路径进来、尚未派发 `job.save`：不写绑定消息。若本就是离线意图在桌面恢复后弹出选择器：取消 = 意图保持 pending，不绑定、不丢字段。
 - **用户删除某条待同步意图：** 删除意图；若已有部分上传的快照暂存，按 §8.5 清理规则。
 - **队列满：** 产品上限建议 100 条意图 + 100 条绑定消息（D07 可调，须有数）。满时 **拒绝新增** 并提示处理，**不静默丢旧项**，**不阻止**原有填表。
-- **应答丢失：** 绑定消息用同一 `messageId` 重试。桌面按 `(clientInstanceId, messageId, restoreEpoch)` 幂等：相同载荷返回原 `resultId`；冲突拒绝。意图没有桌面幂等键，桌面恢复后只转换一次。
+- **应答丢失：** 绑定消息用同一 `messageId` 重试，信封带 **当前** `(archiveId, restoreEpoch)`。仅当该当前身份与桌面 current 一致、且 outbox 的 `sourceRestoreEpoch` 也等于 current 时，桌面才按 `(clientInstanceId, messageId, sourceRestoreEpoch)` + 摘要返回原 `resultId`。`sourceRestoreEpoch` 与 current 不符 → `restore_epoch_mismatch`，不能当成功重放，只能 `outbox.reconcile`。意图没有桌面幂等键，桌面恢复后只转换一次。
 - **重复点击「保存岗位」：** 同一页短时间内（建议 10 s）已有 pending 意图且规范化三元组相同 → 提示已有待同步意图，不第二份；用户明确「再存一次」才新 `intentId`（对应走查 10.4 的再投）。
 
 ```mermaid
@@ -181,7 +182,7 @@ sequenceDiagram
       alt 稍后再说
         Note over SW: 意图保持 pending
       else 使用已有或新建
-        SW->>SW: 写 Bound outbox（messageId，盖 archiveId+restoreEpoch）
+        SW->>SW: 写 Bound outbox（messageId；sourceRestoreEpoch=当时 current）
         SW->>H: job.save
         APP-->>SW: applicationId + resultId
         SW->>SW: 删除意图与对应绑定项
@@ -261,9 +262,19 @@ Code 稳定，供存储、协议、过滤使用；展示名可本地化。MVP �
 
 ### 6.2 阶段折叠函数（冻结，D03 必须实现）
 
-`currentStage` 是按 `recordedAt` 升序（并列用 `id`）折叠事件得到的投影，并在写入那条事件的 **同一事务** 内更新。禁止普通编辑无声改阶段。纠错追加 `stage_corrected`（`from`/`to`/`actor`/`reason`），**不改写**历史事件。
+`currentStage` 按该申请的 **`eventSequence` 升序** 折叠，并在写入那条事件的 **同一事务** 内更新。`recordedAt` / `occurredAt` 只表示时间，**不是**事务顺序。禁止用 UUID `id` 做并列打破。禁止普通编辑无声改阶段。纠错追加 `stage_corrected`（`from`/`to`/`actor`/`reason`），**不改写**历史事件。
 
-`stage_corrected` 只是又一条 **set-absolute** 事件：它成为当前值是因为它排在后面，**不是**因为纠错永远压过未来事件。10.6 在纠错之后补 `interview_recorded` 仍然生效。
+`eventSequence`：每个 **已有 `applicationId` 的申请** 从 1 起单调递增的整数。分配、插入事件、更新 `currentStage` 与 `Application.lastEventSequence` 必须同一事务。未关联申请的收件箱事件使用档案级 `inboxEventSequence`（同样单调），不参与任何申请的阶段折叠。
+
+| 情况 | 行为 |
+| --- | --- |
+| 幂等重试命中已提交回执 | **不**分配新序号；返回原事件/原 `resultId` |
+| 同一事务写入多条事件 | 按调用方给出的批次顺序分配连续序号 |
+| 事务回滚 | 序号不提交；下一笔仍从失败前的 `lastEventSequence+1` 开始（无空洞） |
+| 备份恢复 | 事件带着原 `eventSequence`；**不**重编号。折叠结果与备份时一致 |
+| 旧库无序号（一次性迁移） | D03 用表内稳定 `rowid` 升序赋 1..n，写入迁移记录；**不用** UUID 排序 |
+
+`stage_corrected` 只是又一条 **set-absolute** 事件：它成为当前值是因为 `eventSequence` 更大，**不是**因为纠错永远压过未来事件。10.6 在纠错之后补 `interview_recorded` 仍然生效。走查 10.19 证明同时间戳下顺序稳定。
 
 每个 `eventType` 的折叠效应只有四种：`set-absolute` / `never-regress` / `advance` / `no-op`。
 
@@ -272,7 +283,8 @@ Code 稳定，供存储、协议、过滤使用；展示名可本地化。MVP �
 | `application_created` | `set-absolute saved` |
 | `application_updated` | `no-op` |
 | `job_saved` | `never-regress`：current ∈ {∅, `saved`} → `saved`；已是更后阶段 → `no-op` |
-| `fill_started` / `fill_completed` / `fill_partial` | `advance`：仅 `saved` → `filling`；其他 current `no-op`。**绝不**→`submitted` |
+| `fill_started` | **`no-op`**（开始填写不改持久化阶段） |
+| `fill_completed` / `fill_partial` | `advance`：仅 `saved` → `filling`；其他 current `no-op`。**绝不**→`submitted` |
 | `fill_failed` / `fill_cancelled` | `no-op`（失败/取消不标「填写中」） |
 | `submit_confirmed` | 仅当 current ∈ {`saved`,`filling`} 时 `set-absolute submitted`；否则 `no-op`（从 `interview` 等退回须用户 `stage_corrected`） |
 | `assessment_recorded` | `set-absolute assessment` |
@@ -307,23 +319,29 @@ saved → filling → submitted → assessment → interview → offer
 - 发送方式无法判断时 `sendMode=unknown`，**不捏造** `human`。
 - 旧值 `human_reply` **不再**作为 `replyClass` 或 `replyEvidenceState`。
 
-`replyEvidenceState` 只折叠 **已关联到该申请、且已确认** 的证据上的 `replyClass`（不是 `kind`，不是 `sendMode`，也不是未确认的 AI 建议）。忽略 `unknown` 与空：
+`replyEvidenceState` 由 **证据存在性** 与 **已确认分类** 两个维度投影，只看 **当前仍关联到该申请** 的证据（取消关联后不再计入）。未确认的 AI 建议、`kind`、`sendMode` 不进入本投影。`replyClass` 为空或 `unknown` 视为 **未分类**，不是「没有证据」。
 
-| 已确认 `replyClass` 集合 `C` | `replyEvidenceState` |
+令 `E` = 该申请当前关联证据集合；`C` = `E` 中已确认且非空、非 `unknown` 的 `replyClass` 集合。
+
+| 条件 | `replyEvidenceState` |
 | --- | --- |
-| 没有非空、非 `unknown` 的 `replyClass` | `none_imported` |
-| 只有 `auto_ack` | `auto_ack` |
-| 含 `{assessment_invite, interview_invite, action_required, offer, reject, other}` 之一，且 **没有** `auto_ack` | `classified` |
-| 同时有 `auto_ack` 与上一行任一业务类 | `mixed` |
+| `E` 为空（从未导入，或已全部取消关联） | `none_imported` |
+| `E` 非空且 `C` 为空（已导入/已关联，分类空或 unknown，或仅暂存了 AI 建议） | `imported_unclassified` |
+| `C` 只有 `auto_ack` | `auto_ack` |
+| `C` 含 `{assessment_invite, interview_invite, action_required, offer, reject, other}` 之一，且 **没有** `auto_ack` | `classified` |
+| `C` 同时有 `auto_ack` 与上一行任一业务类 | `mixed` |
+
+已分类的证据与仍未分类的证据并存时，按 `C` 走 `auto_ack` / `classified` / `mixed`（存在性已满足）；未分类项在详情里单独标「待分类」，**不得**因此退回 `none_imported`。
 
 | code | 展示 | 规则 |
 | --- | --- | --- |
-| `none_imported` | 尚未导入回复证据 | 默认。禁止写成「对方未回复」 |
+| `none_imported` | 尚未导入回复证据 | **仅** `E` 为空。禁止写成「对方未回复」 |
+| `imported_unclassified` | 已导入，待分类 | **禁止**显示「尚未导入回复证据」 |
 | `auto_ack` | 已导入自动回执 | 不移动到 `interview`，不暗示通过筛选 |
-| `classified` | 已导入分类通知 | 详情展示具体 `replyClass`（如「面试邀请」）。`sendMode` 另栏显示「人工 / 自动 / 未知」 |
+| `classified` | 已导入分类通知 | 详情展示具体 `replyClass`。`sendMode` 另栏「人工 / 自动 / 未知」 |
 | `mixed` | 回执与其他分类通知均有 | 列表可用摘要，详情看时间线 |
 
-列表不得把 `classified` 写成「已导入人工回复」。
+列表不得把 `classified` 写成「已导入人工回复」。走查 10.20。
 
 ---
 
@@ -389,8 +407,9 @@ saved → filling → submitted → assessment → interview → offer
 | `dedupeUrl` | 候选查询规范化 URL（与 sourceUrl 相同秘密剥离，再去跟踪参数） | 否 | system | mutable | PII |
 | `location` | 地点 | 否 | user/plugin | mutable | PII |
 | `notes` | 备注 | 否 | user | mutable | PII |
-| `currentStage` | 阶段投影（§6.2 折叠） | 是 | system | projected | public-meta |
-| `replyEvidenceState` | 由 `replyClass` 投影，不是文件类型 | 是 | system | projected | public-meta |
+| `currentStage` | 阶段投影（§6.2 按 `eventSequence` 折叠） | 是 | system | projected | public-meta |
+| `lastEventSequence` | 已提交的最大 `eventSequence`；与事件写入同事务递增 | 是 | system | projected | public-meta |
+| `replyEvidenceState` | 证据存在性 + 已确认分类的投影（§6.3），含 `imported_unclassified` | 是 | system | projected | public-meta |
 | `createdAt` / `updatedAt` | UTC | 是 | system | created immutable | public-meta |
 | `archivedAt` | 列表归档（非回收） | 否 | user | mutable | public-meta |
 | `recycleState` | `active` / `recycled` / `purged` | 是 | user/system | mutable | public-meta |
@@ -406,9 +425,10 @@ saved → filling → submitted → assessment → interview → offer
 | --- | --- | --- | --- | --- | --- |
 | `id` | 事件 UUID | 是 | system | immutable | public-meta |
 | `applicationId` | 所属申请；未绑定证据事件可空 | 视类型 | system | immutable | public-meta |
+| `eventSequence` | 该申请（或收件箱）内单调序号，从 1 起。折叠主键。与写入同事务分配 | 是 | system | immutable | public-meta |
 | `eventType` | 见下表 | 是 | system | immutable | public-meta |
 | `occurredAt` | 业务发生时间。`occurredPrecision=unknown` 时 **必须为 null**，禁止填午夜伪造 | 当 precision≠`unknown` | user/import/plugin | immutable | public-meta |
-| `recordedAt` | 写入时间 UTC | 是 | system | immutable | public-meta |
+| `recordedAt` | 写入墙钟 UTC，**仅时间含义**，不参与折叠并列打破 | 是 | system | immutable | public-meta |
 | `occurredPrecision` | `datetime` / `date` / `unknown` | 是 | system | immutable | public-meta |
 | `timeZone` | 有意义时区；未知则空 | 否 | user/import | immutable | public-meta |
 | `source` | `manual` / `plugin` / `import` / `ai_confirmed` | 是 | system | immutable | public-meta |
@@ -426,7 +446,8 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `application_created` | 初始字段快照 | set-absolute `saved` |
 | `application_updated` | from/to 字段 | no-op |
 | `job_saved` | 插件提交的岗位元数据 | never-regress |
-| `fill_started` / `fill_completed` / `fill_partial` | 字段计数、耗时、URL、template、snapshotId、outcome | advance `saved`→`filling` |
+| `fill_started` | 字段计数、耗时、URL、template、snapshotId、outcome | no-op |
+| `fill_completed` / `fill_partial` | 同上 | advance `saved`→`filling` |
 | `fill_failed` / `fill_cancelled` | 同上 outcome | no-op |
 | `submit_confirmed` | 确认方式（插件 D07 或桌面 D04） | 仅 saved/filling → `submitted` |
 | `stage_corrected` | from/to/reason | set-absolute `to` |
@@ -441,7 +462,7 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 
 ### 8.4 ReplyEvidence 与 AttachmentBlob
 
-附件字节在库外。`kind` 是 **获取/格式**，`replyClass` 是 **通知业务类型**，`sendMode` 是 **发送方式**（确认后才写；无法判断则为 `unknown`）。`replyEvidenceState` 按 §6.3 只从已关联、已确认的 `replyClass` 投影（`unknown`/空不计数）。一封 ATS 自动发出的面试邮件可以同时是 `kind=eml`、`replyClass=interview_invite`、`sendMode=automated`；该申请的 `replyEvidenceState=classified`，**不是**「人工回复」。
+附件字节在库外。`kind` 是 **获取/格式**，`replyClass` 是 **通知业务类型**，`sendMode` 是 **发送方式**（确认后才写；无法判断则为 `unknown`）。`replyEvidenceState` 按 §6.3 由关联证据的 **存在性** 与已确认 `replyClass` 投影。已导入但分类空/`unknown` → `imported_unclassified`，**不是** `none_imported`。一封 ATS 自动发出的面试邮件可以同时是 `kind=eml`、`replyClass=interview_invite`、`sendMode=automated`；确认后该申请为 `classified`，**不是**「人工回复」。
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
@@ -493,7 +514,7 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 
 | 阶段 | 字节位置 | 元数据位置 |
 | --- | --- | --- |
-| 每次确认留档，无论桌面是否可握手 | **先**将不可变完整字节提交到扩展源 IndexedDB，成功后才能开始 `snapshot.chunk`；上传期间仍保留 IDB 副本 | 暂存记录持有 `snapshotId` / `sha256` / `byteSize` 与待建队列状态；Bound outbox 保存同一身份和游标 |
+| 每次确认留档，无论桌面是否可握手 | **先**将不可变完整字节提交到扩展源 IndexedDB，成功后才能开始 `snapshot.chunk`；上传期间仍保留 IDB 副本 | 暂存/outbox 持有 `snapshotId`、总哈希、`chunkCount`、每块 `chunkMessageId`、连续 `chunkCursor` |
 | 曾配对但桌面暂不可用 | **扩展源 IndexedDB**（SW / offscreen / 扩展页可访问；**禁止**写在 content script 的页面源 IDB） | `chrome.storage.local` 只存元数据 + `staging=idb`，**不**存整份 blob（`chrome.storage.local` 约 10 MB 配额） |
 | 桌面已持久化完整快照且 ACK 总哈希相符 | 桌面档案为权威副本，此时才允许清理 IDB | ACK 状态先持久化，再清理 IDB/绑定项；中断后可幂等继续清理 |
 
@@ -503,9 +524,25 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 
 **过期：** 暂存超过 30 天仍未 ACK：下次打开插件时提示「有未完成的简历留档」，用户选继续发送 / 丢弃。到期 **不自动删** 未提示过的项。
 
-**部分上传：** `chunkCursor` 记录桌面已 ACK 的最后块号；重试从下一块开始，校验总 `sha256`。桌面在未收齐前不把快照标为完整。
+**分片身份（冻结）：** 一次快照传输是父记录 + 多块。父记录持有 `snapshotId`、`sha256`（总摘要）、`byteSize`、`chunkCount`、`sourceRestoreEpoch`。**每一块** 在首次准备发送时铸造并 **持久化** 自己的 `chunkMessageId`（UUID），以及 `chunkIndex`（0..`chunkCount-1`）、`chunkSha256`。
 
-**统一写前暂存：** 在线开始后断线、SW 重启和浏览器重启与初始离线使用同一 IDB 原字节。分片 ACK 不是完整提交 ACK；完整 ACK 丢失时可按快照 ID/总哈希查询或重传，不能从活模板重建。IDB 与 `chrome.storage.local` 不具备跨库事务：IDB 暂存记录必须包含足够元数据，以便重启后修复缺失的 outbox 索引；有 outbox 但找不到原字节时暂停并报告失败，不假报可恢复。
+- **禁止** 多个 chunk 复用同一个 `messageId`（包括不得复用 `fill.submit` / `job.save` 的 id）。
+- **禁止** 浏览器重启后为同一 `(snapshotId, chunkIndex, sourceRestoreEpoch)` 新铸 `chunkMessageId`。
+- 块级幂等键：`(clientInstanceId, chunkMessageId, sourceRestoreEpoch)`；业务等价键：`(clientInstanceId, snapshotId, chunkIndex, sourceRestoreEpoch)`。二者必须指向同一块。同身份不同 `chunkSha256` → `conflict`。
+- 每块请求仍是完整 UTF-8 JSON 信封 ≤ 64 KiB（ADR §4）。
+
+**`chunkCursor`：** 等于「已从 0 起 **连续** 收到分片 ACK 的下一块下标」。只 ACK 了块 5 而 2–4 未 ACK 时，cursor 仍停在 2，必须重试块 2。乱序到达时桌面可以暂存该块，但 **不得** 把 cursor 跳过空洞，也 **不得** 发完整快照 ACK。
+
+**两种 ACK：**
+
+| ACK | 含义 | 可否删 IDB |
+| --- | --- | --- |
+| 分片 ACK | 这一块已按块身份持久化 | **否** |
+| 完整快照 ACK | 全部块到齐且总哈希相符，桌面快照行已提交 | **是**（先持久化 ACK 状态） |
+
+缺块、乱序、ACK 丢失：用同一 `chunkMessageId` 重试该块。`sourceRestoreEpoch` ≠ current：停止上传，走对账/用户决定；不得把旧块改写成当前 epoch 后重放。见走查 10.21。
+
+**统一写前暂存：** 在线开始后断线、SW 重启和浏览器重启与初始离线使用同一 IDB 原字节。完整 ACK 丢失时可按快照 ID/总哈希查询或按块重传，不能从活模板重建。IDB 与 `chrome.storage.local` 不具备跨库事务：IDB 暂存必须含父记录与 **每块** `chunkMessageId`；有 outbox 但找不到原字节时暂停并报告失败，不假报可恢复。
 
 **清理：** 仅当 (1) 桌面 ACK 完整且哈希相符，或 (2) 用户明确丢弃该留档，或 (3) 用户确认过期提示中的丢弃。浏览器重启后 IDB 仍在，继续发 **原字节**。
 
@@ -615,26 +652,31 @@ erDiagram
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
-| `messageId` | 幂等键之一 | 是 | plugin | immutable | public-meta |
+| `messageId` | 该绑定消息（或该 **chunk**）的幂等 id；块与父消息不得共用 | 是 | plugin | immutable | public-meta |
 | `intentId` | 来源意图（若有） | 否 | plugin | immutable | public-meta |
 | `clientInstanceId` | 每扩展安装/Profile 一次 | 是 | plugin | immutable | public-meta |
 | `messageType` | 与 ADR 枚举相同 | 是 | plugin | immutable | public-meta |
-| `archiveId` | 入队时握手到的档案 | 是 | handshake | immutable | public-meta |
-| `restoreEpoch` | 入队时握手到的指针身份 | 是 | handshake | immutable | public-meta |
+| `archiveId` | 绑定时的档案谱系 | 是 | handshake | immutable | public-meta |
+| `sourceRestoreEpoch` | **绑定时**的来源 epoch，不可变。不是「下次发送时的 current」 | 是 | handshake | immutable | public-meta |
 | `applicationId` | 「使用已有」时已有；「新建」可在 ACK 后回填 | 视类型 | plugin/desktop | 回填一次 | public-meta |
 | `payload` | 业务载荷，**无** Key/密码/快照字节 | 是 | plugin | immutable | PII |
-| `snapshotId` / `sha256` / `byteSize` | 若本次含快照 | 否 | plugin | immutable | public-meta |
-| `chunkCursor` | 已 ACK 的最后块号 | 否 | plugin | mutable | public-meta |
+| `snapshotId` / `sha256` / `byteSize` / `chunkCount` | 若本次含快照 | 否 | plugin | immutable | public-meta |
+| `chunks[]` | 每块 `{chunkIndex, chunkMessageId, chunkSha256, acked}` | 快照必填 | plugin | acked 可变 | public-meta |
+| `chunkCursor` | 从 0 起连续 ACK 的下一块下标；不得因较后 ACK 前移 | 快照必填 | plugin | mutable | public-meta |
 | `createdAt` | 入队 UTC | 是 | plugin | immutable | public-meta |
-| `bytes` | payload 序列化字节数 | 是 | plugin | immutable | public-meta |
+| `bytes` | 父消息 payload 序列化字节数 | 是 | plugin | immutable | public-meta |
 
-恢复后：握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。插件比较每条 **绑定** 消息上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。意图不盖 epoch，恢复后重新走候选，不自动当成已绑定。旧写入请求仍返回 `restore_epoch_mismatch`；历史只读对账与写入授权分开，不能只查询新 epoch 的写入记录。
+发送普通写入时，信封上的 `archiveId`/`restoreEpoch` 必须是 **最新握手的 current**。若 `sourceRestoreEpoch` ≠ current：插件 **不得**发送 `job.save`/`fill.submit`/`snapshot.chunk`/`submit.confirm`，只能 `outbox.reconcile`。桌面若仍收到旧信封，按 ADR §4 拒绝，**不得**改写成 current 后收下。
+
+恢复后：握手 **成功** 并返回新 current。插件比较每条绑定消息的 `sourceRestoreEpoch`，不匹配则暂停，用户选关联/丢弃/另存。意图不盖 epoch，恢复后重新走候选。
 
 #### 8.11 已提交消息回执与恢复对账
 
 D03 在业务事务中同步持久化回执：所属 `archiveId`、`clientInstanceId`、`messageId`、`sourceRestoreEpoch`（该写入提交时的 epoch）、`payloadSha256`、`resultId`、操作类型和提交时间。回执属于可备份业务历史；历史 epoch 不授予当前写入权限。回执保留期至少与对应申请/事件一致；永久清理后的缺失不能解释成“以前从未执行”。
 
-`outbox.reconcile` 的外层信封使用当前握手的 `(archiveId, restoreEpoch)`，payload 每项携带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`。它只读当前所选档案库中的历史回执，**不按当前 epoch 过滤历史行**；不搜索其他档案或接受任意路径。调用方只能查询自己的 clientInstanceId（最多由 D05 规定的有界批次）。响应逐项回显完整身份并返回 `applied` / `not_found` / `conflict` / `unverifiable`，`applied` 才有已核实的 resultId。
+`outbox.reconcile` 的外层信封使用当前握手的 `(archiveId, restoreEpoch)`（缺失或不匹配则整批 `identity_missing` / `restore_epoch_mismatch`）。payload 每项携带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`（快照块另带 `snapshotId`+`chunkIndex`）。它只读当前所选档案库中的历史回执，**不按当前 epoch 过滤历史行**；不搜索其他档案或接受任意路径。调用方只能查询自己的 clientInstanceId（最多由 D05 规定的有界批次）。响应逐项回显完整身份并返回 `applied` / `not_found` / `conflict` / `unverifiable`，`applied` 才有已核实的 resultId。
+
+**`not_found` 不代表从未执行**，只代表这份备份/当前库没有回执；不得据此自动重写。
 
 - 完整旧身份与摘要命中、对应结果仍有效：`applied`，不再新增业务事件。
 - 同身份摘要不符：`conflict`，拒绝自动处理。
@@ -838,11 +880,49 @@ Profile B 恰好也使用 M1，不能命中 A 的回执；同旧身份但摘要�
 
 旧目录 A 和 current.json 指向 E1。向独立目录 B 解压时磁盘满：删除/隔离未完成的本次 staging，A 和 current.json 不变；不把旧目录先移走。只有 B 的完整校验和迁移验证成功后，暂停写入、持久化 B 并原子切换指针到 B/E2。提交点后的崩溃使用 B/E2，旧 A 仍为回滚点；人工回滚 A 时新铸 E3。
 
+### 10.19 同时间戳事件顺序（eventSequence）
+
+**正常：** 同一毫秒内事务依次写入 `application_created` → `submit_confirmed` → `stage_corrected(to=interview)`。三者 `recordedAt` 相同。`eventSequence` 为 1、2、3。折叠后 `currentStage=interview`。备份恢复后序号不变，重算仍为面试。
+
+**反例：** 若只用 UUID 排序，纠正可能排到创建之前，列表显示 `saved`。禁止。幂等重试同一 `submit.confirm` 不得插入 sequence=4。事务在纠正前崩溃：库中只有 1–2，`lastEventSequence=2`，重开后纠正得到 3。
+
+### 10.20 已导入未分类
+
+**正常：** 用户把 `ev-1` 关联到 `app-A` 后暂存 AI 建议、不确认。`E` 非空、`C` 空 → `imported_unclassified`。列表「已导入，待分类」。**不是**「尚未导入回复证据」。确认 `interview_invite` 后变为 `classified`。取消关联后 `E` 空 → `none_imported`。
+
+**反例：** 把空/`unknown` 的 `replyClass` 投影成 `none_imported`，用户以为证据丢了。禁止。已有 `auto_ack` 另附一份未分类截图时，状态仍是 `auto_ack`，截图标「待分类」。
+
+### 10.21 快照分片身份
+
+**正常：** 快照 3 块。父记录 `snapshotId=S1`，块 0/1/2 各有持久化 `chunkMessageId` C0/C1/C2。块 0、1 ACK 后 cursor=2。SW 重启后仍用 C2 发块 2，不得新铸。全部到齐且总哈希相符才完整 ACK，然后删 IDB。
+
+**反例 1：** 三块共用 `fill.submit` 的 messageId，第二块摘要冲突。禁止。
+**反例 2：** 只收到块 2 的 ACK 就把 cursor 设为 3，跳过 0–1。禁止。
+**反例 3：** 完整 ACK 前删 IDB，重启后从 v2 模板重算。禁止。
+**反例 4：** epoch 已变为 E2 仍把 C0 当普通写入重放。必须 `restore_epoch_mismatch`，只允许对账。
+
+### 10.22 信封档案身份
+
+**正常：** 握手返回 `(A1,E2)`。随后 `job.save` / `queryCandidates` / `snapshot.chunk` / `outbox.reconcile` 外层都带 `archiveId=A1, restoreEpoch=E2`。桌面比对 current 后执行。
+
+**反例：** 绑定消息只带 messageId、不带档案身份，桌面用 current 替补后执行旧 E1 写入。禁止。`health`/`handshake` 若携带身份 → `identity_not_allowed`。缺失 → `identity_missing`。E1 写入打到 E2 current → `restore_epoch_mismatch`，不是原 resultId。
+
+### 10.23 来源 epoch 与当前 epoch
+
+**正常：** Bound outbox.`sourceRestoreEpoch=E1`。恢复后 current=E2。插件不发送该 `job.save`，只对账。对账 `applied` 不授予再写。用户另存时新 `messageId` + `sourceRestoreEpoch=E2`，先持久化再发送。
+
+**反例：** 把 outbox.`restoreEpoch` 理解成「每次握手刷新的当前值」，或「相同载荷一律返回原 resultId」而不先校验 current。禁止。`not_found` 自动重写造成重复申请。禁止。
+
+### 10.24 原型失败同步（文档纪律）
+
+V8 杀进程后面试通知不弹：先改产品 §5.4 与 ADR §3.8 的能力边界，再在 #17 记决策，再改 D10/D14 验收。**不**改 D05 信封。禁止只改 issue 正文而留下旧设计。
+
 ## 11. UI 文案约束（产品级）
 
 | 禁止 | 必须 |
 | --- | --- |
-| 「对方未回复」 | 「尚未导入回复证据」 |
+| 「对方未回复」 | `none_imported`：「尚未导入回复证据」 |
+| 已导入未分类却显示「尚未导入」 | `imported_unclassified`：「已导入，待分类」 |
 | 「已通过筛选」（仅因回执） | 「已导入自动回执」 |
 | 填写成功后自动显示「已投递」 | 「填写完成（未确认投递）」 |
 | 「本地应用 = AI 全部离线」 | 使用云端模型时展示外发范围与服务商 |

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -5,7 +5,7 @@
 | 标题 | MVP 产品需求与对象模型 |
 | 作者 | D01 design PR |
 | 日期 | 2026-09-06 |
-| 状态 | Draft / Ready for review |
+| 状态 | 可修订开工基线（PR 合并后生效） |
 | 上级 | [README.md](README.md) · [D01 #17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) · [Epic #15](https://github.com/TshyGO/resume-form-assistant-plugin/issues/15) |
 | 并列 | [adr-architecture.md](adr-architecture.md) · [data-privacy.md](data-privacy.md) · [downstream-decisions.md](downstream-decisions.md) |
 
@@ -287,12 +287,14 @@ Code 稳定，供存储、协议、过滤使用；展示名可本地化。MVP �
 | `fill_completed` / `fill_partial` | `advance`：仅 `saved` → `filling`；其他 current `no-op`。**绝不**→`submitted` |
 | `fill_failed` / `fill_cancelled` | `no-op`（失败/取消不标「填写中」） |
 | `submit_confirmed` | 仅当 current ∈ {`saved`,`filling`} 时 `set-absolute submitted`；否则 `no-op`（从 `interview` 等退回须用户 `stage_corrected`） |
-| `assessment_recorded` | `set-absolute assessment` |
-| `interview_recorded` | `set-absolute interview` |
+| `assessment_recorded` | 仅显式推进且 current ∈ {saved,filling,submitted,assessment} 时设 assessment；历史补录或更后/终止阶段不改变 current |
+| `interview_recorded` | 仅显式推进且 current ∈ {saved,filling,submitted,assessment,interview} 时设 interview；历史补录或更后/终止阶段不改变 current |
 | `interview_rescheduled` | 仅当 current ∈ {`saved`,`filling`,`submitted`,`assessment`} 时设 `interview`；若 current ∈ {`interview`,`offer`,`rejected`,`withdrawn`,`closed`} 则 `no-op`（从拒绝等恢复须 `stage_corrected` 或 `interview_recorded`） |
 | `offer_recorded` / `rejected` / `withdrawn` / `closed` | `set-absolute` 对应 code |
 | `stage_corrected` | `set-absolute` payload.`to` |
 | `evidence_*` / `note_*` / `todo_*` | `no-op` |
+
+**历史补录约束：** 阶段相关事件的 payload 持久化 `stageUpdateMode`（`history_only` / `update_progress`）。导入通知和手动补录默认为 history_only：仍分配 eventSequence，但所有阶段效应均为 no-op。用户明确选择更新当前进度才使用 update_progress 并应用上表；历史补录不能仅因较晚记录而覆盖当前阶段，回退/从终止阶段恢复须明确的 stage_corrected（含原因）。确认通知分类不等于确认更新当前阶段。D03/D04/D11 负责实现与测试，不继续扩展 D01。
 
 建议的正向路径（UI 可跳步，但必须写对应事件）：
 
@@ -451,8 +453,8 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `fill_failed` / `fill_cancelled` | 同上 outcome | no-op |
 | `submit_confirmed` | 确认方式（插件 D07 或桌面 D04） | 仅 saved/filling → `submitted` |
 | `stage_corrected` | from/to/reason | set-absolute `to` |
-| `assessment_recorded` | 名称、截止 | set-absolute `assessment` |
-| `interview_recorded` | round、时间 | set-absolute `interview` |
+| `assessment_recorded` | 名称、截止、stageUpdateMode | 按 §6.2 显式推进；历史补录 no-op |
+| `interview_recorded` | round、时间、stageUpdateMode | 按 §6.2 显式推进；历史补录 no-op |
 | `interview_rescheduled` | round、from/to 时间 | 仅 saved/filling/submitted/assessment → `interview`；其余 no-op |
 | `offer_recorded` / `rejected` / `withdrawn` / `closed` | 原因可选 | set-absolute 对应 code |
 | `evidence_imported` | evidenceId | no-op |
@@ -672,9 +674,9 @@ erDiagram
 
 #### 8.11 已提交消息回执与恢复对账
 
-D03 在业务事务中同步持久化回执：所属 `archiveId`、`clientInstanceId`、`messageId`、`sourceRestoreEpoch`（该写入提交时的 epoch）、`payloadSha256`、`resultId`、操作类型和提交时间。回执属于可备份业务历史；历史 epoch 不授予当前写入权限。回执保留期至少与对应申请/事件一致；永久清理后的缺失不能解释成“以前从未执行”。
+D03 在业务事务中同步持久化回执：所属 `archiveId`、`clientInstanceId`、`messageId`、`sourceRestoreEpoch`（该写入提交时的 epoch）、`payloadSha256`、`resultId`、操作类型和提交时间。回执属于可备份业务历史；历史 epoch 不授予当前写入权限。永久删除业务对象时必须在同一事务保留最小幂等墓碑（消息身份、摘要、purged 标记，不含已删除正文），至少保留至该来源 epoch 不再能通过普通写入校验。重试命中墓碑返回 `previously_purged`，不得重建申请或返回可用旧对象；只读对账返回 purged 状态。墓碑随备份保留，清理前验证不存在仍可接受的旧请求。D03/D07/D12 落实此约束。
 
-`outbox.reconcile` 的外层信封使用当前握手的 `(archiveId, restoreEpoch)`（缺失或不匹配则整批 `identity_missing` / `restore_epoch_mismatch`）。payload 每项携带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`（快照块另带 `snapshotId`+`chunkIndex`）。它只读当前所选档案库中的历史回执，**不按当前 epoch 过滤历史行**；不搜索其他档案或接受任意路径。调用方只能查询自己的 clientInstanceId（最多由 D05 规定的有界批次）。响应逐项回显完整身份并返回 `applied` / `not_found` / `conflict` / `unverifiable`，`applied` 才有已核实的 resultId。
+`outbox.reconcile` 的外层信封使用当前握手的 `(archiveId, restoreEpoch)`（缺失或不匹配则整批 `identity_missing` / `restore_epoch_mismatch`）。payload 每项携带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`（快照块另带 `snapshotId`+`chunkIndex`）。它只读当前所选档案库中的历史回执，**不按当前 epoch 过滤历史行**；不搜索其他档案或接受任意路径。调用方只能查询自己的 clientInstanceId（最多由 D05 规定的有界批次）。响应逐项回显完整身份并返回 `applied` / `purged` / `not_found` / `conflict` / `unverifiable`，`applied` 才有已核实的 resultId。
 
 **`not_found` 不代表从未执行**，只代表这份备份/当前库没有回执；不得据此自动重写。
 
@@ -774,7 +776,7 @@ D03 在业务事务中同步持久化回执：所属 `archiveId`、`clientInstan
 - Event `stage_corrected` {from:`rejected`, to:`interview`, actor:`user`, reason}。
 - 折叠后 current=`interview`（`stage_corrected` 是后一条 set-absolute）。时间线：**拒绝事件与纠错事件都在**。
 - 可再补 `interview_recorded`（仍 set-absolute `interview`）与 Todo。若曾有拒绝相关 Todo，用户手动取消；系统不猜。
-- 若纠错 **之后** 又来一条更晚的 `assessment_recorded`，折叠会把 current 设为 `assessment`——纠错 **不**永远压过未来事件。
+- 若纠错后补录过去的 assessment_recorded，history_only 不改变当前面试阶段。即使显式推进，也不得从面试退回测评；需要回退时由用户另记 stage_corrected。
 - 若再次纠回 `rejected`，再追加一条 `stage_corrected`，不删除前两条。
 
 ### 10.7 桌面未安装 / 从未配对 / 曾经配对但不可用 / AI 宕机

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -15,7 +15,11 @@
 
 ## 1. Overview
 
-求职者已经在用 Resume Pro 插件填写网申，但填完之后不知道「哪份投了、用了哪版简历、后来邮件是哪一岗」。本 MVP 把产品扩成 **浏览器填写入口 + Windows 本地求职档案**：插件继续独立填表；桌面主程序保存申请、事件、附件、当次简历快照和待办。桌面档案是申请数据的权威源；插件通过受限 Native Messaging 写入，离线时入队。
+求职者已经在用 Resume Pro 插件填写网申，但填完之后不知道「哪份投了、用了哪版简历、后来邮件是哪一岗」。本 MVP 把产品扩成 **浏览器填写入口 + 本机求职档案**：插件继续独立填表；桌面主程序保存申请、事件、附件、当次简历快照和待办。
+
+**目标平台是 Windows 与 macOS。** 实现可以 Windows 优先，但业务模型、SQLite、事件、AI 建议和通信消息保持平台无关；D02 起必须做 macOS 原型，不能等 Windows 全做完再移植。Linux 仍非首版产品。浏览器首阶段仍是 Chrome / Edge，**不默认承诺 Safari**。
+
+桌面档案是申请数据的权威源；插件通过受限 Native Messaging 写入。离线时持久化的是 **保存意图** 或 **已绑定业务消息**（见 §5.2），二者不是同一状态，也不得把「待同步」说成「桌面已保存」。
 
 当前仓库 **没有** 申请对象、填写事件日志或桌面连接（见 [README 现状表](README.md#现状以仓库代码为准不以-readme-宣传为准)）。填写仍是用户点击触发；[`form-agent.js`](../../form-agent.js) 只在确认后点击安全「新增/添加」按钮，从不提交表单。本需求保持该安全边界，并加上「填写完成 ≠ 已投递」。
 
@@ -39,7 +43,7 @@
 
 ### 2.3 目标用户
 
-在 Windows 上使用 Chrome 或 Edge、已用 Resume Pro 填写网申的 **中文个人求职者**。不假设企业 IT、不假设多设备、不假设会写代码。能接受「先装桌面程序再从网页保存岗位」；不装桌面时原插件能力必须仍可用。
+在 **Windows 或 macOS** 上使用 Chrome 或 Edge、已用 Resume Pro 填写网申的 **中文个人求职者**。不假设企业 IT、不假设多设备同步、不假设会写代码。能接受「先装桌面程序再从网页保存岗位」；不装桌面时原插件能力必须仍可用。不把 Safari 当首阶段目标。
 
 ---
 
@@ -60,9 +64,10 @@
 
 - 邮箱 OAuth / IMAP 轮询 / 自动拉取
 - 自动提交网申、代发邮件、任意网页 Agent
-- 云账号、云同步、多设备同步、团队协作
-- Mac / Linux 成品
+- 云账号、云同步、多设备实时同步、团队协作（换电脑 = 备份恢复，不是云同步）
+- Linux 成品；Safari 扩展；默认承诺 App Store / Chrome Web Store 上架
 - 扩展商店上架与静默自动更新（检查更新仍可沿用插件现有 GitHub Release 提示）
+- 把「首个正式版必须双平台同一天交付」写成未确认承诺（见 [开放问题](downstream-decisions.md#需要项目负责人选择)）
 - `.msg` / Outlook 虚拟拖拽对象（不支持时提示导出 `.eml` 或粘贴正文）
 - 把当前开发者机器路径写进产品
 - 在 D01 修改插件权限、存储、功能或把 `manifest.json` 版本从 `0.3.0` 改掉
@@ -78,11 +83,11 @@
 3. **没有导入邮件 ≠ 没有收到回信。** UI 文案必须是「尚未导入回复证据」，禁止「对方未回复」。
 4. **同公司多岗、重复申请必须可区分。** 禁止按公司或 URL 自动合并；身份是申请 UUID。
 5. **AI 只建议。** 确认后才事务性写事件/阶段/待办；模型输出不得替换原始证据字节。
-6. **桌面档案是 source of truth。** 插件离线队列 + 幂等 + `archiveId`/`generation` 检查。
+6. **桌面档案是 source of truth。** 插件离线队列分 **意图 / 已绑定消息**；幂等与 `archiveId`/`restoreEpoch` 检查。
 7. **只记录用户主动使用插件的操作。** 禁止密码、OTP、API Key、Cookie；禁止全局键鼠采集。
 8. **升级 / 卸载 / 恢复不得静默删除申请和附件。**
 9. **AI 或网络失败时，手动管理必须仍可用。**
-10. **无邮箱连接、无自动投递、无通用 web agent、无云账号、无多设备同步、v1 无 Mac/Linux 成品。**
+10. **无邮箱连接、无自动投递、无通用 web agent、无云账号、无多设备实时同步。** Linux 与 Safari 仍非首版。Windows + macOS 是架构目标，实现顺序与「正式版是否双平台同时交付」见开放问题。
 
 ---
 
@@ -98,59 +103,94 @@
 
 此流程是 [D04 #19](https://github.com/TshyGO/resume-form-assistant-plugin/issues/19) 的验收闭环，不断网、不调外部 API。
 
-### 5.2 插件辅助
+### 5.2 插件辅助：保存意图 vs 已绑定业务消息
 
-1. 用户在招聘页点「保存岗位到本地」（**D07**）。侧边栏展示提取的公司/岗位/地点/URL，缺项手补，不捏造。
-2. 桌面按 **两层候选**（§7）返回最小元数据；用户选「使用已有」或「新建」。默认阶段 `saved`。
+1. 用户在招聘页点「保存岗位到本地」（**D07**）。侧边栏展示提取的公司/岗位/地点/URL，缺项手补，不捏造。用户点确认后，插件记下一次 **保存意图**（见下）。
+2. **仅当桌面可握手** 时，才查询两层候选（§7）；用户选「使用已有」或「新建」。默认阶段 `saved`。
 3. 用户照常使用现有「一键 AI 填写」/「AI 辅助新增条目」。填写本身不依赖桌面。
-4. 可选：将本次填写事件 + 简历快照归档到已绑定申请（D08；快照字节走分片，见 ADR §4）。
+4. 可选：将本次填写事件 + 简历快照归档到已绑定申请（D08；快照字节见 §8.5）。
 5. 用户另点「确认已投递」（**插件按钮归 D07**，`submit.confirm`，与填写成功无关），或之后在桌面（D04）/证据确认（D11）推进阶段。
 
-**Outbox 顺序（冻结）：** 先探测 host 注册 / 本 origin 是否已配对 / 协议是否兼容。未安装、未配对：不建长期队列。协议不兼容：不入队，提示升级。`handshake` 与 `application.queryCandidates` 是 **读**，不写 outbox。**只在用户确认「使用已有」或「新建」之后、派发写入**（`job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm`）时才持久化 outbox 行，并盖上握手得到的 `(archiveId, generation)`。用户点「取消」：什么都不入队。已配对但 EXE 未运行或离线或拉起失败：此时才 durable 入队 +「待同步」。
+#### 5.2.1 两种队列对象（冻结）
+
+| 对象 | 用户已经确认了什么 | 是否已有申请 UUID | 是否已盖 `archiveId`/`restoreEpoch` | UI |
+| --- | --- | --- | --- | --- |
+| **保存意图** `SaveIntent` | 要保存这些字段（公司/岗位/URL/地点） | **否** | **否**（可记下「上次成功握手」作提示，不作提交凭证） | 「待同步（尚未绑定申请）」 |
+| **已绑定业务消息** Bound outbox | 已选「使用已有」或「新建」，协议可重试 | **是**（已有 id，或桌面将在 `job.save` 成功时返回新 id） | **是**（当前握手身份） | 「待同步」；**仅**桌面持久化应答后才「桌面已保存」 |
+
+**禁止：** 以「先握手成功」作为「桌面不可用时才能入队」的前提。曾经配对但此刻桌面不可用时，持久化的是 **意图**，不是 `job.save`。
+
+**禁止：** 把待同步说成已保存。
+
+#### 5.2.2 何时确定哪些 ID
+
+| ID | 何时确定 | 之后是否可变 |
+| --- | --- | --- |
+| `intentId` | 用户确认字段、产生保存意图时 | 不可变。取消则删除该意图 |
+| `clientInstanceId` | 每个扩展安装 / Profile 一次 | 清存储后新 ID |
+| `messageId`（绑定消息） | 用户完成「使用已有 / 新建」并派发 `job.save` / `fill.submit` / `submit.confirm` 时 | 不可变。重试沿用，不新铸 |
+| 申请 UUID | 选「使用已有」= 候选 id；选「新建」= **桌面提交成功后**返回的新 UUID。意图阶段 **没有** 申请 UUID | 不可变 |
+| `archiveId` / `restoreEpoch` | **成功握手**时盖到绑定消息上。意图不盖当前身份 | 绑定后不可变；恢复后旧消息因 epoch 不匹配而暂停 |
+
+#### 5.2.3 分模式行为
+
+| 模式 | 如何判断 | 用户确认保存字段之后 | 恢复后 |
+| --- | --- | --- | --- |
+| **未安装 / 从未配对** | 无 host 注册，或本 origin 从未成功写入过 pairing 记录 | **不建长期意图、不建绑定队列**。说明安装或到桌面粘贴扩展 ID。填写不受影响 | — |
+| **曾经配对，桌面暂不可用** | pairing 记录存在，但 host 拉起失败 / 握手超时 / 管道断开 | **持久化 SaveIntent**，UI「待同步（尚未绑定申请）」。不调用 `queryCandidates`，不铸申请 UUID，不盖 restoreEpoch | 桌面恢复 → 握手 → 若 epoch 与已有 **绑定** 队列冲突则先暂停那些绑定项 → 对每条意图：`queryCandidates` → 用户消歧 → 派发 `job.save`（此时才有 `messageId` + 身份盖章） |
+| **已配对且握手成功** | 握手返回兼容协议 | 可直接 `queryCandidates`；用户选绑定后再写 Bound outbox 并发送。意图可跳过或瞬间转换 | — |
+| **协议不兼容** | 握手返回区间不交 | **不把意图升级为绑定消息**，也不发送。已有意图保留并提示升级；未配对路径仍不建新意图 | 升级后再走「桌面恢复」列 |
+
+`handshake` 与 `application.queryCandidates` 始终是 **读**，不单独构成「已保存」。
+
+#### 5.2.4 取消、队列满、应答丢失、重复点击
+
+- **取消字段确认：** 不写意图。
+- **取消候选选择器：** 若此次从「桌面已可用」路径进来、尚未派发 `job.save`：不写绑定消息。若本就是离线意图在桌面恢复后弹出选择器：取消 = 意图保持 pending，不绑定、不丢字段。
+- **用户删除某条待同步意图：** 删除意图；若已有部分上传的快照暂存，按 §8.5 清理规则。
+- **队列满：** 产品上限建议 100 条意图 + 100 条绑定消息（D07 可调，须有数）。满时 **拒绝新增** 并提示处理，**不静默丢旧项**，**不阻止**原有填表。
+- **应答丢失：** 绑定消息用同一 `messageId` 重试。桌面按 `(clientInstanceId, messageId, restoreEpoch)` 幂等：相同载荷返回原 `resultId`；冲突拒绝。意图没有桌面幂等键，桌面恢复后只转换一次。
+- **重复点击「保存岗位」：** 同一页短时间内（建议 10 s）已有 pending 意图且规范化三元组相同 → 提示已有待同步意图，不第二份；用户明确「再存一次」才新 `intentId`（对应走查 10.4 的再投）。
 
 ```mermaid
 sequenceDiagram
   participant U as 用户
   participant CS as content.js
   participant SW as background.js
-  participant H as native-host.exe
-  participant APP as Tauri EXE
-  U->>CS: 保存岗位到本地（确认字段）
+  participant H as NM host
+  participant APP as 应用进程唯一写入者
+  U->>CS: 确认保存字段
   CS->>CS: 剥离 URL 秘密参数
-  CS->>SW: runtime.sendMessage
-  SW->>SW: 探测：host 注册？本 origin 已配对？
-  alt 未安装或未配对
-    SW-->>U: 安装说明 / 粘贴扩展 ID（不写 outbox）
-  else 已安装已配对
-    SW->>H: Native Messaging handshake（读，不是配对，不入队）
-    alt 协议不兼容
-      SW-->>U: 提示升级（不入队）
+  CS->>SW: 保存意图
+  SW->>SW: 探测：安装？曾经配对？
+  alt 未安装或从未配对
+    SW-->>U: 安装 / 粘贴扩展 ID（不写意图）
+  else 曾经配对
+    SW->>SW: 持久化 SaveIntent（intentId，无申请 UUID）
+    SW-->>U: 待同步（尚未绑定申请）
+    SW->>H: 尝试 handshake（失败也保留意图）
+    alt 握手失败或超时
+      Note over SW: 意图待桌面恢复；禁止显示桌面已保存
+    else 协议不兼容
+      SW-->>U: 提示升级（意图保留，不升级为 job.save）
     else 握手成功
-      SW->>SW: 比对已有 outbox 上的 archiveId/generation
-      alt 身份不匹配
-        SW-->>U: 暂停旧队列：关联 / 丢弃 / 另存
-      else 身份匹配或队列空
-        alt EXE 未运行
-          H->>APP: 按需启动 Tauri EXE（可隐藏）
-        end
-        SW->>H: application.queryCandidates（读，不入队）
-        APP-->>SW: exact[] + sameCompany[]
-        U->>CS: 使用已有 / 新建 / 取消
-        alt 取消
-          Note over SW: 不写 outbox
-        else 使用已有或新建
-          SW->>SW: 此时才写入 outbox（固定 messageId，盖上当前 archiveId/generation）
-          SW->>H: job.save
-          APP-->>SW: 提交后的 resultId
-          SW->>SW: 删除对应 outbox 项
-          SW-->>U: 桌面已保存（stage=saved，非已投递）
-        end
+      SW->>SW: 绑定队列 epoch 检查
+      SW->>H: application.queryCandidates（读）
+      APP-->>SW: exact[] + sameCompany[]
+      U->>CS: 使用已有 / 新建 / 稍后再说
+      alt 稍后再说
+        Note over SW: 意图保持 pending
+      else 使用已有或新建
+        SW->>SW: 写 Bound outbox（messageId，盖 archiveId+restoreEpoch）
+        SW->>H: job.save
+        APP-->>SW: applicationId + resultId
+        SW->>SW: 删除意图与对应绑定项
+        SW-->>U: 桌面已保存（stage=saved，非已投递）
       end
     end
   end
 ```
 
-「桌面已保存」只在持久化应答之后显示。已入队但未提交时显示「待同步」，不得假成功。取消选择器不会留下 `job.save` 队列项。
 
 ### 5.3 证据 + AI 建议
 
@@ -174,6 +214,28 @@ flowchart TD
   J -->|否| K[证据已存 阶段不变]
   J -->|是| L[同一事务: Event + stage 投影 + Todo]
 ```
+
+### 5.4 提醒与进程生命周期（共同语义）
+
+五种用户/系统状态必须分开，禁止混用文案：
+
+| 状态 | 含义 | 待办列表 | 系统通知 | 插件保存 |
+| --- | --- | --- | --- | --- |
+| **关闭窗口** | UI 不可见；应用进程可按平台习惯退到托盘/菜单栏或仅隐藏窗口 | 可用（再打开窗口） | 若已启用后台提醒：已登记的系统调度仍有效 | host 仍可按需拉起应用进程 |
+| **后台提醒已启用** | 用户在设置中打开，并 **授予** 系统通知权限 | 可用 | 到期项写入 OS 调度；**不依赖**进程一直活着 | 正常 |
+| **用户明确退出** | 托盘/菜单栏「退出」或等效 | 下次启动仍在 | **取消尚未触发的系统调度**（或按设置保留；默认取消并在退出前告知「退出后不会弹出面试提醒」） | 下次由 host 按需拉起（若仍配对） |
+| **休眠 / 重启 / 关机** | OS 生命周期 | 磁盘上仍在 | 已登记的系统调度：由 OS 决定。Windows 计划 Toast 有约 5 分钟投递窗口，关机过久可能丢（**待验证于本机**，官方如此说明）。重启后应用 **不**偷偷设开机启动去补火 | 重启后需再握手 |
+| **未授权通知** | 用户拒绝或从未授予系统通知 | **必须仍可用** | 不弹。设置页说明「待办在，提醒不会出现」 | 无关 |
+
+共同规则：
+
+1. 关窗 ≠ 退出 ≠ 关机。
+2. 不把「闲置 N 分钟后退出进程」当成日程系统。进程空闲退出 **可以**存在（省资源），但次日面试必须走系统调度。
+3. 不偷偷开机启动、不偷偷注册 Login Item / 计划任务「保活」。
+4. 未授权通知时，应用内待办、逾期标记、打开应用后的一次汇总，仍然要做（D10）。
+5. 通知正文默认不含简历/邮件正文。
+
+平台实现差异见 [ADR §3.8](adr-architecture.md#38-提醒与后台-平台实现)。
 
 ---
 
@@ -228,25 +290,40 @@ saved → filling → submitted → assessment → interview → offer
 任意阶段 --stage_corrected--> 任意阶段（需原因）
 ```
 
-### 6.3 第二维度：回复证据状态
+### 6.3 第二维度：回复证据状态（业务类型 ≠ 发送方式）
 
-与流程阶段独立。`replyEvidenceState` 只折叠 **已关联到该申请、且已确认** 的证据上的 `replyClass`（不是 `kind`，也不是未确认的 AI 建议）。证据本身不蕴含阶段。
+与流程阶段独立。证据本身不蕴含阶段。
 
-对一条申请，令 `C` 为上述 `replyClass` 的集合，并 **忽略** `unknown` 与空：
+两条正交字段：
 
-| `C` 的内容 | `replyEvidenceState` |
+| 字段 | 含义 | 取值 |
+| --- | --- | --- |
+| `replyClass` | **通知业务类型** | `auto_ack` / `assessment_invite` / `interview_invite` / `action_required` / `offer` / `reject` / `other` / `unknown` |
+| `sendMode` | **发送方式** | `human` / `automated` / `unknown` |
+
+面试邀请、测评、Offer、拒信都 **可能由 ATS 自动发出**。因此：
+
+- **禁止**仅凭 `replyClass=interview_invite`（或测评/Offer/拒信）投影成「人工回复」。
+- 发送方式无法判断时 `sendMode=unknown`，**不捏造** `human`。
+- 旧值 `human_reply` **不再**作为 `replyClass` 或 `replyEvidenceState`。
+
+`replyEvidenceState` 只折叠 **已关联到该申请、且已确认** 的证据上的 `replyClass`（不是 `kind`，不是 `sendMode`，也不是未确认的 AI 建议）。忽略 `unknown` 与空：
+
+| 已确认 `replyClass` 集合 `C` | `replyEvidenceState` |
 | --- | --- |
 | 没有非空、非 `unknown` 的 `replyClass` | `none_imported` |
 | 只有 `auto_ack` | `auto_ack` |
-| 含 `{human_reply, assessment_invite, interview_invite, action_required, offer, reject, other}` 之一，且 **没有** `auto_ack` | `human_reply` |
-| 同时有 `auto_ack` 与上一行任一人工作类 | `mixed` |
+| 含 `{assessment_invite, interview_invite, action_required, offer, reject, other}` 之一，且 **没有** `auto_ack` | `classified` |
+| 同时有 `auto_ack` 与上一行任一业务类 | `mixed` |
 
 | code | 展示 | 规则 |
 | --- | --- | --- |
 | `none_imported` | 尚未导入回复证据 | 默认。禁止写成「对方未回复」 |
 | `auto_ack` | 已导入自动回执 | 不移动到 `interview`，不暗示通过筛选 |
-| `human_reply` | 已导入人工回复 | 含面试/测评/Offer/拒信等人工类；仍需用户确认才改 **阶段** |
-| `mixed` | 回执与人工回复均有 | 列表可用摘要，详情看时间线 |
+| `classified` | 已导入分类通知 | 详情展示具体 `replyClass`（如「面试邀请」）。`sendMode` 另栏显示「人工 / 自动 / 未知」 |
+| `mixed` | 回执与其他分类通知均有 | 列表可用摘要，详情看时间线 |
+
+列表不得把 `classified` 写成「已导入人工回复」。
 
 ---
 
@@ -289,13 +366,15 @@ saved → filling → submitted → assessment → interview → offer
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
-| `archiveId` | 本档案实例 UUID。恢复 **保留 backup 的值**，不新铸 | 是 | system | immutable | public-meta |
-| `generation` | 单调递增；每次恢复 **必 +1** | 是 | system | mutable（仅系统提升） | public-meta |
+| `archiveId` | 档案内容谱系 UUID。备份 **包含** 它；恢复 **保留 backup 的值**，不新铸 | 是 | system | immutable | public-meta |
+| `restoreEpoch` | 当前指针身份。每次 **成功切换 current 指针** 新铸 UUID。**不写入备份包**，不从备份拷贝 | 是 | system | mutable（仅切换 current 时新铸） | public-meta |
 | `schemaVersion` | 逻辑/物理 schema 版本 | 是 | system | mutable（迁移） | public-meta |
 | `createdAt` | 档案创建 UTC | 是 | system | immutable | public-meta |
 | `displayName` | 用户可见档案名 | 否 | user | mutable | public-meta |
 
-同一时刻桌面只把 **一个** 档案标为 current。插件握手拿到的就是 current 的 `archiveId`+`generation`。
+同一时刻桌面只把 **一个** 档案标为 current。插件握手拿到的是 current 的 `archiveId` + `restoreEpoch`。
+
+`restoreEpoch` 存在机器本地的 current 指针文件（见 [data-privacy.md §6.5](data-privacy.md#65-恢复)），**不是** backup 内 `generation+1`。重复恢复同一备份会得到 **不同** epoch，旧队列不会因「还是 A1、generation 都变成 4」而被静默接受。不再使用 `generation` 做握手隔离（若 D03 仍保留整数计数，只作内部迁移序号，不进 NM 握手）。
 
 ### 8.2 Application
 
@@ -362,14 +441,15 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 
 ### 8.4 ReplyEvidence 与 AttachmentBlob
 
-附件字节在库外。`kind` 是 **获取/格式**，`replyClass` 是 **语义**（确认后才写）。`replyEvidenceState` 按 §6.3 从已关联、已确认的 `replyClass` 投影（`unknown`/空不计数）。一封面试邮件可以同时是 `kind=eml` 与 `replyClass=interview_invite`，此时该申请的 `replyEvidenceState=human_reply`。
+附件字节在库外。`kind` 是 **获取/格式**，`replyClass` 是 **通知业务类型**，`sendMode` 是 **发送方式**（确认后才写；无法判断则为 `unknown`）。`replyEvidenceState` 按 §6.3 只从已关联、已确认的 `replyClass` 投影（`unknown`/空不计数）。一封 ATS 自动发出的面试邮件可以同时是 `kind=eml`、`replyClass=interview_invite`、`sendMode=automated`；该申请的 `replyEvidenceState=classified`，**不是**「人工回复」。
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
 | `evidenceId` | UUID | 是 | system | immutable | public-meta |
 | `applicationId` | 可空（收件箱未关联） | 否 | user | mutable（改关联） | public-meta |
 | `kind` | 获取格式：`eml` / `screenshot` / `pdf` / `paste` / `unknown` | 是 | import/system | immutable | public-meta |
-| `replyClass` | 语义：`auto_ack` / `human_reply` / `assessment_invite` / `interview_invite` / `action_required` / `offer` / `reject` / `other` / `unknown`；确认前可空 | 否 | user / ai_suggest+confirm | mutable 至确认 | public-meta |
+| `replyClass` | 业务类型：`auto_ack` / `assessment_invite` / `interview_invite` / `action_required` / `offer` / `reject` / `other` / `unknown`；确认前可空 | 否 | user / ai_suggest+confirm | mutable 至确认 | public-meta |
+| `sendMode` | 发送方式：`human` / `automated` / `unknown`。无法判断时必须 `unknown`，禁止因 `replyClass` 捏造 `human` | 否 | user / ai_suggest+confirm | mutable 至确认 | public-meta |
 | `blobSha256` | 指向 AttachmentBlob | 是 | system | immutable | public-meta |
 | `originalFilename` | 导入时文件名 | 否 | import | immutable | PII |
 | `importedAt` | UTC | 是 | system | immutable | public-meta |
@@ -404,7 +484,31 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `createdAt` | UTC | 是 | system | immutable | public-meta |
 | `byteSize` | 用于超限判断 | 是 | system | immutable | public-meta |
 
-快照内容是 PII。默认填写留档 **不把逐字段值塞进 `fill.submit` 信封**；快照文件由用户在归档时确认后经 `snapshot.chunk` 传输（每块 ≤ 64 KiB），或改在桌面导入。单份快照 **> 2 MiB 拒绝**，明确失败。Outbox 只存 `snapshotId`/`sha256`/分片游标，不把整份 blob 放进 `chrome.storage.local`。
+快照内容是 PII。默认填写留档 **不把逐字段值塞进 `fill.submit` 信封**。
+
+**生成时机：** 用户确认「本次留档」时，插件从 **当时** 的活模板做一份结构化拷贝（JSON，字段与 `normalizeTemplate` 一致），计算 `sha256` 与 `byteSize`，铸 `snapshotId`。这之后活模板再改，也 **不得**用新模板重生成该 `snapshotId`。
+
+**字节放哪：**
+
+| 阶段 | 字节位置 | 元数据位置 |
+| --- | --- | --- |
+| 刚确认留档、桌面可握手 | 经 `snapshot.chunk` 写入桌面 `snapshots/` | Bound outbox：`snapshotId` / `sha256` / `byteSize` / `chunkCursor` |
+| 曾配对但桌面暂不可用 | **扩展源 IndexedDB**（SW / offscreen / 扩展页可访问；**禁止**写在 content script 的页面源 IDB） | `chrome.storage.local` 只存元数据 + `staging=idb`，**不**存整份 blob（`chrome.storage.local` 约 10 MB 配额） |
+| 桌面已 ACK 完整快照 | 仅桌面档案 | 删除 IDB 项与绑定消息 |
+
+依据：[Chrome 扩展 Storage and cookies](https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies) — IndexedDB 在 SW 可用；content script 的 web storage 是 **宿主页面**源，不是扩展源。
+
+**配额与上限：** 单份 **> 2 MiB 拒绝**，明确失败，填表仍可用。暂存合计建议 ≤ 20 MiB 或 20 份（先到为准）。满：提示处理旧暂存，不覆盖、不从活模板另做一份顶掉。
+
+**过期：** 暂存超过 30 天仍未 ACK：下次打开插件时提示「有未完成的简历留档」，用户选继续发送 / 丢弃。到期 **不自动删** 未提示过的项。
+
+**部分上传：** `chunkCursor` 记录桌面已 ACK 的最后块号；重试从下一块开始，校验总 `sha256`。桌面在未收齐前不把快照标为完整。
+
+**清理：** 仅当 (1) 桌面 ACK 完整且哈希相符，或 (2) 用户明确丢弃该留档，或 (3) 用户确认过期提示中的丢弃。浏览器重启后 IDB 仍在，继续发 **原字节**。
+
+**失败降级：** IndexedDB 打开失败 → 本次留档失败并说明原因，**不**假装已暂存；填写本身成功。不把「只存了哈希」说成可以恢复文件。
+
+**权限：** D08 实现 IndexedDB 暂存时，若配额不够，可申请 `unlimitedStorage`（D08 的插件变更，不是 D01/0.3.0）。无该权限时仍须在产品上限内工作或明确失败。
 
 ### 8.6 Todo
 
@@ -422,7 +526,7 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `interviewRound` | 可选轮次 | 否 | user | mutable | public-meta |
 | `sourceEventId` | 创建来源 | 否 | system | immutable | public-meta |
 
-提醒能力依赖进程模型：窗口关闭但 Tauri EXE 后端仍在（托盘/idle 窗口期内）时可提醒；彻底退出或关机后 **v1 不保证** 提醒，且 **不得** 偷偷注册开机启动（D10 / ADR）。Idle 默认 15 分钟，见 ADR §3.4。
+提醒语义见 §5.4（关窗 / 启用后台提醒 / 主动退出 / 休眠重启关机 / 未授权通知）。**禁止**把「进程闲置 15 分钟内还活着」包装成可靠的次日面试提醒。**禁止**偷偷注册开机启动。启用后台提醒时，应把到期项登记到 **用户授权的系统调度通知**（Windows 计划 Toast / macOS `UNCalendarNotificationTrigger`）；进程可以随后退出。系统调度不是 100%：Windows 计划通知在关机超过约 5 分钟窗口时可能被丢弃（官方说明，见 ADR），产品文案必须写明，不得承诺「关机期间也一定送到」。
 
 ### 8.7 AiSuggestion
 
@@ -442,7 +546,7 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `modelLabel` | 用户配置的模型名 | 否 | system | immutable | public-meta |
 | `promptScope` | 外发范围摘要（非原文密钥） | 否 | system | immutable | public-meta |
 
-禁止字段：API Key、完整档案库、未选中申请的简历快照。D11 建议的分类写入 `ReplyEvidence.replyClass`（与 `kind` 分离），确认前不改正式阶段。
+禁止字段：API Key、完整档案库、未选中申请的简历快照。D11 建议分别给出 `replyClass` 与 `sendMode`（与 `kind` 分离）；无法判断发送方式则 `sendMode=unknown`。确认前不改正式阶段。
 
 ### 8.8 填写留档默认范围
 
@@ -483,23 +587,41 @@ erDiagram
   Todo }o--o| Event : sourced_from
 ```
 
-### 8.10 Plugin Outbox（逻辑对象，存在 `chrome.storage.local.desktopOutbox`）
+### 8.10 插件队列：SaveIntent 与 Bound outbox
 
-仅在 **host 已注册 ∧ 本 origin 已配对 ∧ 协议兼容 ∧ 用户已确认派发写入**（`job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm`）之后持久化。handshake 与候选查询不入队。每条记录盖上当时握手到的档案身份。
+存在 `chrome.storage.local` 的新 key：`desktopSaveIntents`、`desktopOutbox`、`desktopClientInstanceId`、`desktopPairing`（上次成功握手的 archiveId/restoreEpoch/时间，不作提交凭证）。**禁止**占用 `templates` / `activeTemplateId` / `aiConfig` / `resumeProUpdateCache` / `resumeProDismissedVersion`。
+
+**SaveIntent**（曾经配对且用户已确认字段；桌面不必当时可用）：
+
+| 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
+| --- | --- | --- | --- | --- | --- |
+| `intentId` | 意图 UUID | 是 | plugin | immutable | public-meta |
+| `clientInstanceId` | 见上 | 是 | plugin | immutable | public-meta |
+| `company` / `title` / `sourceUrl` / `location` | 用户确认的字段（URL 已脱敏） | 公司、岗位是 | user | immutable | PII |
+| `createdAt` | 确认时刻 UTC | 是 | plugin | immutable | public-meta |
+| `lastSeenArchiveId` | 上次成功握手的 archiveId，仅提示 | 否 | cache | mutable | public-meta |
+| `status` | `pending_desktop` / `pending_bind` / `cancelled` | 是 | plugin | mutable | public-meta |
+
+意图 **没有** `messageId`、申请 UUID、`restoreEpoch`。它 **不是** NM 消息类型。
+
+**Bound outbox**（用户已完成绑定，可按协议重试）：
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
 | `messageId` | 幂等键之一 | 是 | plugin | immutable | public-meta |
-| `clientInstanceId` | 每扩展安装/Profile 一次的 UUID（`desktopClientInstanceId`） | 是 | plugin | immutable | public-meta |
+| `intentId` | 来源意图（若有） | 否 | plugin | immutable | public-meta |
+| `clientInstanceId` | 每扩展安装/Profile 一次 | 是 | plugin | immutable | public-meta |
 | `messageType` | 与 ADR 枚举相同 | 是 | plugin | immutable | public-meta |
 | `archiveId` | 入队时握手到的档案 | 是 | handshake | immutable | public-meta |
-| `generation` | 入队时握手到的代 | 是 | handshake | immutable | public-meta |
-| `payload` | 业务载荷，**无** Key/密码 | 是 | plugin | immutable | PII |
+| `restoreEpoch` | 入队时握手到的指针身份 | 是 | handshake | immutable | public-meta |
+| `applicationId` | 「使用已有」时已有；「新建」可在 ACK 后回填 | 视类型 | plugin/desktop | 回填一次 | public-meta |
+| `payload` | 业务载荷，**无** Key/密码/快照字节 | 是 | plugin | immutable | PII |
+| `snapshotId` / `sha256` / `byteSize` | 若本次含快照 | 否 | plugin | immutable | public-meta |
+| `chunkCursor` | 已 ACK 的最后块号 | 否 | plugin | mutable | public-meta |
 | `createdAt` | 入队 UTC | 是 | plugin | immutable | public-meta |
 | `bytes` | payload 序列化字节数 | 是 | plugin | immutable | public-meta |
-| `chunkCursor` | `snapshot.chunk` 已确认的最后序号；非分片则为空 | 否 | plugin | mutable | public-meta |
 
-恢复后：握手 **成功** 并返回新 `(archiveId, generation)`；插件比较每条 outbox 上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。关联通过 `outbox.reconcile` 查询哪些 `messageId` 已在恢复库中。服务端幂等是安全网，不是「静默重放许可」。
+恢复后：握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。插件比较每条 **绑定** 消息上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。意图不盖 epoch，恢复后重新走候选，不自动当成已绑定。关联通过 `outbox.reconcile` 查询哪些 `messageId` 已在 **当前 epoch** 的库中。桌面幂等键是 `(clientInstanceId, messageId, restoreEpoch)`：epoch 不同则 **不是** 当前档案的重放，返回 `restore_epoch_mismatch`，不得当成成功幂等。
 
 ---
 
@@ -507,21 +629,21 @@ erDiagram
 
 | 模式 | 插件填写/模板/AI | 保存岗位 / 确认投递 | 桌面档案 | AI 建议 |
 | --- | --- | --- | --- | --- |
-| 未安装桌面 | 与今天相同 | 说明如何安装；**不建 durable outbox**；不得说已保存 | 无 | 无 |
-| 已安装但未配对 | 正常 | 说明在桌面粘贴扩展 ID；**不建 durable outbox**；**不得**说「未安装」 | 本地手动可用 | 桌面侧可用 |
-| 已安装已配对但未运行 | 正常 | host 按需启动 Tauri EXE；失败则 **durable 入队** +「待同步」 | 拉起后可用 | 拉起后可用 |
-| 离线（无互联网） | 本地匹配仍可用；上游 AI 失败 | 已配对则可入队 | 导入/待办/改阶段全部可用 | 禁用并给出原因 |
+| 未安装 / 从未配对 | 与今天相同 | 说明安装或粘贴 ID；**不建意图、不建绑定队列**；不得说已保存 | 无桌面档案 | 无 |
+| 已安装但未配对 | 正常 | 说明在桌面粘贴扩展 ID；**不建意图**；**不得**说「未安装」 | 本地手动可用 | 桌面侧可用 |
+| 曾经配对，桌面暂不可用 | 正常 | **持久化 SaveIntent** +「待同步（尚未绑定申请）」；禁止「桌面已保存」。快照字节进 IndexedDB | 拉起后可用 | 拉起后可用 |
+| 离线（无互联网） | 本地匹配仍可用；上游 AI 失败 | 同「曾经配对」：意图可入；绑定消息需桌面 | 导入/待办/改阶段全部可用 | 禁用并给出原因 |
 | AI 不可用 | 现有：保留已验证本地匹配 | 与 AI 无关 | 手动阶段/证据可用 | 建议失败开放 |
-| 协议不兼容 | 填写不受影响 | **不入队**；提示升级 | 本地手动可用 | 本地手动可用 |
-| `generation` 不匹配 | 填写不受影响 | 握手成功；**暂停旧队列**；关联/丢弃/另存 | 以桌面 current 为准 | 正常 |
+| 协议不兼容 | 填写不受影响 | 意图保留；**不升级为 job.save**；提示升级 | 本地手动可用 | 本地手动可用 |
+| `restoreEpoch` 不匹配 | 填写不受影响 | 握手成功；**暂停绑定队列**；意图重新走候选 | 以桌面 current 为准 | 正常 |
 
-队列容量满：停止新增留档并提示，不静默丢旧项，**不阻止**原有填表（D07）。
+队列容量满：停止新增意图/留档并提示，不静默丢旧项，**不阻止**原有填表（D07）。
 
 ---
 
 ## 10. 合成走查（强制）
 
-下列使用合成数据，不读取真实简历或邮箱。每个走查列出对象、阶段、事件、证据、待办和用户选择。
+下列使用合成数据，不读取真实简历或邮箱。每个走查列出对象、阶段、事件、证据、待办和用户选择。10.9–10.13 是本轮强制补测。
 
 ### 10.1 同公司两岗 + 无岗位名的面试邮件
 
@@ -535,7 +657,7 @@ erDiagram
 | 4 | 确认投递 B | `app-B` → `submitted` |
 | 5 | 导入面试邮件 | Evidence `ev-1`，`applicationId=null`，`kind=eml`，`replyClass` 空，收件箱可见 |
 | 6 | 可选 AI | 建议 `candidateApplicationIds=[UUID1,UUID2]`，`replyClass=interview_invite`，`uncertainties` 含「无岗位名」；**不自动选** |
-| 7 | 用户把 `ev-1` 关联到 `app-A` 并确认「面试 一面」 | Event `evidence_associated`、`interview_recorded`（round=1）；`replyClass=interview_invite`；`app-A` stage=`interview`（set-absolute）；**`app-A.replyEvidenceState=human_reply`**（§6.3：`interview_invite` ∈ 人工类且无 `auto_ack`）；Todo「一面」；`app-B` 的 `replyEvidenceState` 仍 `none_imported` |
+| 7 | 用户把 `ev-1` 关联到 `app-A` 并确认「面试 一面」 | Event `evidence_associated`、`interview_recorded`（round=1）；`replyClass=interview_invite`；`sendMode=unknown`（正文看不出是人还是 ATS）；`app-A` stage=`interview`；**`app-A.replyEvidenceState=classified`**（不是「人工回复」）；Todo「一面」；`app-B` 仍 `none_imported` |
 
 禁止：只因公司名相同把邮件归到最近一条申请。
 
@@ -595,28 +717,84 @@ erDiagram
 - 若纠错 **之后** 又来一条更晚的 `assessment_recorded`，折叠会把 current 设为 `assessment`——纠错 **不**永远压过未来事件。
 - 若再次纠回 `rejected`，再追加一条 `stage_corrected`，不删除前两条。
 
-### 10.7 桌面未安装 / 未运行 / 离线 / AI 宕机
+### 10.7 桌面未安装 / 从未配对 / 曾经配对但不可用 / AI 宕机
 
-| 场景 | 期望 |
+| 场景 | 用户看见 | 保存了什么 | 失败后如何恢复 |
+| --- | --- | --- | --- |
+| 未安装 / 从未配对 | 填写与今天一致。保存入口说明安装或粘贴 ID。**不是**「待同步」 | 无意图、无绑定队列 | 装好并配对后重新点保存 |
+| 已安装未配对 | 同上填写。文案「请在桌面粘贴扩展 ID」，**不得**显示「未安装」 | 无意图 | 粘贴 ID、重载扩展后再保存 |
+| 曾经配对，应用进程未运行且拉起失败 | 「待同步（尚未绑定申请）」**禁止**「桌面已保存」 | SaveIntent（字段 + intentId），无申请 UUID | 打开桌面后弹出候选，绑定后才 `job.save` |
+| 无互联网 | 桌面手动档案可用。插件 AI 走现有错误 | 同曾经配对：意图可入 | 联网后 AI 另说；意图不依赖网 |
+| AI 宕机 | 桌面建议失败开放。插件「取消 AI 等待（保留本地匹配）」 | 证据与手动阶段不受影响 | 换模型或手改 |
+
+### 10.8 恢复身份与旧队列（含重复恢复同一备份）
+
+**设定：** 绑定队列有 `messageId=M1` 的 `job.save`，盖着 `archiveId=A1, restoreEpoch=E1`。备份 B 含 A1（**不含** E1）。
+
+**第一次恢复 B：**
+
+- 预览 → 确认 → 解压到 **新目录**，旧 current 挪到 retired。
+- 新铸 `restoreEpoch=E2`（UUID），写入机器本地 current 指针。`archiveId` 仍为 A1。
+- 握手成功，返回 `(A1, E2)`。握手不因 epoch 变化失败。
+- M1 盖章 `(A1, E1)` ≠ `(A1, E2)` → **暂停**绑定队列。
+- 用户三选：关联 / 丢弃 / 另存。关联调用 `outbox.reconcile`；已在 **当前 epoch 库** 中的 messageId 不再重放。
+- 若此时桌面在用户确认前就收到 M1：返回 `restore_epoch_mismatch`，**不得**按 `(clientInstanceId, messageId)` 当成成功幂等。
+
+**再次用同一备份 B 恢复：**
+
+- 再铸 `restoreEpoch=E3`，**不是** E2，也不是「backup 里没有 generation 就当 1」。
+- 盖着 E1 或 E2 的队列都不匹配 E3。
+- **证明无碰撞：** 两次恢复同一 B 得到 E2 ≠ E3；旧 M1 永远不会因为「archiveId 还是 A1」被静默接受。
+
+**恢复到新机器：** 新机器没有 E1 指针，铸 E4。旧机器插件仍持 E1；两边互不相认。
+
+**恢复失败回滚：** 校验失败则 **不切换** current 指针，E1 仍有效，绑定队列可继续。已切换后用户选回滚：再切回 retired 目录时 **新铸 E5**（指向旧文件），不复用 E1（避免插件已按 E2 对账后又被 E1 静默收下）。
+
+**意图：** 无 epoch 盖章；恢复后重新 `queryCandidates`，不自动绑定。
+
+### 10.9 桌面不可用时保存岗位（强制走查）
+
+**设定：** 用户上周已配对。今天主程序未开，host 拉起失败。
+
+| | |
 | --- | --- |
-| 未安装 | 填写、模板、插件 AI 与今天一致。保存入口说明安装；**不写 durable outbox**；不假装已保存 |
-| 已安装未配对 | 同上填写。入口说明到桌面粘贴扩展 ID（Chrome/Edge 各一次）。**不写 durable outbox**。**不得**显示「未安装」 |
-| 已安装已配对未运行 | host 按需启动 Tauri EXE（可隐藏）。成功则保存；失败则 durable 入队 +「待同步」，**禁止**显示「桌面已保存」 |
-| 离线 | 桌面列表/详情/导入/待办/改阶段可用。插件 AI 走现有错误路径。**仅已配对**的保存请求入队 |
-| AI 宕机 | 桌面建议失败开放。证据与手动改阶段不受影响。插件「取消 AI 等待（保留本地匹配）」保持 |
+| 用户看见 | 字段确认框照常。确认后侧边栏「待同步（尚未绑定申请）」+ 待同步计数 +1。**不是**「桌面已保存」 |
+| 保存了什么 | `SaveIntent`：intentId=I1，公司/岗位/URL。无申请 UUID，无 restoreEpoch，无 `job.save` |
+| 失败后如何恢复 | 打开桌面 → 握手 → 两层候选。用户选新建 → Bound `job.save`（新 messageId=M2，盖当前 epoch）→ ACK 后「桌面已保存」，stage=`saved`。若用户取消候选：意图仍 pending |
 
-### 10.8 恢复档案后的旧插件队列
+### 10.10 离线留档后改模板（强制走查）
 
-**设定：** 插件 outbox 有 `messageId=M1` 的 `job.save`，记录上盖着 `archiveId=A1, generation=3`。用户用该档案的备份恢复。
+**设定：** 模板 v1 填写成功。用户确认留档时桌面不可用。随后把活模板改成 v2。
 
-- 恢复预览 → 确认 → **解压到新档案目录**，current 指针切换，**`archiveId` 仍为 backup 中的 A1**，`generation` **必** 从 3 增到 4；旧目录保留为回滚点。
-- 插件下次 **握手成功**，返回 `(A1, 4)`。握手不因 generation 变化失败。
-- 插件比较 M1 上盖的 `(A1, 3)` ≠ 当前 `(A1, 4)` → **暂停**旧队列（不清掉存储）。
-- UI 三选：
-  - **关联：** 采用新握手身份；调用 `outbox.reconcile([M1,…])`；已在恢复库中的 messageId 不再重放；未包含的项需用户逐条确认后作为新写入（默认不自动重放）。
-  - **丢弃：** 删除旧队列项，不写入。
-  - **另存：** 把队列项当作对新 generation 的新申请（新 `messageId` 或用户确认的强制新写），仍走两层候选。
-- **禁止** 把 generation=3 的项在用户确认前自动打进 generation=4。服务端幂等只防止确认后的重复提交。
+| | |
+| --- | --- |
+| 用户看见 | 留档确认时「待同步（快照已暂存）」；改模板不提示「历史快照会变」 |
+| 保存了什么 | 确认瞬间从 v1 拷贝的字节进扩展源 IndexedDB，key=`snapshotId=S1`，sha256=H1。storage 里只有元数据 |
+| 失败后如何恢复 | 桌面回来后按 S1 **原字节** 分片上传，ACK 后桌面打开的是 v1。禁止从 v2 重算。若 IDB 被清：明确「快照暂存丢失，请重新留档或在桌面导入」，不静默用 v2 |
+
+### 10.11 次日面试提醒（强制走查）
+
+**设定：** 今天 21:00 用户为 `app-A` 建待办「一面，明天 10:00」，并 **启用后台提醒、授予系统通知**。然后关窗，23:00 明确未点「退出」。次日 10:00 前进程可能已因空闲退出。
+
+| | |
+| --- | --- |
+| 用户看见 | 关窗后设置页曾说明「提醒由系统发送，不需要窗口开着」。次日约 10:00 系统通知（标题含公司/岗位，无简历正文）。点通知可打开应用进该申请 |
+| 保存了什么 | Todo 在 SQLite；一条 OS 计划通知登记。**不是**「15 分钟 idle 内进程还活着所以能提醒」 |
+| 失败后如何恢复 | 若未授权通知：待办仍在，打开应用有逾期汇总，文案「系统通知未授权」。若用户昨晚点了「退出」：默认已取消未触发的计划通知，设置/退出对话框已告知。若整晚关机且超过 Windows 计划 Toast 投递窗口：可能丢，打开应用后补一次汇总，**不**假装一定送到。macOS 日历触发在重启后通常仍在（**待验证**） |
+
+### 10.12 重复恢复同一备份（强制走查）
+
+见 10.8 第二次恢复。用户看见「检测到插件有盖着旧 restoreEpoch 的待同步项」，必须三选。保存了新 epoch 的 current 指针。失败（损坏包）则 current 不变。
+
+### 10.13 自动发送的面试邀请（强制走查）
+
+**设定：** 导入星河科技 ATS 发出的「面试邀请」邮件（典型自动信）。
+
+| | |
+| --- | --- |
+| 用户看见 | 收件箱预览。AI 建议 `replyClass=interview_invite`，`sendMode=automated`（或 `unknown` 若模型不确定）。详情 **禁止**写「人工回复」。用户确认后列表 `replyEvidenceState=classified`，副文案「面试邀请（自动发送）」 |
+| 保存了什么 | Evidence + 确认后的 class/mode；阶段仅在用户确认「记为面试」后才 `interview` |
+| 失败后如何恢复 | 模型失败：证据仍在，用户可手选业务类型与发送方式。不得因「这是面试邀请」自动填 `sendMode=human` |
 
 ---
 
@@ -628,8 +806,10 @@ erDiagram
 | 「已通过筛选」（仅因回执） | 「已导入自动回执」 |
 | 填写成功后自动显示「已投递」 | 「填写完成（未确认投递）」 |
 | 「本地应用 = AI 全部离线」 | 使用云端模型时展示外发范围与服务商 |
-| 未持久化应答显示「桌面已保存」 | 「待同步」/ 错误码 |
+| 未持久化应答显示「桌面已保存」 | 意图：「待同步（尚未绑定申请）」；绑定后未 ACK：「待同步」 |
 | 把未配对说成「未安装」 | 「请在桌面主程序粘贴扩展 ID」 |
+| 把面试邀请写成「人工回复」 | 「面试邀请」+ 发送方式「人工 / 自动 / 未知」 |
+| 「关窗后 15 分钟内会提醒」当日程承诺 | 「已启用系统提醒」或「未授权 / 已退出，不会弹出」 |
 
 空列表、存储失败、目录不可写必须可操作，禁止静默切到临时目录（D02）。
 
@@ -637,13 +817,14 @@ erDiagram
 
 ## 12. 最低环境与发行（产品口径）
 
-| 项 | MVP 口径 |
+| 项 | 建议口径（正式覆盖范围见开放问题） |
 | --- | --- |
-| OS | Windows 10 22H2 或更新，64 位。Windows 11 含 WebView2；Win10 大多数已有 Runtime，安装器仍应能引导安装（见 ADR） |
-| 浏览器 | Chrome / Edge **116+**（与当前 `minimum_chrome_version` 一致） |
-| 权限 | 日常使用不要求管理员；per-user 安装 |
-| 签名 | 未持有代码签名证书前 **不宣传已签名**；文档必须写明 SmartScreen 对未签名 `setup.exe` 的警告 |
-| 离线 | 档案、导入、待办、手动阶段：可用。云端 AI：不可用并说明原因 |
+| OS | **Windows 10 22H2+ x64**；**macOS 11+**（Tauri 2 默认可到 10.13，本项目建议 11 以便 Apple Silicon 主路径）。Linux 非首版 |
+| CPU | Windows：x64；ARM64 **待验证**。macOS：**Apple Silicon 一等公民**；Intel 走 universal 或单独构建，**待验证** |
+| 浏览器 | Chrome / Edge **116+**。macOS 同样。**不默认承诺 Safari** |
+| 安装 | Windows：NSIS per-user（日常不要求管理员）。macOS：`.app` / `.dmg`。是否另发 Windows MSI、正式版是否双平台同发 → 开放问题 |
+| 签名 | Windows：无证书前不宣传已签名，须写 SmartScreen。macOS：分发须代码签名与公证（[Tauri macOS signing](https://v2.tauri.app/distribute/sign/macos/)）；无公证时写明 Gatekeeper 拦截，不假装「已公证」 |
+| 离线 | 档案、导入、待办、手动阶段：可用。云端 AI：不可用并说明原因。意图队列不依赖互联网 |
 | 插件分发 | 继续独立 ZIP；不装桌面也能填表 |
 
 负载预期：单用户、一季秋招约数十至数百条申请，不是服务器 QPS。列表查询目标：数百条申请过滤/搜索在本地 **100 ms 量级**（D03/D04 验证，非 D01 实现）。
@@ -656,9 +837,11 @@ erDiagram
 | --- | --- | --- |
 | 高 | 用户把填写成功当成已投递 | 默认 `saved`；独立确认；文案冻结 |
 | 高 | 按公司自动合并导致通知串岗 | UUID 身份；候选提示；AI 强制消歧 |
-| 中 | 未打包扩展 ID 漂移 / 把未配对当成未安装 | 桌面粘贴 ID；未配对单独降级且不入队 |
-| 中 | 快照大于业务信封 | `snapshot.chunk`；> 2 MiB 拒绝；outbox 不存整 blob |
-| 低 | 托盘图标被用户视为广告 | 负责人可关托盘；见开放问题 |
+| 中 | 未打包扩展 ID 漂移 / 把未配对当成未安装 | 桌面粘贴 ID；未配对不建意图 |
+| 中 | 快照大于业务信封或桌面不可用时丢字节 | 确认时写入 IndexedDB；> 2 MiB 拒绝；重试用原字节 |
+| 中 | 把 idle 退出当成次日提醒 | 系统调度通知；文案区分退出/未授权 |
+| 中 | 重复恢复同一备份复用 generation | `restoreEpoch` 每次切换新铸 |
+| 低 | 托盘/菜单栏被当成广告 | 可关；退出能力限制必须仍能看见 |
 
 ---
 

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -67,7 +67,7 @@
 - 云账号、云同步、多设备实时同步、团队协作（换电脑 = 备份恢复，不是云同步）
 - Linux 成品；Safari 扩展；默认承诺 App Store / Chrome Web Store 上架
 - 扩展商店上架与静默自动更新（检查更新仍可沿用插件现有 GitHub Release 提示）
-- 把「首个正式版必须双平台同一天交付」写成未确认承诺（见 [开放问题](downstream-decisions.md#需要项目负责人选择)）
+- 把「首个正式版必须双平台同一天交付」写成未确认承诺（见 [开放问题](downstream-decisions.md#4-需要项目负责人选择)）
 - `.msg` / Outlook 虚拟拖拽对象（不支持时提示导出 `.eml` 或粘贴正文）
 - 把当前开发者机器路径写进产品
 - 在 D01 修改插件权限、存储、功能或把 `manifest.json` 版本从 `0.3.0` 改掉
@@ -235,7 +235,7 @@ flowchart TD
 4. 未授权通知时，应用内待办、逾期标记、打开应用后的一次汇总，仍然要做（D10）。
 5. 通知正文默认不含简历/邮件正文。
 
-平台实现差异见 [ADR §3.8](adr-architecture.md#38-提醒与后台-平台实现)。
+平台实现差异见 [ADR §3.8](adr-architecture.md#38-提醒与后台平台实现)。
 
 ---
 
@@ -335,7 +335,7 @@ saved → filling → submitted → assessment → interview → offer
 
 - 公司名：去首尾空白、全半角、常见后缀（有限词表，如「有限公司」）折叠后再比；原始字符串始终保留。
 - 岗位名：去首尾空白、压缩空白。
-- URL：去掉 fragment；剥离已知密钥查询参数（见 [data-privacy.md](data-privacy.md#71-url-脱敏)）；host 小写。
+- URL：去掉 fragment；剥离已知密钥查询参数（见 [data-privacy.md](data-privacy.md#71-url-脱敏与去重-url)）；host 小写。
 
 保存时两层查询（同一最小元数据形状：id、公司、岗位、阶段、URL、更新时间；不把整库同步给插件）：
 
@@ -385,8 +385,8 @@ saved → filling → submitted → assessment → interview → offer
 | `companyNormalized` | 去重查询用 | 是 | system | mutable（随 company） | PII |
 | `title` | 岗位名（原始）。与公司连用可识别雇主关系，按 PII 处理 | 是 | user/plugin | mutable | PII |
 | `titleNormalized` | 去重查询用 | 是 | system | mutable | PII |
-| `sourceUrl` | 展示/存储用 URL（剥秘密参数，保留 ATS `code`/`key` 岗位号，见隐私 §7.1） | 否 | user/plugin | mutable | PII |
-| `dedupeUrl` | 身份规范化 URL（更窄剥离集） | 否 | system | mutable | PII |
+| `sourceUrl` | 展示/存储用 URL（默认剥离 `code`/`key` 等秘密参数，仅已审核的 ATS 规则例外，见隐私 §7.1） | 否 | user/plugin | mutable | PII |
+| `dedupeUrl` | 候选查询规范化 URL（与 sourceUrl 相同秘密剥离，再去跟踪参数） | 否 | system | mutable | PII |
 | `location` | 地点 | 否 | user/plugin | mutable | PII |
 | `notes` | 备注 | 否 | user | mutable | PII |
 | `currentStage` | 阶段投影（§6.2 折叠） | 是 | system | projected | public-meta |
@@ -453,11 +453,12 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `blobSha256` | 指向 AttachmentBlob | 是 | system | immutable | public-meta |
 | `originalFilename` | 导入时文件名 | 否 | import | immutable | PII |
 | `importedAt` | UTC | 是 | system | immutable | public-meta |
-| `sourcePathHint` | 仅导入瞬间；**不作为长期依赖** | 否 | import | immutable | PII |
 | `subject` / `fromAddr` / `sentAt` | 邮件头（若可解析） | 否 | import | immutable | PII |
 | `bodyExtract` | 本地提取的纯文本/清洗 HTML 转文本 | 否 | import | immutable | PII |
 
 **AttachmentBlob**（ER 中的字节实体）：
+
+`sourcePathHint` 不属于 ReplyEvidence 的长期字段：仅导入任务在内存中临时使用，导入完成、失败或取消后清除。不进入 D03 schema、SQLite、事件载荷、备份或诊断导出；错误提示使用安全文件名/错误代码，而不是原始绝对路径。
 
 | 字段 | 含义 | 必填 | 来源 | 可变性 | 敏感级 |
 | --- | --- | --- | --- | --- | --- |
@@ -492,9 +493,9 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 
 | 阶段 | 字节位置 | 元数据位置 |
 | --- | --- | --- |
-| 刚确认留档、桌面可握手 | 经 `snapshot.chunk` 写入桌面 `snapshots/` | Bound outbox：`snapshotId` / `sha256` / `byteSize` / `chunkCursor` |
+| 每次确认留档，无论桌面是否可握手 | **先**将不可变完整字节提交到扩展源 IndexedDB，成功后才能开始 `snapshot.chunk`；上传期间仍保留 IDB 副本 | 暂存记录持有 `snapshotId` / `sha256` / `byteSize` 与待建队列状态；Bound outbox 保存同一身份和游标 |
 | 曾配对但桌面暂不可用 | **扩展源 IndexedDB**（SW / offscreen / 扩展页可访问；**禁止**写在 content script 的页面源 IDB） | `chrome.storage.local` 只存元数据 + `staging=idb`，**不**存整份 blob（`chrome.storage.local` 约 10 MB 配额） |
-| 桌面已 ACK 完整快照 | 仅桌面档案 | 删除 IDB 项与绑定消息 |
+| 桌面已持久化完整快照且 ACK 总哈希相符 | 桌面档案为权威副本，此时才允许清理 IDB | ACK 状态先持久化，再清理 IDB/绑定项；中断后可幂等继续清理 |
 
 依据：[Chrome 扩展 Storage and cookies](https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies) — IndexedDB 在 SW 可用；content script 的 web storage 是 **宿主页面**源，不是扩展源。
 
@@ -503,6 +504,8 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 **过期：** 暂存超过 30 天仍未 ACK：下次打开插件时提示「有未完成的简历留档」，用户选继续发送 / 丢弃。到期 **不自动删** 未提示过的项。
 
 **部分上传：** `chunkCursor` 记录桌面已 ACK 的最后块号；重试从下一块开始，校验总 `sha256`。桌面在未收齐前不把快照标为完整。
+
+**统一写前暂存：** 在线开始后断线、SW 重启和浏览器重启与初始离线使用同一 IDB 原字节。分片 ACK 不是完整提交 ACK；完整 ACK 丢失时可按快照 ID/总哈希查询或重传，不能从活模板重建。IDB 与 `chrome.storage.local` 不具备跨库事务：IDB 暂存记录必须包含足够元数据，以便重启后修复缺失的 outbox 索引；有 outbox 但找不到原字节时暂停并报告失败，不假报可恢复。
 
 **清理：** 仅当 (1) 桌面 ACK 完整且哈希相符，或 (2) 用户明确丢弃该留档，或 (3) 用户确认过期提示中的丢弃。浏览器重启后 IDB 仍在，继续发 **原字节**。
 
@@ -540,6 +543,8 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `candidateApplicationIds` | 消歧列表，可多条 | 是 | ai_suggest | immutable | public-meta |
 | `suggestedStage` | 可空 | 否 | ai_suggest | immutable | public-meta |
 | `suggestedRound` | 可空 | 否 | ai_suggest | immutable | public-meta |
+| `suggestedReplyClass` | 建议的通知业务类型；取值同 ReplyEvidence.replyClass，无法识别为 `unknown` | 是 | ai_suggest | immutable | public-meta |
+| `suggestedSendMode` | 建议发送方式：`human` / `automated` / `unknown`；不得仅凭通知类型推断人工发送 | 是 | ai_suggest | immutable | public-meta |
 | `suggestedTodos` | 结构化待办草案 | 否 | ai_suggest | immutable | PII |
 | `excerptRefs` | 证据片段引用 | 否 | ai_suggest | immutable | PII |
 | `uncertainties` | 模型自报不确定点 | 否 | ai_suggest | immutable | public-meta |
@@ -547,6 +552,8 @@ MVP 事件类型（可在 D03 增补，但下列语义冻结）：
 | `promptScope` | 外发范围摘要（非原文密钥） | 否 | system | immutable | public-meta |
 
 禁止字段：API Key、完整档案库、未选中申请的简历快照。D11 建议分别给出 `replyClass` 与 `sendMode`（与 `kind` 分离）；无法判断发送方式则 `sendMode=unknown`。确认前不改正式阶段。
+
+提取结果先写入 `suggestedReplyClass` / `suggestedSendMode`；暂存、关闭窗口、重启后仍能恢复建议，不能借用 ReplyEvidence 正式字段暂存。审核时允许编辑草稿，但保留模型原建议；确认操作把用户批准的 class/mode 与正式证据、事件、阶段/待办更新放入同一事务，并记录批准值。`modified_confirmed` 必须可追溯原建议和最终批准值；重复确认幂等。
 
 ### 8.8 填写留档默认范围
 
@@ -621,7 +628,18 @@ erDiagram
 | `createdAt` | 入队 UTC | 是 | plugin | immutable | public-meta |
 | `bytes` | payload 序列化字节数 | 是 | plugin | immutable | public-meta |
 
-恢复后：握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。插件比较每条 **绑定** 消息上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。意图不盖 epoch，恢复后重新走候选，不自动当成已绑定。关联通过 `outbox.reconcile` 查询哪些 `messageId` 已在 **当前 epoch** 的库中。桌面幂等键是 `(clientInstanceId, messageId, restoreEpoch)`：epoch 不同则 **不是** 当前档案的重放，返回 `restore_epoch_mismatch`，不得当成成功幂等。
+恢复后：握手 **成功** 并返回新 `(archiveId, restoreEpoch)`。插件比较每条 **绑定** 消息上盖的身份，不匹配则暂停，用户选关联/丢弃/另存。意图不盖 epoch，恢复后重新走候选，不自动当成已绑定。旧写入请求仍返回 `restore_epoch_mismatch`；历史只读对账与写入授权分开，不能只查询新 epoch 的写入记录。
+
+#### 8.11 已提交消息回执与恢复对账
+
+D03 在业务事务中同步持久化回执：所属 `archiveId`、`clientInstanceId`、`messageId`、`sourceRestoreEpoch`（该写入提交时的 epoch）、`payloadSha256`、`resultId`、操作类型和提交时间。回执属于可备份业务历史；历史 epoch 不授予当前写入权限。回执保留期至少与对应申请/事件一致；永久清理后的缺失不能解释成“以前从未执行”。
+
+`outbox.reconcile` 的外层信封使用当前握手的 `(archiveId, restoreEpoch)`，payload 每项携带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`。它只读当前所选档案库中的历史回执，**不按当前 epoch 过滤历史行**；不搜索其他档案或接受任意路径。调用方只能查询自己的 clientInstanceId（最多由 D05 规定的有界批次）。响应逐项回显完整身份并返回 `applied` / `not_found` / `conflict` / `unverifiable`，`applied` 才有已核实的 resultId。
+
+- 完整旧身份与摘要命中、对应结果仍有效：`applied`，不再新增业务事件。
+- 同身份摘要不符：`conflict`，拒绝自动处理。
+- 未找到回执：`not_found`，仅说明该备份未包含证明；缺失回执表/无法核实结果：`unverifiable`。两者均不自动重放，交由用户核对已有记录或另存。
+- 用户明确决定重新写入时，创建新 messageId、盖当前 epoch，并记录旧身份关联；该转换及新 outbox 身份需先持久化，重试不能再生成另一份新消息。旧 envelope 永远不能因为对账成功被当成当前写入许可。
 
 ---
 
@@ -729,15 +747,15 @@ erDiagram
 
 ### 10.8 恢复身份与旧队列（含重复恢复同一备份）
 
-**设定：** 绑定队列有 `messageId=M1` 的 `job.save`，盖着 `archiveId=A1, restoreEpoch=E1`。备份 B 含 A1（**不含** E1）。
+**设定：** 绑定队列有 `messageId=M1` 的 `job.save`，盖着 `archiveId=A1, restoreEpoch=E1`。备份 B 含 A1 和业务历史回执（可能含 sourceRestoreEpoch=E1），但不含当前指针文件。
 
 **第一次恢复 B：**
 
-- 预览 → 确认 → 解压到 **新目录**，旧 current 挪到 retired。
+- 预览 → 确认 → 在 **新目录** 完整解压/校验/验证迁移，旧 current 保持不动；成功原子切换 current.json 后，旧目录才登记为 retired 回滚点，不在提交前搬走。
 - 新铸 `restoreEpoch=E2`（UUID），写入机器本地 current 指针。`archiveId` 仍为 A1。
 - 握手成功，返回 `(A1, E2)`。握手不因 epoch 变化失败。
 - M1 盖章 `(A1, E1)` ≠ `(A1, E2)` → **暂停**绑定队列。
-- 用户三选：关联 / 丢弃 / 另存。关联调用 `outbox.reconcile`；已在 **当前 epoch 库** 中的 messageId 不再重放。
+- 用户三选：关联 / 丢弃 / 另存。关联按 §8.11 查询备份中保留的完整历史回执（含 clientInstanceId、旧 epoch 和摘要）；已核实的结果不重写，不局限于 E2 的回执。
 - 若此时桌面在用户确认前就收到 M1：返回 `restore_epoch_mismatch`，**不得**按 `(clientInstanceId, messageId)` 当成成功幂等。
 
 **再次用同一备份 B 恢复：**
@@ -798,6 +816,28 @@ erDiagram
 
 ---
 
+### 10.14 在线开始、上传中断、模板改变
+
+确认快照 S 时桌面在线：先将原字节 B 和摘要 H 提交到扩展源 IDB，再发送分片。收到部分 ACK 后 SW 重启，用户把模板改为 B2；恢复发送的仍是 B，最终桌面总哈希必须为 H。完整 ACK 丢失时保留 IDB 并核对/幂等重传；没有完整持久化 ACK 不删除 B。IDB 提交失败时不开始可恢复上传，提示留档失败，填写不受影响。
+
+### 10.15 暂存 AI 分类建议
+
+模型返回 `interview_invite` / `automated`：只写 AiSuggestion 的 suggestedReplyClass/suggestedSendMode，证据正式分类不变。用户选择暂存、重启后两项仍在；修改发送方式为 unknown 并确认时，在同一事务登记批准值、事件/阶段/待办。原模型建议仍可查看；重复确认不重复写入。
+
+### 10.16 凭据 URL 与临时导入路径
+
+无已审核 ATS 规则的 OAuth `?code=SECRET`、重置密码 `?key=SECRET`，在写入 SaveIntent 前即剥离；档案、日志和备份均不含 SECRET。一个岗位号规则的正例不能放行同 host 的 callback/reset 路径。导入 `C:\\Users\\合成用户\\Downloads\\通知.eml` 后，只保留安全文件名与托管副本；成功/失败/取消后清除内存 sourcePathHint，长期对象、备份和诊断中不存在原路径。
+
+### 10.17 恢复后的历史回执对账
+
+E1 时 Profile A 的 M1 已提交，回执 R 与申请一起进入备份，但浏览器未收到 ACK。恢复备份后当前身份是 E2。旧 E1 的 job.save 直接发送必须被拒绝；用户选择对账，外层用 E2，查询项用 `(A, M1, E1, payloadSha256)`，在恢复库的历史回执命中 R，返回 applied，不再建一条申请。
+
+Profile B 恰好也使用 M1，不能命中 A 的回执；同旧身份但摘要不同返回 conflict。若提交发生在备份之后，备份内找不到回执：返回 not_found，要求人工核对/另存，不宣称从未执行。重复恢复生成 E3 后仍可查 R，但 E1/E2 都不能重新取得写入权限。
+
+### 10.18 恢复解压失败
+
+旧目录 A 和 current.json 指向 E1。向独立目录 B 解压时磁盘满：删除/隔离未完成的本次 staging，A 和 current.json 不变；不把旧目录先移走。只有 B 的完整校验和迁移验证成功后，暂停写入、持久化 B 并原子切换指针到 B/E2。提交点后的崩溃使用 B/E2，旧 A 仍为回滚点；人工回滚 A 时新铸 E3。
+
 ## 11. UI 文案约束（产品级）
 
 | 禁止 | 必须 |
@@ -838,7 +878,7 @@ erDiagram
 | 高 | 用户把填写成功当成已投递 | 默认 `saved`；独立确认；文案冻结 |
 | 高 | 按公司自动合并导致通知串岗 | UUID 身份；候选提示；AI 强制消歧 |
 | 中 | 未打包扩展 ID 漂移 / 把未配对当成未安装 | 桌面粘贴 ID；未配对不建意图 |
-| 中 | 快照大于业务信封或桌面不可用时丢字节 | 确认时写入 IndexedDB；> 2 MiB 拒绝；重试用原字节 |
+| 中 | 快照过大或任意上传中断时丢字节 | 确认时写入 IndexedDB；> 2 MiB 拒绝；重试用原字节 |
 | 中 | 把 idle 退出当成次日提醒 | 系统调度通知；文案区分退出/未授权 |
 | 中 | 重复恢复同一备份复用 generation | `restoreEpoch` 每次切换新铸 |
 | 低 | 托盘/菜单栏被当成广告 | 可关；退出能力限制必须仍能看见 |
@@ -847,7 +887,7 @@ erDiagram
 
 ## 14. Open Questions
 
-产品侧需负责人确认的项并入 [downstream-decisions.md](downstream-decisions.md#需要项目负责人选择)（填写留档默认范围、托盘、备份加密等）。本文不单开重复列表。
+产品侧需负责人确认的项并入 [downstream-decisions.md](downstream-decisions.md#4-需要项目负责人选择)（填写留档默认范围、托盘、备份加密等）。本文不单开重复列表。
 
 ---
 


### PR DESCRIPTION
## 第三轮契约修订（b6b0729）

修复审查六项：请求信封必须带当前 archiveId/restoreEpoch；imported_unclassified；eventSequence；chunk 级持久化 messageId 与连续 cursor；V1–V12 文档同步矩阵；sourceRestoreEpoch vs current 幂等。走查 10.19–10.24。未合并、未关闭 #17、未宣称架构冻结。

---

## Summary

D01（#17 / Epic #15）设计基线第二轮修订。仍 **只改文档与相关 issue 正文**，不实现桌面程序，不改插件功能/权限/存储/版本（`0.3.0`），不合并、不关闭 #17，**不宣称架构已冻结**。

关联：#17 #15

文档入口：[`docs/desktop-mvp/README.md`](docs/desktop-mvp/README.md)

## 逐项回应

### 一、平台：Windows 优先，架构支持 macOS

五份文档已去掉「只要 Windows / v1 无 Mac」冻结语。Windows 与 macOS 都是目标平台；业务模型/SQLite/事件/建议/NM 消息平台无关。适配边界（目录、IPC、NM 注册、凭据、通知、安装签名）写在 ADR §3.9。Windows 交付 NSIS；macOS 交付 `.app`/`.dmg`。建议 Apple Silicon 一等、macOS 11+、Chrome/Edge 116+，不默认承诺 Safari。进程契约改为 **应用进程 / NM host 进程 / WebView 子进程**，不再把 `*.exe` 写进平台无关协议。

「正式版是否必须双平台同时交付」仍是开放问题（推荐见下）。

### 二、离线入队顺序

区分 **SaveIntent**（已确认字段、尚未绑定申请 UUID）与 **Bound outbox**（已选使用已有/新建，可按协议重试）。曾经配对但桌面暂不可用：持久化意图并显示「待同步（尚未绑定申请）」，**禁止**「桌面已保存」。桌面恢复后 handshake → 候选 → 用户消歧 → 才 `job.save`。未安装/从未配对不建长期意图。协议不兼容不把意图升级为绑定消息。`messageId` / 申请 UUID / `restoreEpoch` 的确定时机见产品 §5.2。

### 三、离线快照字节

确认留档时从 **当时** 模板生成不可变字节。无论桌面是否在线，发送前所有字节先提交到 **扩展源 IndexedDB**（SW/offscreen/扩展页），元数据进 `chrome.storage.local`。浏览器重启或改活模板后仍发送原字节。上限 2 MiB；暂存配额与过期提示；ACK 或用户丢弃才清理。不把「只存哈希」说成可恢复文件。

### 四、提醒与后台退出

关窗 / 后台提醒已启用 / 明确退出 / 休眠重启关机 / 未授权 五种状态分开。推荐：授权后用 **系统调度通知**，进程可空闲退出。不偷偷开机启动。不把「15 分钟 idle」包装成次日提醒。Windows 计划 Toast 约 5 分钟投递窗口写进文案。

### 五、恢复身份

用每次成功切换 current 指针时 **新铸的 `restoreEpoch`（UUID）**，存在机器本地 `current.json`，**当前指针不进备份，历史回执保留 sourceRestoreEpoch**。重复恢复同一备份 → 不同 epoch。回滚也再铸。旧绑定队列盖章不符则暂停。幂等键为 `(clientInstanceId, messageId, restoreEpoch)`；epoch 不符返回 `restore_epoch_mismatch`，不得当成功重放。走查 10.8 / 10.12 给出碰撞反例。

### 六、概念表述

1. `replyClass` = 业务类型，`sendMode` = 发送方式（human/automated/unknown）。面试邀请等不得仅因类型投影成「人工回复」。
2. Tauri 仍推荐，但 Electron 可 per-user 安装、**可以**做 NM stdio、不是天然必须管理员。独立 host 二进制是推荐隔离方式，不是唯一实现。体积数字标待打样。

### 七、文档与 issue 同步

五份文档交叉一致。已更新 issue 正文（条款修订 + 「D01 修订」附录），**未改依赖 DAG**，未改 LICENSE。

修改的 issue：#15 #17 #16 #18 #23 #24 #20 #22 #21 #26 #25 #28 #29 #27。

D04 未改 issue 正文（范围几乎不动）；D09 仅补 `sendMode` 一句。建议若 Mac 公证拖死 D13，用 #29 下的小 PR 拆分，不新建阻塞边。

## 仍需负责人决定

见 [`downstream-decisions.md` §4](docs/desktop-mvp/downstream-decisions.md)。摘要：

1. 正式「桌面 MVP」标签是否必须 Win+Mac 同时交付 → **推荐正式标签双平台；实现顺序 Windows 优先；D02 缺 Mac 原型不能关**
2. Tauri 2 vs Electron → **推荐 Tauri 2**（论据已改写）
3. 后台提醒：系统调度 vs 常驻进程 → **推荐系统调度**
4. 备份加密 → **推荐不加密 + PII 警告**
5. Windows 是否另发 MSI → **推荐仅 NSIS**

## 需要原型验证的假设

V1 IPC/单实例；V2 按需启动（含 Mac `.app`）；V3 manifest 重读；V4 SW 与 `connectNative`；V5 64 KiB 拒绝行为；V6 WebView2 bootstrapper；V7 Win ARM64 / Mac Intel；V8–V9 系统通知杀进程与 AUMID；V10 Mac Edge NM 路径；V11 公证与 helper；V12 IndexedDB 重启读回。

## 范围自检

- [x] 未实现桌面代码、未搭脚手架、未安装框架、未注册 NM
- [x] 未改插件功能/权限/存储/版本
- [x] 未合并、未发布、不关闭 #17
- [x] 未把 MIT 写成未来所有模块许可


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 文档
- 更新桌面 MVP 设计、架构及产品需求文档，支持 Windows 与 macOS。
- 补充安装、通知、离线保存、快照恢复、消息回执及跨平台运行规则。
- 新增数据隐私、备份恢复与敏感信息处理说明。
- 更新架构决策、开放问题和原型验证计划，明确当前为可修订开工基线。
- 补充同步交付范围、删除语义及平台适配要求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 第三轮收尾（49d353b）

- 统一在线/离线快照写前暂存，完整提交/哈希 ACK 前保留原字节，补充跨 IDB/outbox 中断恢复约定。
- code/key 默认剥离；仅审核过的精确 ATS 站点/路径/参数/岗位号语法可例外，认证路径不可放行。
- AiSuggestion 新增 suggestedReplyClass/suggestedSendMode，暂存/重启不写正式证据，确认记录批准值与原建议。
- 当前 epoch 写入授权与完整历史回执只读对账分离；历史 sourceRestoreEpoch 可备份但不能恢复成当前授权；not_found 不代表从未执行。
- sourcePathHint 仅导入内存，完成/失败/取消后清除，不进入长期 schema/备份/诊断。
- 修正恢复先搬旧目录的时序：先准备校验 staging，再原子切换；加入在线中断、暂存分类、URL、历史对账、恢复失败走查（产品 §10.14–10.18）。
- 完整 JSON 分片预算明确为 UTF-8 65536 字节，并修复五份文档的章节链接。

已同步并读回核验：#15 #17 #18 #20 #21 #22 #23 #25 #27 #28；未改变依赖 DAG。
验证：文档本地路径/章节锚点检查无缺失；git diff --check 通过；原插件 109 项回归通过。文档走查不等于桌面实现测试，未实现任何功能。

本轮只修改 docs/desktop-mvp 的五份文档。PR 和 #17 保持开放，不合并、不发布；原五项负责人决策仍待确认。

