### PR TITLE
chore: ignore the whole local output/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,9 @@ Thumbs.db
 # Local browser/debug profiles
 .edge-icon-profile/
 .playwright-cli/
-output/playwright/
 
-# Build and package artifacts
+# Build, package and local run artifacts
+output/
 *.zip
 dist/
 release/


### PR DESCRIPTION
仓库维护，无运行时改动。只改 `.gitignore` 一处，4 行。

## 问题

`.gitignore` 只忽略了 `output/playwright/`。实际写在 `output/` 下的其他本地产物（评审记录、PR 正文草稿、验证包）既没被跟踪、也没被忽略，会一直以 `??` 挂在 `git status` 里，跨 worktree 都是噪音。

## 改动

- `output/playwright/` → `output/`。
- 顺带把它从「Local browser/debug profiles」段移到「Build, package and local run artifacts」段 —— `output/` 装的不只是浏览器调试配置，原来的分组名已经不准。

## 验证

- `git ls-files output` 为空：没有任何被跟踪的文件在 `output/` 下，这条规则不会排除掉已跟踪内容。
- `.github/`、`desktop/scripts/`、`desktop/package.json`、`tests/` 中无任何位置引用 `output/`，CI 与打包脚本不依赖它。
- 实测：在 `output/` 下放探针文件后 `git status` 静默，`git check-ignore -v` 指向 `.gitignore:9`。
- `desktop/` 的插件 ZIP allowlist 不受影响（`*.zip` 本就已被忽略）。

不涉及 D05 #32，不改插件权限、版本或任何运行时行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项**
  * 更新构建、打包及本地运行产物的忽略规则，避免相关输出文件被纳入版本控制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->