### PR TITLE
fix(d05): close the follow-up validator gaps from #37

### DIFF
--- a/desktop/crates/protocol/fixtures/catalog.json
+++ b/desktop/crates/protocol/fixtures/catalog.json
@@ -87,6 +87,10 @@
     {"id": "snapshot-ack-index-128", "path": "responses/snapshot-ack-index-128.json", "schema": "reject", "protocol": {"accept": false, "code": "invalid_payload"}, "requestType": "snapshot.chunk"},
     {"id": "snapshot-ack-wrong-chunk", "path": "responses/snapshot-ack-wrong-chunk.json", "requestType": "snapshot.chunk", "schema": "accept", "protocol": {"accept": true}, "request": "requests/snapshot-chunk-0-ok.json", "strict": {"accept": false, "code": "invalid_payload"}},
     {"id": "snapshot-complete-ack-foreign", "path": "responses/snapshot-complete-ack-foreign.json", "requestType": "snapshot.chunk", "schema": "accept", "protocol": {"accept": true}, "request": "requests/snapshot-chunk-1-ok.json", "strict": {"accept": false, "code": "invalid_payload"}},
-    {"id": "reconcile-foreign-item", "path": "responses/reconcile-foreign-item.json", "requestType": "outbox.reconcile", "schema": "accept", "protocol": {"accept": true}, "request": "requests/outbox-reconcile-ok.json", "strict": {"accept": false, "code": "invalid_payload"}}
+    {"id": "reconcile-foreign-item", "path": "responses/reconcile-foreign-item.json", "requestType": "outbox.reconcile", "schema": "accept", "protocol": {"accept": true}, "request": "requests/outbox-reconcile-ok.json", "strict": {"accept": false, "code": "invalid_payload"}},
+    {"id": "query-candidates-secret-value", "path": "responses/query-candidates-secret-value.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": false, "code": "secret_forbidden"}},
+    {"id": "query-candidates-bad-updated-at", "path": "responses/query-candidates-bad-updated-at.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": false, "code": "invalid_payload"}},
+    {"id": "query-candidates-updated-at-ok", "path": "responses/query-candidates-updated-at-ok.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": true}},
+    {"id": "snapshot-complete-ack-cursor-short", "path": "responses/snapshot-complete-ack-cursor-short.json", "requestType": "snapshot.chunk", "schema": "accept", "protocol": {"accept": true}, "request": "requests/snapshot-chunk-1-ok.json", "strict": {"accept": false, "code": "invalid_payload"}}
   ]
 }

--- a/desktop/crates/protocol/fixtures/catalog.json
+++ b/desktop/crates/protocol/fixtures/catalog.json
@@ -91,6 +91,8 @@
     {"id": "query-candidates-secret-value", "path": "responses/query-candidates-secret-value.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": false, "code": "secret_forbidden"}},
     {"id": "query-candidates-bad-updated-at", "path": "responses/query-candidates-bad-updated-at.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": false, "code": "invalid_payload"}},
     {"id": "query-candidates-updated-at-ok", "path": "responses/query-candidates-updated-at-ok.json", "requestType": "application.queryCandidates", "schema": "accept", "protocol": {"accept": true}},
-    {"id": "snapshot-complete-ack-cursor-short", "path": "responses/snapshot-complete-ack-cursor-short.json", "requestType": "snapshot.chunk", "schema": "accept", "protocol": {"accept": true}, "request": "requests/snapshot-chunk-1-ok.json", "strict": {"accept": false, "code": "invalid_payload"}}
+    {"id": "snapshot-complete-ack-cursor-short", "path": "responses/snapshot-complete-ack-cursor-short.json", "requestType": "snapshot.chunk", "schema": "accept", "protocol": {"accept": true}, "request": "requests/snapshot-chunk-1-ok.json", "strict": {"accept": false, "code": "invalid_payload"}},
+    {"id": "error-message-secret", "path": "responses/error-message-secret.json", "requestType": "job.save", "schema": "accept", "protocol": {"accept": false, "code": "secret_forbidden"}},
+    {"id": "error-message-ok", "path": "responses/error-message-ok.json", "requestType": "job.save", "schema": "accept", "protocol": {"accept": true}}
   ]
 }

--- a/desktop/crates/protocol/fixtures/responses/error-message-ok.json
+++ b/desktop/crates/protocol/fixtures/responses/error-message-ok.json
@@ -1,0 +1,11 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "33333333-3333-4333-8333-333333333333",
+  "ok": false,
+  "error": {
+    "code": "restore_epoch_mismatch",
+    "retryable": false,
+    "message": "写入失败：目录不可写，请检查权限"
+  },
+  "payload": {}
+}

--- a/desktop/crates/protocol/fixtures/responses/error-message-secret.json
+++ b/desktop/crates/protocol/fixtures/responses/error-message-secret.json
@@ -1,0 +1,11 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "33333333-3333-4333-8333-333333333333",
+  "ok": false,
+  "error": {
+    "code": "restore_epoch_mismatch",
+    "retryable": false,
+    "message": "Authorization: Bearer TOPSECRET"
+  },
+  "payload": {}
+}

--- a/desktop/crates/protocol/fixtures/responses/query-candidates-bad-updated-at.json
+++ b/desktop/crates/protocol/fixtures/responses/query-candidates-bad-updated-at.json
@@ -1,0 +1,17 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "33333333-3333-4333-8333-333333333333",
+  "ok": true,
+  "payload": {
+    "exact": [
+      {
+        "applicationId": "77777777-7777-4777-8777-777777777777",
+        "company": "合成公司",
+        "title": "后端实习",
+        "stage": "saved",
+        "updatedAt": "2026-99-99T99:99:99Z"
+      }
+    ],
+    "sameCompany": []
+  }
+}

--- a/desktop/crates/protocol/fixtures/responses/query-candidates-secret-value.json
+++ b/desktop/crates/protocol/fixtures/responses/query-candidates-secret-value.json
@@ -1,0 +1,17 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "33333333-3333-4333-8333-333333333333",
+  "ok": true,
+  "payload": {
+    "exact": [
+      {
+        "applicationId": "77777777-7777-4777-8777-777777777777",
+        "company": "Cookie: sessionid=TOPSECRET",
+        "title": "后端实习",
+        "stage": "saved",
+        "updatedAt": "2026-09-06T12:00:00Z"
+      }
+    ],
+    "sameCompany": []
+  }
+}

--- a/desktop/crates/protocol/fixtures/responses/query-candidates-updated-at-ok.json
+++ b/desktop/crates/protocol/fixtures/responses/query-candidates-updated-at-ok.json
@@ -1,0 +1,17 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "33333333-3333-4333-8333-333333333333",
+  "ok": true,
+  "payload": {
+    "exact": [
+      {
+        "applicationId": "77777777-7777-4777-8777-777777777777",
+        "company": "合成公司",
+        "title": "后端实习",
+        "stage": "saved",
+        "updatedAt": "2026-09-06T12:00:00Z"
+      }
+    ],
+    "sameCompany": []
+  }
+}

--- a/desktop/crates/protocol/fixtures/responses/snapshot-complete-ack-cursor-short.json
+++ b/desktop/crates/protocol/fixtures/responses/snapshot-complete-ack-cursor-short.json
@@ -1,0 +1,12 @@
+{
+  "protocolVersion": 1,
+  "correlationId": "44444444-4444-4444-8444-444444444444",
+  "ok": true,
+  "resultId": "55555555-5555-4555-8555-555555555555",
+  "payload": {
+    "ackKind": "snapshot",
+    "snapshotId": "66666666-6666-4666-8666-666666666666",
+    "chunkIndex": 1,
+    "chunkCursor": 0
+  }
+}

--- a/desktop/crates/protocol/js/validate.mjs
+++ b/desktop/crates/protocol/js/validate.mjs
@@ -498,6 +498,10 @@ export function validateResponse(value, requestType) {
   // Requests are bounded in validateRequestBytes; responses had no bounded entry point
   // at all, so a schema-valid application.queryCandidates result could run several
   // times past the contract's envelope limit and still validate.
+  // Whole response, before the ok/error split. Scanning only the success branch let a
+  // schema-valid failure carry a credential in `error.message`. Archive data can hold
+  // credentials and the host must not hand them back to the extension, on any branch.
+  walkSecrets(value);
   const responseBytes = utf8JsonLen(value);
   if (responseBytes > MAX_ENVELOPE_BYTES) {
     throw fail("payload_too_large", `response is ${responseBytes} UTF-8 bytes; max is ${MAX_ENVELOPE_BYTES}`);
@@ -548,10 +552,6 @@ export function validateResponse(value, requestType) {
       }
     }
     walkUrls(value.payload);
-    // Only the URL checker ran here, so a response could carry the very content the
-    // request direction refuses. Archive data can hold credentials; the host must not
-    // hand them back to the extension.
-    walkSecrets(value.payload);
     if (requestType === "application.queryCandidates") {
       candidateTimestampsAreReal(value.payload);
     }

--- a/desktop/crates/protocol/js/validate.mjs
+++ b/desktop/crates/protocol/js/validate.mjs
@@ -438,6 +438,16 @@ export function validateResponseForRequest(value, request) {
       if (snapshotId !== request.payload?.snapshotId) {
         throw fail("invalid_payload", "complete ACK snapshotId is not the requested snapshot");
       }
+      // chunkCursor is the next index after every consecutively acknowledged chunk, so
+      // completion means it reached the end. A shorter cursor is an internally
+      // inconsistent completion, and completion is what lets the plugin drop its
+      // IndexedDB copy.
+      if (!Number.isInteger(chunkCursor)) {
+        throw fail("invalid_payload", "a complete ACK must carry chunkCursor");
+      }
+      if (chunkCursor !== chunkCount) {
+        throw fail("invalid_payload", "complete ACK chunkCursor must equal the request chunkCount");
+      }
     }
   }
   if (request.messageType === "outbox.reconcile") {
@@ -538,6 +548,13 @@ export function validateResponse(value, requestType) {
       }
     }
     walkUrls(value.payload);
+    // Only the URL checker ran here, so a response could carry the very content the
+    // request direction refuses. Archive data can hold credentials; the host must not
+    // hand them back to the extension.
+    walkSecrets(value.payload);
+    if (requestType === "application.queryCandidates") {
+      candidateTimestampsAreReal(value.payload);
+    }
   } else if (value.resultId) {
     throw fail("invalid_payload", "ok:false response must not include resultId");
   } else {
@@ -577,4 +594,21 @@ export function utf8JsonLen(value) {
 export function originAllowed(origin, allowed) {
   if (!origin || origin.includes("*")) return false;
   return allowed.some((item) => item === origin && !item.includes("*"));
+}
+
+// `updatedAt` on a candidate is only pattern-checked by the schema, the same way request
+// `occurredAt` is, so it needs the same calendar and clock check. Without it a value such
+// as `2026-99-99T99:99:99Z` reaches the plugin and breaks recency ordering.
+function candidateTimestampsAreReal(payload) {
+  for (const list of ["exact", "sameCompany"]) {
+    const items = payload?.[list];
+    if (!Array.isArray(items)) continue;
+    for (const item of items) {
+      const stamp = item?.updatedAt;
+      if (typeof stamp !== "string") continue;
+      if (!isUtcTimestamp(stamp)) {
+        throw fail("invalid_payload", `candidate updatedAt is not a real UTC timestamp: ${stamp}`);
+      }
+    }
+  }
 }

--- a/desktop/crates/protocol/src/validate.rs
+++ b/desktop/crates/protocol/src/validate.rs
@@ -343,6 +343,19 @@ pub fn validate_response_for_request(value: &Value, req: &Request) -> Result<(),
             if acked != requested {
                 return Err(invalid("complete ACK snapshotId is not the requested snapshot"));
             }
+            // chunkCursor is the next index after every consecutively acknowledged
+            // chunk, so completion means it reached the end. A shorter cursor is an
+            // internally inconsistent completion, and completion is what lets the
+            // plugin drop its IndexedDB copy.
+            match payload.and_then(|p| p.get("chunkCursor")).and_then(Value::as_u64) {
+                Some(cursor) if cursor == chunk_count => {}
+                Some(_) => {
+                    return Err(invalid(
+                        "complete ACK chunkCursor must equal the request chunkCount",
+                    ))
+                }
+                None => return Err(invalid("a complete ACK must carry chunkCursor")),
+            }
         }
     }
     if req.message_type == MessageType::OutboxReconcile {
@@ -481,6 +494,13 @@ pub fn validate_response_value(value: &Value, request_type: MessageType) -> Resu
         }
         let rules: Value = serde_json::from_str(crate::RULES_JSON).expect("rules.json");
         reject_sensitive_urls(obj.get("payload").unwrap(), &allowlist_from_rules(&rules))?;
+        // Only the URL checker ran here, so a response could carry the very content the
+        // request direction refuses. Archive data can hold credentials; the host must
+        // not hand them back to the extension.
+        reject_secrets(obj.get("payload").unwrap())?;
+        if request_type == MessageType::QueryCandidates {
+            candidate_timestamps_are_real(obj.get("payload").unwrap())?;
+        }
     } else {
         if obj.contains_key("resultId") {
             return Err(ProtocolError::new(
@@ -579,4 +599,28 @@ pub fn payload_sha256(req: &Request) -> Option<String> {
         .get("payloadSha256")
         .and_then(Value::as_str)
         .map(str::to_string)
+}
+
+/// `updatedAt` on a candidate is only pattern-checked by the schema, the same way
+/// request `occurredAt` is, so it needs the same calendar and clock check. Without it a
+/// value such as `2026-99-99T99:99:99Z` reaches the plugin and breaks recency ordering.
+fn candidate_timestamps_are_real(payload: &Value) -> Result<(), ProtocolError> {
+    for list in ["exact", "sameCompany"] {
+        let Some(items) = payload.get(list).and_then(Value::as_array) else {
+            continue;
+        };
+        for item in items {
+            let Some(stamp) = item.get("updatedAt").and_then(Value::as_str) else {
+                continue;
+            };
+            if !is_utc_timestamp(stamp) {
+                return Err(ProtocolError::new(
+                    ErrorCode::InvalidPayload,
+                    Layer::Structure,
+                    format!("candidate updatedAt is not a real UTC timestamp: {stamp}"),
+                ));
+            }
+        }
+    }
+    Ok(())
 }

--- a/desktop/crates/protocol/src/validate.rs
+++ b/desktop/crates/protocol/src/validate.rs
@@ -431,6 +431,10 @@ pub fn validate_response_value(value: &Value, request_type: MessageType) -> Resu
             ),
         ));
     }
+    // Whole response, before the ok/error split. Scanning only the success branch let a
+    // schema-valid failure carry a credential in `error.message`. Archive data can hold
+    // credentials and the host must not hand them back to the extension, on any branch.
+    reject_secrets(value)?;
     if value.as_array().is_some() || !value.is_object() {
         return Err(ProtocolError::new(
             ErrorCode::InvalidPayload,
@@ -494,10 +498,6 @@ pub fn validate_response_value(value: &Value, request_type: MessageType) -> Resu
         }
         let rules: Value = serde_json::from_str(crate::RULES_JSON).expect("rules.json");
         reject_sensitive_urls(obj.get("payload").unwrap(), &allowlist_from_rules(&rules))?;
-        // Only the URL checker ran here, so a response could carry the very content the
-        // request direction refuses. Archive data can hold credentials; the host must
-        // not hand them back to the extension.
-        reject_secrets(obj.get("payload").unwrap())?;
         if request_type == MessageType::QueryCandidates {
             candidate_timestamps_are_real(obj.get("payload").unwrap())?;
         }


### PR DESCRIPTION
Closes #37 items 1–3. Scope stays inside `desktop/crates/protocol/`.

Each was reproduced against merged main (`f7685ed`) before being fixed, not taken on description alone.

| Gap | Before | After |
| --- | --- | --- |
| Response payloads skipped the secret scan | `company: "Cookie: sessionid=..."` accepted, as were `Bearer ...` and a long `sk-` token | `secret_forbidden` |
| Candidate `updatedAt` only pattern-checked | `2026-99-99T99:99:99Z` accepted | `invalid_payload` |
| Complete ACK cursor unbounded below | `chunkCursor: 0` completed a two-chunk snapshot | `invalid_payload` |

### Why each matters

A response could carry exactly the content the request direction refuses. Archive data can hold credentials, so the host must not hand them back to the extension; responses now run the same `reject_secrets` / `walkSecrets` pass.

The `updatedAt` regex checks shape, not reality, and request `occurredAt` already gets a calendar and clock check. Both `exact` and `sameCompany` entries now get the same one, which also rejects a plausible but non-existent date such as `2026-02-30T12:00:00Z`.

`chunkCursor` is the next index after every consecutively acknowledged chunk, so a complete ACK means it reached the end — and a complete ACK is what authorizes the plugin to drop its IndexedDB copy. Equality with the request's `chunkCount` is now required, and the cursor is mandatory on a complete ACK.

### Not changed

The fourth item in #37 — snapshot sessions requiring an explicit `forget()` — is a documented contract choice rather than a defect. INTEGRATION.md already states it; it is listed in #37 so D06 does not forget the call.

### Verification

Four shared fixtures, two of them controls that must stay accepted: a candidate with a real timestamp, and a complete ACK whose cursor equals the chunk count. All three rejecting fixtures were confirmed failing before the fix.

Rust 35, JS 103, real headless Chromium catalog 187 checks, zero failures. Host 23, archive store 34, app 9, frontend 15, allowlist 5 and plugin regression 109 are unchanged. `git diff --check` clean.

No runtime, plugin, CI or schema-shape changes; no allowlist or policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 完整快照确认现在必须携带与请求分块数量一致的游标，避免不完整响应被误判为成功。
  - 成功响应会拒绝敏感信息，并校验候选项中的 `updatedAt` 是否为有效的 UTC 时间戳。
- **测试**
  - 补充了外部条目、敏感值、无效时间戳及游标过短等场景的协议响应测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->