### PR TITLE
feat: support composing sidebar chip values

### DIFF
--- a/content.css
+++ b/content.css
@@ -177,11 +177,55 @@
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
+  transition: background 140ms ease, color 140ms ease, box-shadow 140ms ease;
 }
 
-:host .resume-pro__chip.is-success {
-  background: rgba(33, 185, 122, 0.14);
-  color: #21b97a;
+:host .resume-pro__chip:hover,
+:host .resume-pro__chip:focus-visible {
+  background: rgba(79, 110, 247, 0.2);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(79, 110, 247, 0.15);
+}
+
+:host .resume-pro__chip.is-in-field {
+  background: #3855d9;
+  color: #fff;
+}
+
+:host .resume-pro__chip-actions {
+  position: fixed;
+  z-index: 2147483647;
+  display: flex;
+  min-width: 116px;
+  padding: 6px;
+  gap: 6px;
+  border: 1px solid rgba(79, 110, 247, 0.2);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 12px 32px rgba(30, 41, 59, 0.2);
+}
+
+:host .resume-pro__chip-actions[hidden] {
+  display: none;
+}
+
+:host .resume-pro__chip-actions button {
+  flex: 1;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: #eef2ff;
+  color: #3855d9;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+:host .resume-pro__chip-actions button:hover,
+:host .resume-pro__chip-actions button:focus-visible {
+  background: #4f6ef7;
+  color: #fff;
+  outline: none;
 }
 
 :host .resume-pro__empty {

--- a/content.js
+++ b/content.js
@@ -31,8 +31,10 @@
     background-color: transparent;
   }
 }
-`;
+  `;
   const fieldHighlightTimers = new WeakMap();
+  const chipSelectionIdsByTarget = new WeakMap();
+  const chipWriteTargets = new WeakSet();
   let shadowRoot = null;
   const state = {
     dragOffsetX: 0,
@@ -41,7 +43,8 @@
     currentStore: null,
     statusTimer: null,
     lastFocusedField: null,
-    managerVisible: false
+    managerVisible: false,
+    chipAction: null
   };
 
   const StorageService = {
@@ -141,6 +144,17 @@
     `;
 
     shadowRoot.appendChild(sidebar);
+    const chipActions = document.createElement("div");
+    chipActions.id = "resume-pro-chip-actions";
+    chipActions.className = "resume-pro__chip-actions";
+    chipActions.hidden = true;
+    chipActions.setAttribute("role", "menu");
+    chipActions.setAttribute("aria-label", "字段填写方式");
+    chipActions.innerHTML = `
+      <button type="button" role="menuitem" data-chip-mode="add">添加</button>
+      <button type="button" role="menuitem" data-chip-mode="replace">替换</button>
+    `;
+    shadowRoot.appendChild(chipActions);
     bindSidebarEvents(sidebar);
   }
 
@@ -194,6 +208,21 @@
     aiFillButton.addEventListener("click", handleAiFillClick);
     sidebar.querySelector("#resume-pro-repeat-fill").addEventListener("click", handleRepeatFillClick);
     openManagerButton?.addEventListener("click", () => setManagerVisibility(true));
+
+    const chipActions = shadowRoot.querySelector("#resume-pro-chip-actions");
+    chipActions?.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+    chipActions?.querySelectorAll("[data-chip-mode]").forEach((actionButton) => {
+      actionButton.addEventListener("click", () => handleChipAction(actionButton.dataset.chipMode));
+    });
+    document.addEventListener("mousedown", () => closeChipActionMenu());
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        closeChipActionMenu();
+      }
+    });
   }
 
   function bindStorageSync() {
@@ -237,14 +266,15 @@
         </div>
       `;
     } else {
-      groupsContainer.innerHTML = activeTemplate.groups.map((group) => `
+      groupsContainer.innerHTML = activeTemplate.groups.map((group, groupIndex) => `
       <section class="resume-pro__group">
         <div class="resume-pro__group-name">${escapeHtml(group.name)}</div>
         <div class="resume-pro__chips">
-          ${group.fields.map((field) => `
+          ${group.fields.map((field, fieldIndex) => `
             <button
               class="resume-pro__chip"
               type="button"
+              data-chip-id="${escapeHtml(`${activeTemplate.id}:${groupIndex}:${fieldIndex}`)}"
               data-value="${escapeHtml(field.value)}"
               title="${escapeHtml(field.value)}"
             >
@@ -267,26 +297,325 @@
     if (setupButton) {
       setupButton.addEventListener("click", () => setManagerVisibility(true));
     }
+
+    closeChipActionMenu();
+    syncChipSelectionState();
   }
 
   async function handleFieldChipClick(button) {
     const value = button.dataset.value || "";
-    const copied = await copyText(value);
-    const filled = await fillLastFocusedField(value);
+    const target = getLastFocusedFillTarget();
 
-    button.classList.add("is-success");
-    button.textContent = filled ? "已填写" : "已复制";
-    window.setTimeout(() => {
-      button.classList.remove("is-success");
-      renderSidebar();
-    }, 1000);
-
-    if (filled) {
-      showStatus(copied ? "已复制并填入当前输入框。" : "已填入当前输入框。", "success");
+    closeChipActionMenu();
+    if (!value) {
       return;
     }
 
-    showStatus(copied ? "字段值已复制到剪贴板。" : "字段值已准备好，请手动粘贴。", "success");
+    if (!target) {
+      await copyText(value);
+      return;
+    }
+
+    if (!isComposableTextTarget(target)) {
+      await copyText(value);
+      const filled = await Promise.resolve(setElementValue(target, value));
+      if (filled) {
+        target.focus?.();
+        state.lastFocusedField = target;
+      }
+      return;
+    }
+
+    const selection = captureTextSelection(target);
+    const currentValue = getComposableTargetValue(target);
+    syncChipSelectionState();
+    if (button.classList.contains("is-in-field")) {
+      await applyChipValue(target, value, "remove", selection, button.dataset.chipId);
+      return;
+    }
+
+    if (!currentValue) {
+      await copyText(value);
+      await applyChipValue(target, value, "add", selection, button.dataset.chipId);
+      return;
+    }
+
+    showChipActionMenu(button, target, value, selection);
+  }
+
+  async function handleChipAction(mode) {
+    const action = state.chipAction;
+    closeChipActionMenu();
+    if (!action || !["add", "replace"].includes(mode)) {
+      return;
+    }
+
+    await copyText(action.value);
+    const filled = await applyChipValue(action.target, action.value, mode, action.selection, action.button.dataset.chipId);
+    if (!filled) {
+      return;
+    }
+  }
+
+  function showChipActionMenu(button, target, value, selection) {
+    const menu = shadowRoot?.querySelector("#resume-pro-chip-actions");
+    if (!menu) {
+      return;
+    }
+
+    state.chipAction = { button, target, value, selection };
+    menu.hidden = false;
+    const buttonRect = button.getBoundingClientRect();
+    const menuRect = menu.getBoundingClientRect();
+    const left = Math.max(8, Math.min(buttonRect.left, window.innerWidth - menuRect.width - 8));
+    const fitsBelow = buttonRect.bottom + menuRect.height + 8 <= window.innerHeight;
+    const top = fitsBelow ? buttonRect.bottom + 6 : Math.max(8, buttonRect.top - menuRect.height - 6);
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+  }
+
+  function closeChipActionMenu() {
+    const menu = shadowRoot?.querySelector?.("#resume-pro-chip-actions");
+    if (menu) {
+      menu.hidden = true;
+    }
+    state.chipAction = null;
+  }
+
+  function captureTextSelection(target) {
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      const fallback = target.value.length;
+      return {
+        start: Number.isInteger(target.selectionStart) ? target.selectionStart : fallback,
+        end: Number.isInteger(target.selectionEnd) ? target.selectionEnd : fallback
+      };
+    }
+
+    const selection = window.getSelection?.();
+    if (!selection?.rangeCount) {
+      const fallback = target.textContent?.length || 0;
+      return { start: fallback, end: fallback };
+    }
+
+    const range = selection.getRangeAt(0);
+    if (!target.contains(range.commonAncestorContainer)) {
+      const fallback = target.textContent?.length || 0;
+      return { start: fallback, end: fallback };
+    }
+
+    const beforeStart = range.cloneRange();
+    beforeStart.selectNodeContents(target);
+    beforeStart.setEnd(range.startContainer, range.startOffset);
+    const beforeEnd = range.cloneRange();
+    beforeEnd.selectNodeContents(target);
+    beforeEnd.setEnd(range.endContainer, range.endOffset);
+    return { start: beforeStart.toString().length, end: beforeEnd.toString().length };
+  }
+
+  function composeChipText(currentValue, chipValue, mode, selection = {}) {
+    const current = String(currentValue || "");
+    const chip = String(chipValue || "");
+    const rawStart = Number.isInteger(selection.start) ? selection.start : current.length;
+    const start = Math.min(Math.max(0, rawStart), current.length);
+
+    if (!chip) {
+      return { value: current, caret: start, changed: false };
+    }
+
+    if (mode === "replace") {
+      return { value: chip, caret: chip.length, changed: current !== chip };
+    }
+
+    if (mode === "remove") {
+      const index = findNearestChipOccurrence(current, chip, start);
+      if (index < 0) {
+        return { value: current, caret: start, changed: false };
+      }
+      return {
+        value: current.slice(0, index) + current.slice(index + chip.length),
+        caret: index,
+        changed: true
+      };
+    }
+
+    return {
+      value: current.slice(0, start) + chip + current.slice(start),
+      caret: start + chip.length,
+      changed: true
+    };
+  }
+
+  function findNearestChipOccurrence(current, chip, caret) {
+    let nearestIndex = -1;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+    let index = current.indexOf(chip);
+    while (index >= 0) {
+      const distance = caret < index ? index - caret : caret > index + chip.length ? caret - (index + chip.length) : 0;
+      if (distance < nearestDistance) {
+        nearestIndex = index;
+        nearestDistance = distance;
+      }
+      index = current.indexOf(chip, index + Math.max(1, chip.length));
+    }
+    return nearestIndex;
+  }
+
+  async function applyChipValue(target, chipValue, mode, selection, chipId = "") {
+    if (!isComposableTextTarget(target) || !document.contains(target)) {
+      return false;
+    }
+
+    const composed = composeChipText(getComposableTargetValue(target), chipValue, mode, selection);
+    if (!composed.changed) {
+      if (mode === "replace" && chipId) {
+        updateTrackedChipSelection(target, chipId, mode);
+        syncChipSelectionState();
+        return true;
+      }
+      return false;
+    }
+
+    const hadTrackedSelection = chipSelectionIdsByTarget.has(target);
+    const previousSelection = new Set(chipSelectionIdsByTarget.get(target) || []);
+    updateTrackedChipSelection(target, chipId, mode);
+    chipWriteTargets.add(target);
+    let filled;
+    try {
+      filled = await Promise.resolve(setElementValue(target, composed.value));
+    } finally {
+      chipWriteTargets.delete(target);
+    }
+    if (!filled) {
+      if (chipId) {
+        if (hadTrackedSelection) {
+          chipSelectionIdsByTarget.set(target, previousSelection);
+        } else {
+          chipSelectionIdsByTarget.delete(target);
+        }
+      }
+      return false;
+    }
+
+    target.focus?.();
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      target.setSelectionRange?.(composed.caret, composed.caret);
+    } else {
+      setContentEditableCaret(target, composed.caret);
+    }
+    state.lastFocusedField = target;
+    syncChipSelectionState();
+    return true;
+  }
+
+  function getComposableTargetValue(target) {
+    return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement
+      ? String(target.value || "")
+      : String(target.textContent || "");
+  }
+
+  function setContentEditableCaret(target, caret) {
+    const selection = window.getSelection?.();
+    const range = document.createRange?.();
+    if (!selection || !range) {
+      return;
+    }
+    const textNode = target.firstChild || target;
+    const offset = textNode === target ? 0 : Math.min(caret, textNode.textContent?.length || 0);
+    range.setStart(textNode, offset);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  function isComposableTextTarget(target) {
+    if (target instanceof HTMLTextAreaElement || (target instanceof HTMLElement && target.isContentEditable)) {
+      return true;
+    }
+    return target instanceof HTMLInputElement && ["text", "search", "tel", "url", "email", "password"].includes(target.type || "text");
+  }
+
+  function syncChipSelectionState() {
+    if (!shadowRoot?.querySelectorAll) {
+      return;
+    }
+    const target = getLastFocusedFillTarget();
+    const currentValue = target && isComposableTextTarget(target) ? getComposableTargetValue(target) : "";
+    const buttons = Array.from(shadowRoot.querySelectorAll(".resume-pro__chip"));
+    const selectedIds = target && isComposableTextTarget(target)
+      ? resolveSelectedChipIds(target, buttons, currentValue)
+      : new Set();
+    buttons.forEach((button) => {
+      const selected = selectedIds.has(button.dataset.chipId);
+      button.classList.toggle("is-in-field", selected);
+      button.setAttribute("aria-pressed", String(selected));
+    });
+  }
+
+  function updateTrackedChipSelection(target, chipId, mode) {
+    if (!chipId) {
+      return;
+    }
+    const selectedIds = new Set(chipSelectionIdsByTarget.get(target) || []);
+    if (mode === "replace") {
+      selectedIds.clear();
+    }
+    if (mode === "remove") {
+      selectedIds.delete(chipId);
+    } else {
+      selectedIds.add(chipId);
+    }
+    chipSelectionIdsByTarget.set(target, selectedIds);
+  }
+
+  function resolveSelectedChipIds(target, buttons, currentValue) {
+    const hasTrackedSelection = chipSelectionIdsByTarget.has(target);
+    const previousIds = chipSelectionIdsByTarget.get(target) || new Set();
+    const nextIds = new Set();
+    const buttonsByValue = new Map();
+
+    buttons.forEach((button, index) => {
+      if (!button.dataset.chipId) {
+        button.dataset.chipId = `rendered-chip-${index}`;
+      }
+      const value = button.dataset.value || "";
+      if (!value) {
+        return;
+      }
+      if (!buttonsByValue.has(value)) {
+        buttonsByValue.set(value, []);
+      }
+      buttonsByValue.get(value).push(button);
+    });
+
+    buttonsByValue.forEach((sameValueButtons, value) => {
+      let remaining = countTextOccurrences(currentValue, value);
+      const preferred = sameValueButtons.filter((button) => previousIds.has(button.dataset.chipId));
+      const candidates = hasTrackedSelection
+        ? preferred
+        : sameValueButtons;
+      candidates.forEach((button) => {
+        if (remaining > 0) {
+          nextIds.add(button.dataset.chipId);
+          remaining -= 1;
+        }
+      });
+    });
+
+    chipSelectionIdsByTarget.set(target, nextIds);
+    return nextIds;
+  }
+
+  function countTextOccurrences(text, value) {
+    if (!value) {
+      return 0;
+    }
+    let count = 0;
+    let index = String(text || "").indexOf(value);
+    while (index >= 0) {
+      count += 1;
+      index = String(text || "").indexOf(value, index + value.length);
+    }
+    return count;
   }
 
   function newRequestId() {
@@ -793,6 +1122,17 @@
 
       if (isFillTarget(target)) {
         state.lastFocusedField = target;
+        closeChipActionMenu();
+        syncChipSelectionState();
+      }
+    }, true);
+    document.addEventListener("input", (event) => {
+      if (event.target === state.lastFocusedField) {
+        closeChipActionMenu();
+        if (!chipWriteTargets.has(event.target)) {
+          chipSelectionIdsByTarget.delete(event.target);
+        }
+        syncChipSelectionState();
       }
     }, true);
   }
@@ -815,20 +1155,16 @@
     }
   }
 
-  async function fillLastFocusedField(value) {
+  function getLastFocusedFillTarget() {
     const candidates = [state.lastFocusedField, document.activeElement];
 
     for (const candidate of candidates) {
       if (candidate instanceof HTMLElement && isFillTarget(candidate) && document.contains(candidate)) {
-        if (await Promise.resolve(setElementValue(candidate, value))) {
-          candidate.focus?.();
-          state.lastFocusedField = candidate;
-          return true;
-        }
+        return candidate;
       }
     }
 
-    return false;
+    return null;
   }
 
   function setElementValue(element, value) {
@@ -1288,11 +1624,19 @@
       formatFillDiagnostics,
       getHighlightTargets,
       handleAiFillClick,
+      handleChipAction,
+      handleFieldChipClick,
       highlightFilledField,
       injectFieldHighlightStyles,
       isInViewport,
+      applyChipValue,
+      composeChipText,
+      syncChipSelectionState,
       setCurrentStore(store) {
         state.currentStore = store;
+      },
+      setLastFocusedField(field) {
+        state.lastFocusedField = field;
       },
       setShadowRoot(root) {
         shadowRoot = root;

--- a/tests/chip-compose-template.csv
+++ b/tests/chip-compose-template.csv
@@ -1,0 +1,4 @@
+Category,Field,Value
+Compose Test,A,A
+Compose Test,B,B
+Compose Test,C,C

--- a/tests/fill-highlight.test.js
+++ b/tests/fill-highlight.test.js
@@ -24,6 +24,16 @@ function loadHighlightHelpers(options = {}) {
     contains(value) {
       return this.values.has(value);
     }
+
+    toggle(value, force) {
+      const shouldAdd = force === undefined ? !this.values.has(value) : Boolean(force);
+      if (shouldAdd) {
+        this.values.add(value);
+      } else {
+        this.values.delete(value);
+      }
+      return shouldAdd;
+    }
   }
 
   class HTMLElement {
@@ -35,8 +45,14 @@ function loadHighlightHelpers(options = {}) {
       this.value = "";
       this.type = "text";
       this.disabled = false;
+      this.readOnly = false;
+      this.selectionStart = 0;
+      this.selectionEnd = 0;
+      this.isConnected = true;
       this.id = "";
       this.name = "";
+      this.dataset = {};
+      this.attributes = {};
       this.previousElementSibling = null;
       this.offsetWidth = 100;
       this.scrollCalls = [];
@@ -45,7 +61,11 @@ function loadHighlightHelpers(options = {}) {
     }
 
     getAttribute(name) {
-      return this[name] || null;
+      return this.attributes[name] ?? this[name] ?? null;
+    }
+
+    setAttribute(name, value) {
+      this.attributes[name] = String(value);
     }
 
     closest() {
@@ -67,6 +87,15 @@ function loadHighlightHelpers(options = {}) {
       this.dispatchedEvents.push(event);
       return true;
     }
+
+    focus() {
+      document.activeElement = this;
+    }
+
+    setSelectionRange(start, end) {
+      this.selectionStart = start;
+      this.selectionEnd = end;
+    }
   }
 
   class HTMLInputElement extends HTMLElement {
@@ -85,6 +114,7 @@ function loadHighlightHelpers(options = {}) {
   const styleElements = [];
   const document = {
     readyState: "loading",
+    activeElement: null,
     documentElement: { clientHeight: 600, clientWidth: 800 },
     head: {
       appendChild(element) {
@@ -106,6 +136,9 @@ function loadHighlightHelpers(options = {}) {
     },
     getElementById(id) {
       return styleElements.find((element) => element.id === id) || null;
+    },
+    contains(element) {
+      return element?.isConnected !== false;
     }
   };
 
@@ -149,7 +182,7 @@ function loadHighlightHelpers(options = {}) {
     },
     crypto: { randomUUID: () => "test-id" },
     document,
-    navigator: {},
+    navigator: { clipboard: { writeText: async () => {} } },
     self: { __RESUME_PRO_TEST__: true, ResumeProFormAgent: options.formAgent,
       ResumeProAIClient: { send: options.sendMessage || (async () => ({ success: true, matches: [] })),
         cancel: requestId => options.sendMessage({ type: 'CANCEL_AI_FILL', requestId }) } },
@@ -407,6 +440,219 @@ test("diagnostic summary only exposes allowlisted counts, durations and errors",
   assert.match(summary, /未执行 \/ 未取得/);
   assert.ok(!summary.includes("secret-key"));
   assert.ok(!summary.includes("private-name"));
+});
+
+test("chip text can be added at the caret, replaced, and removed", () => {
+  const { helpers } = loadHighlightHelpers();
+
+  const empty = helpers.composeChipText("", "A", "add", { start: 0, end: 0 });
+  assert.equal(empty.value, "A");
+  assert.equal(empty.caret, 1);
+
+  const appended = helpers.composeChipText("A", "B", "add", { start: 1, end: 1 });
+  assert.equal(appended.value, "AB");
+  assert.equal(appended.caret, 2);
+
+  const inserted = helpers.composeChipText("AB", "C", "add", { start: 1, end: 1 });
+  assert.equal(inserted.value, "ACB");
+  assert.equal(inserted.caret, 2);
+
+  const replaced = helpers.composeChipText("AB", "C", "replace", { start: 1, end: 1 });
+  assert.equal(replaced.value, "C");
+  assert.equal(replaced.caret, 1);
+
+  const removed = helpers.composeChipText("AB", "A", "remove", { start: 2, end: 2 });
+  assert.equal(removed.value, "B");
+  assert.equal(removed.caret, 0);
+});
+
+test("chip addition writes the combined value and restores the caret", async () => {
+  const { helpers, HTMLInputElement } = loadHighlightHelpers();
+  const input = new HTMLInputElement();
+  input.value = "AB";
+  input.selectionStart = 1;
+  input.selectionEnd = 1;
+
+  const filled = await helpers.applyChipValue(input, "C", "add", { start: 1, end: 1 });
+
+  assert.equal(filled, true);
+  assert.equal(input.value, "ACB");
+  assert.equal(input.selectionStart, 2);
+  assert.equal(input.selectionEnd, 2);
+  assert.equal(input.dispatchedEvents.length, 2);
+});
+
+test("a nonempty input waits for add or replace, while a selected chip is removed directly", async () => {
+  const { helpers, timers, HTMLElement, HTMLInputElement } = loadHighlightHelpers();
+  const menu = new HTMLElement();
+  menu.hidden = true;
+  menu.style = {};
+  menu.rect = { top: 0, left: 0, bottom: 44, right: 116, width: 116, height: 44 };
+  const status = new HTMLElement();
+  status.className = "resume-pro__status";
+  const chipA = new HTMLElement();
+  chipA.dataset.value = "A";
+  chipA.textContent = "字段 A";
+  const chipB = new HTMLElement();
+  chipB.dataset.value = "B";
+  chipB.textContent = "字段 B";
+  helpers.setShadowRoot({
+    querySelector(selector) {
+      return ({
+        "#resume-pro-chip-actions": menu,
+        "#resume-pro-status": status
+      })[selector] || null;
+    },
+    querySelectorAll(selector) {
+      return selector === ".resume-pro__chip" ? [chipA, chipB] : [];
+    }
+  });
+
+  const input = new HTMLInputElement();
+  input.value = "A";
+  input.selectionStart = 1;
+  input.selectionEnd = 1;
+  helpers.setLastFocusedField(input);
+
+  await helpers.handleFieldChipClick(chipB);
+  assert.equal(menu.hidden, false);
+  assert.equal(input.value, "A");
+
+  await helpers.handleChipAction("add");
+  assert.equal(menu.hidden, true);
+  assert.equal(input.value, "AB");
+
+  input.value = "A";
+  input.selectionStart = 1;
+  input.selectionEnd = 1;
+  await helpers.handleFieldChipClick(chipB);
+  await helpers.handleChipAction("replace");
+  assert.equal(input.value, "B");
+
+  input.selectionStart = 0;
+  input.selectionEnd = 0;
+  await helpers.handleFieldChipClick(chipA);
+  await helpers.handleChipAction("add");
+  assert.equal(input.value, "AB");
+
+  await helpers.handleFieldChipClick(chipA);
+  assert.equal(input.value, "B");
+  assert.equal(chipA.textContent, "字段 A");
+  assert.equal(chipB.textContent, "字段 B");
+  assert.equal(status.className, "resume-pro__status");
+  assert.equal(status.textContent, "");
+  assert.equal(timers.length, 0);
+});
+
+test("chips deepen when their values occur in the focused input", () => {
+  const { helpers, HTMLElement, HTMLInputElement } = loadHighlightHelpers();
+  const buttons = ["A", "B", "C"].map((value) => {
+    const button = new HTMLElement();
+    button.dataset.value = value;
+    return button;
+  });
+  const input = new HTMLInputElement();
+  input.value = "ABC";
+  helpers.setShadowRoot({
+    querySelector() {
+      return null;
+    },
+    querySelectorAll(selector) {
+      return selector === ".resume-pro__chip" ? buttons : [];
+    }
+  });
+  helpers.setLastFocusedField(input);
+
+  helpers.syncChipSelectionState();
+  assert.deepEqual(buttons.map((button) => button.classList.contains("is-in-field")), [true, true, true]);
+
+  input.value = "BC";
+  helpers.syncChipSelectionState();
+  assert.deepEqual(buttons.map((button) => button.classList.contains("is-in-field")), [false, true, true]);
+  assert.equal(buttons[0].attributes["aria-pressed"], "false");
+});
+
+test("chips with identical values keep independent selected states", async () => {
+  const { helpers, HTMLElement, HTMLInputElement } = loadHighlightHelpers();
+  const menu = new HTMLElement();
+  menu.hidden = true;
+  menu.style = {};
+  menu.rect = { top: 0, left: 0, bottom: 44, right: 116, width: 116, height: 44 };
+  const chipA = new HTMLElement();
+  chipA.dataset.chipId = "field-a";
+  chipA.dataset.value = "相同内容";
+  const chipC = new HTMLElement();
+  chipC.dataset.chipId = "field-c";
+  chipC.dataset.value = "相同内容";
+  helpers.setShadowRoot({
+    querySelector(selector) {
+      return selector === "#resume-pro-chip-actions" ? menu : null;
+    },
+    querySelectorAll(selector) {
+      return selector === ".resume-pro__chip" ? [chipA, chipC] : [];
+    }
+  });
+  const input = new HTMLInputElement();
+  helpers.setLastFocusedField(input);
+
+  await helpers.handleFieldChipClick(chipA);
+  assert.equal(input.value, "相同内容");
+  assert.equal(chipA.classList.contains("is-in-field"), true);
+  assert.equal(chipC.classList.contains("is-in-field"), false);
+
+  await helpers.handleFieldChipClick(chipC);
+  assert.equal(menu.hidden, false);
+  assert.equal(input.value, "相同内容");
+
+  await helpers.handleChipAction("replace");
+  assert.equal(chipA.classList.contains("is-in-field"), false);
+  assert.equal(chipC.classList.contains("is-in-field"), true);
+
+  const secondInput = new HTMLInputElement();
+  helpers.setLastFocusedField(secondInput);
+  await helpers.handleFieldChipClick(chipC);
+  assert.equal(secondInput.value, "相同内容");
+  assert.equal(chipA.classList.contains("is-in-field"), false);
+  assert.equal(chipC.classList.contains("is-in-field"), true);
+});
+
+test("replacement clears a previously selected chip even when its value prefixes the new chip", async () => {
+  const { helpers, HTMLElement, HTMLInputElement } = loadHighlightHelpers();
+  const menu = new HTMLElement();
+  menu.hidden = true;
+  menu.style = {};
+  menu.rect = { top: 0, left: 0, bottom: 44, right: 116, width: 116, height: 44 };
+  const chips = [
+    ["field-a", "产品"],
+    ["field-b", "经理"],
+    ["field-c", "产品设计师"]
+  ].map(([chipId, value]) => {
+    const chip = new HTMLElement();
+    chip.dataset.chipId = chipId;
+    chip.dataset.value = value;
+    return chip;
+  });
+  helpers.setShadowRoot({
+    querySelector(selector) {
+      return selector === "#resume-pro-chip-actions" ? menu : null;
+    },
+    querySelectorAll(selector) {
+      return selector === ".resume-pro__chip" ? chips : [];
+    }
+  });
+  const input = new HTMLInputElement();
+  input.value = "产品经理";
+  input.selectionStart = input.value.length;
+  input.selectionEnd = input.value.length;
+  helpers.setLastFocusedField(input);
+  helpers.syncChipSelectionState();
+  assert.deepEqual(chips.map((chip) => chip.classList.contains("is-in-field")), [true, true, false]);
+
+  await helpers.handleFieldChipClick(chips[2]);
+  await helpers.handleChipAction("replace");
+
+  assert.equal(input.value, "产品设计师");
+  assert.deepEqual(chips.map((chip) => chip.classList.contains("is-in-field")), [false, false, true]);
 });
 
 test("highlight styles are not duplicated in content.css", () => {

--- a/tests/manual-chip-compose.html
+++ b/tests/manual-chip-compose.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Resume Pro 字段组合测试</title>
+  <style>
+    :root { color-scheme: light; font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f5f7fb; color: #1e293b; }
+    main { width: min(720px, calc(100% - 40px)); margin: 56px auto; padding: 32px; border-radius: 20px; background: #fff; box-shadow: 0 18px 50px rgba(30, 41, 59, .1); }
+    h1 { margin: 0 0 10px; font-size: 26px; }
+    .lead { margin: 0 0 28px; color: #64748b; line-height: 1.7; }
+    label { display: block; margin-bottom: 8px; font-weight: 700; }
+    input { box-sizing: border-box; width: 100%; padding: 14px 16px; border: 2px solid #cbd5e1; border-radius: 12px; font-size: 18px; outline: none; }
+    input:focus { border-color: #4f6ef7; box-shadow: 0 0 0 4px rgba(79, 110, 247, .12); }
+    button { margin-top: 12px; padding: 9px 14px; border: 0; border-radius: 9px; background: #e2e8f0; color: #334155; cursor: pointer; font-weight: 700; }
+    ol { margin: 28px 0 0; padding-left: 22px; line-height: 1.9; }
+    code { padding: 2px 6px; border-radius: 6px; background: #eef2ff; color: #3855d9; }
+    #current-value { margin-top: 14px; color: #64748b; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>字段组合测试</h1>
+    <p class="lead">先点击下面的输入框，把光标放到需要的位置，再点击右侧 Resume Pro 中的字段 A、B、C。</p>
+
+    <label for="combined-field">网页表单的单个输入框</label>
+    <input id="combined-field" type="text" autocomplete="off" placeholder="在这里测试 A、B、C 的组合">
+    <button id="clear-field" type="button">清空输入框</button>
+    <div id="current-value" aria-live="polite">当前内容：（空）</div>
+
+    <ol>
+      <li>空框点 A，应直接得到 <code>A</code>。</li>
+      <li>再点 B，应出现“添加 / 替换”；选“添加”得到 <code>AB</code>。</li>
+      <li>把光标放在 A 和 B 中间，点 C 后选“添加”，应得到 <code>ACB</code>。</li>
+      <li>输入框为 <code>AB</code> 时再次点 A，应删除 A，仅保留 <code>B</code>。</li>
+      <li>输入框含 A、B、C 时，对应 chip 应变深；删除某项后，它应恢复原色。</li>
+    </ol>
+  </main>
+  <script>
+    const input = document.querySelector("#combined-field");
+    const output = document.querySelector("#current-value");
+    function showValue() {
+      output.textContent = `当前内容：${input.value || "（空）"}`;
+    }
+    input.addEventListener("input", showValue);
+    document.querySelector("#clear-field").addEventListener("click", () => {
+      input.value = "";
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.focus();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
侧边栏字段 chip 原先每次点击都会覆盖整个输入框，无法把简历中分别维护的字段组合到网页的单个表单项中。

This change:

- inserts the first chip value into an empty field at the caret;
- offers “添加 / 替换” for a non-empty text field;
- inserts added values at the saved caret position and replaces the whole value only when requested;
- removes an already selected chip value when that chip is clicked again;
- tracks chip identity so equal or overlapping values do not select the wrong field;
- keeps selected-chip styling synchronized with the focused input without transient status messages that move the sidebar;
- adds a local manual test page and A/B/C CSV fixture.

Validation:

- JavaScript syntax checks for all extension entry points
- `node --test tests/*.test.js` — 115 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 侧边栏字段芯片支持向输入框、文本域和可编辑区域插入、替换及移除文本。
  - 点击芯片后可使用操作菜单选择添加或替换内容，并支持按选区定位插入。
  - 芯片会显示选中、悬停和键盘聚焦状态，提升操作反馈与可用性。
- **界面优化**
  - 新增芯片过渡动画及固定操作菜单样式，交互更清晰顺畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->