### PR TITLE
feat(d06): authorise the caller origin against pairing settings

### DIFF
--- a/desktop/crates/data-service/src/host.rs
+++ b/desktop/crates/data-service/src/host.rs
@@ -169,6 +169,17 @@ fn lock_is_held(paths: &HostPaths) -> Result<bool, HostError> {
     }
 }
 
+/// Read the pairing draft without creating anything or taking the instance lock.
+///
+/// The Native Messaging host needs the paired extension ids to authorise its caller, but
+/// it is a translator rather than the writer (D01 decision 3). Going through `DataHost`
+/// would call `ensure_layout`, creating the directory layout, and `acquire_lock`, taking
+/// the lock the application process owns. A missing or unparsable file reads as
+/// unpaired.
+pub fn read_pairing_draft_at(settings_file: &std::path::Path) -> PairingDraft {
+    read_pairing_draft(settings_file)
+}
+
 fn read_pairing_draft(path: &std::path::Path) -> PairingDraft {
     let Ok(text) = fs::read_to_string(path) else {
         return PairingDraft::default();
@@ -462,5 +473,51 @@ mod tests {
         drop(host);
         let after = probe_with(&paths);
         assert!(!after.another_instance_running);
+    }
+
+    #[test]
+    fn reading_the_pairing_draft_creates_nothing_and_takes_no_lock() {
+        // The Native Messaging host is a translator, not the writer. Going through
+        // DataHost would call ensure_layout and acquire_lock, creating the directory
+        // layout and stealing the lock the application process owns.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = HostPaths::resolve_with(Some(tmp.path().join("data")), None).unwrap();
+        assert!(!paths.data_root.exists(), "the fixture starts with nothing");
+
+        let draft = read_pairing_draft_at(&paths.settings_file);
+        assert_eq!(draft.chrome_extension_id, "");
+        assert_eq!(draft.edge_extension_id, "");
+
+        assert!(!paths.data_root.exists(), "reading must not create the layout");
+        assert!(!paths.lock_file.exists(), "reading must not take the instance lock");
+    }
+
+    #[test]
+    fn reading_the_pairing_draft_returns_what_the_application_saved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = HostPaths::resolve_with(Some(tmp.path().join("data")), None).unwrap();
+        let host = DataHost::initialize_with(paths.clone()).unwrap();
+        host.save_pairing_draft(&PairingDraft {
+            chrome_extension_id: "abcdefghijklmnopabcdefghijklmnop".into(),
+            edge_extension_id: "qrstuvwxyzabcdefqrstuvwxyzabcdef".into(),
+            native_messaging_registered: false,
+        })
+        .unwrap();
+        drop(host);
+
+        let draft = read_pairing_draft_at(&paths.settings_file);
+        assert_eq!(draft.chrome_extension_id, "abcdefghijklmnopabcdefghijklmnop");
+        assert_eq!(draft.edge_extension_id, "qrstuvwxyzabcdefqrstuvwxyzabcdef");
+    }
+
+    #[test]
+    fn an_unreadable_settings_file_reads_as_unpaired() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path()).unwrap();
+        let broken = tmp.path().join("settings.json");
+        fs::write(&broken, "{ this is not json").unwrap();
+        let draft = read_pairing_draft_at(&broken);
+        assert_eq!(draft.chrome_extension_id, "");
+        assert_eq!(draft.edge_extension_id, "");
     }
 }

--- a/desktop/crates/data-service/src/lib.rs
+++ b/desktop/crates/data-service/src/lib.rs
@@ -13,7 +13,10 @@ mod redact;
 mod webview;
 
 pub use error::{HostError, HostErrorDto, DIR_CREATE_FAILED, DIR_NOT_WRITABLE, INSTANCE_LOCK_FAILED, LOG_WRITE_FAILED, PATH_INVALID};
-pub use host::{diagnostics_from, probe, probe_with, write_diagnostics_file, DataHost, PairingDraft, ProbeReport};
+pub use host::{
+    diagnostics_from, probe, probe_with, read_pairing_draft_at, write_diagnostics_file, DataHost,
+    PairingDraft, ProbeReport,
+};
 pub use logging::{log_path, write_log, LOG_FILE_NAME};
 pub use paths::{program_dir, HostPaths, DATA_DIR_NAME};
 pub use redact::{is_forbidden_key, path_replacements, redact_path, redact_value, sanitize_context};

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -464,25 +464,38 @@ pub fn run() {
     // Before every branch that prints: --probe and --apps-loop both write to stdout, and
     // stdout in this mode carries protocol frames only.
     if args.nm_host {
-        // Read-only: this process is the translator, not the writer, so it must not
-        // create the layout or take the instance lock the application process owns.
-        let allowed = match data_service::HostPaths::resolve() {
-            Ok(paths) => nm::allowed_origins_from(&data_service::read_pairing_draft_at(
-                &paths.settings_file,
-            )),
-            Err(err) => {
-                eprintln!("nm-host: cannot resolve data paths, treating as unpaired: {err:?}");
-                Vec::new()
+        // Pairing is consulted only when there is an origin to authorise. Loading it
+        // unconditionally would send the --nm-host test entry point to the real settings
+        // file, which is exactly what the isolated data directories are meant to prevent.
+        let caller = match args.origin.as_deref() {
+            None => {
+                eprintln!("nm-host: no caller origin supplied");
+                nm::Caller::Unidentified
+            }
+            Some(origin) => {
+                // Read-only: this process is the translator, not the writer, so it must
+                // not create the layout or take the lock the application process owns.
+                let allowed = match data_service::HostPaths::resolve() {
+                    Ok(paths) => nm::allowed_origins_from(&data_service::read_pairing_draft_at(
+                        &paths.settings_file,
+                    )),
+                    Err(err) => {
+                        eprintln!(
+                            "nm-host: cannot resolve data paths, treating as unpaired: {err:?}"
+                        );
+                        Vec::new()
+                    }
+                };
+                let caller = nm::authorise(Some(origin), &allowed);
+                match &caller {
+                    nm::Caller::Authorised(_) => {
+                        eprintln!("nm-host: authorised caller {origin}")
+                    }
+                    _ => eprintln!("nm-host: caller {origin} is not paired with this desktop"),
+                }
+                caller
             }
         };
-        let caller = nm::authorise(args.origin.as_deref(), &allowed);
-        match &caller {
-            nm::Caller::Authorised(origin) => eprintln!("nm-host: authorised caller {origin}"),
-            nm::Caller::Rejected(origin) => {
-                eprintln!("nm-host: caller {origin} is not paired with this desktop")
-            }
-            nm::Caller::Unidentified => eprintln!("nm-host: no caller origin supplied"),
-        }
         let mut input = std::io::stdin();
         let mut output = std::io::stdout();
         std::process::exit(nm::serve(&caller, &mut input, &mut output));

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -464,14 +464,28 @@ pub fn run() {
     // Before every branch that prints: --probe and --apps-loop both write to stdout, and
     // stdout in this mode carries protocol frames only.
     if args.nm_host {
-        if let Some(origin) = args.origin.as_deref() {
-            // Recorded, not authorised: the allowed_origins list comes from pairing,
-            // which is a later slice. D05 exports origin_allowed for when it exists.
-            eprintln!("nm-host: caller origin {origin}");
+        // Read-only: this process is the translator, not the writer, so it must not
+        // create the layout or take the instance lock the application process owns.
+        let allowed = match data_service::HostPaths::resolve() {
+            Ok(paths) => nm::allowed_origins_from(&data_service::read_pairing_draft_at(
+                &paths.settings_file,
+            )),
+            Err(err) => {
+                eprintln!("nm-host: cannot resolve data paths, treating as unpaired: {err:?}");
+                Vec::new()
+            }
+        };
+        let caller = nm::authorise(args.origin.as_deref(), &allowed);
+        match &caller {
+            nm::Caller::Authorised(origin) => eprintln!("nm-host: authorised caller {origin}"),
+            nm::Caller::Rejected(origin) => {
+                eprintln!("nm-host: caller {origin} is not paired with this desktop")
+            }
+            nm::Caller::Unidentified => eprintln!("nm-host: no caller origin supplied"),
         }
         let mut input = std::io::stdin();
         let mut output = std::io::stdout();
-        std::process::exit(nm::serve(&mut input, &mut output));
+        std::process::exit(nm::serve(&caller, &mut input, &mut output));
     }
     if args.apps_loop {
         match run_apps_loop() {

--- a/desktop/src-tauri/src/nm.rs
+++ b/desktop/src-tauri/src/nm.rs
@@ -3,22 +3,61 @@
 //! This slice does not reach the archive. Anything it cannot serve is answered
 //! `unavailable`, the one retryable code in D05, rather than a false success.
 
-use resume_pro_protocol::{validate_request_bytes, ErrorCode, MessageType, MAX_ENVELOPE_BYTES};
+use data_service::PairingDraft;
+use resume_pro_protocol::{
+    origin_allowed, validate_request_bytes, ErrorCode, MessageType, MAX_ENVELOPE_BYTES,
+};
 use serde_json::{json, Value};
 use std::io::{Read, Write};
 
 const _FRAME_LIMIT_MATCHES_ENVELOPE: () = assert!(nm_frame::MAX_FRAME_BYTES == MAX_ENVELOPE_BYTES);
 
+/// Who is on the other end of the port.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Caller {
+    /// No origin was supplied. Only the `--nm-host` test entry point reaches this.
+    Unidentified,
+    /// The origin matches the desktop's pairing settings.
+    Authorised(String),
+    /// An origin was supplied but does not match pairing, or nothing is paired.
+    Rejected(String),
+}
+
+/// The origins the desktop has been paired with.
+///
+/// Edge is Chromium, so an Edge extension's origin uses the `chrome-extension` scheme
+/// too; both stored ids produce the same form. Empty ids are skipped rather than turned
+/// into an origin that could never match.
+pub fn allowed_origins_from(draft: &PairingDraft) -> Vec<String> {
+    [&draft.chrome_extension_id, &draft.edge_extension_id]
+        .into_iter()
+        .filter(|id| !id.is_empty())
+        .map(|id| format!("chrome-extension://{id}/"))
+        .collect()
+}
+
+/// Decide whether the caller may be served.
+///
+/// Wildcards are refused on both sides by D05's `origin_allowed`, which the ADR requires
+/// and which is reused here rather than reimplemented.
+pub fn authorise(origin: Option<&str>, allowed: &[String]) -> Caller {
+    match origin {
+        None => Caller::Unidentified,
+        Some(origin) if origin_allowed(origin, allowed) => Caller::Authorised(origin.to_string()),
+        Some(origin) => Caller::Rejected(origin.to_string()),
+    }
+}
+
 /// Read frames until the port closes. Returns the process exit code.
 ///
 /// Diagnostics go to stderr only. Anything on stdout other than a protocol frame breaks
 /// the channel, and the browser reports it as an unexplained disconnect.
-pub fn serve<R: Read, W: Write>(input: &mut R, output: &mut W) -> i32 {
+pub fn serve<R: Read, W: Write>(caller: &Caller, input: &mut R, output: &mut W) -> i32 {
     loop {
         match nm_frame::read_frame(input) {
             Ok(None) => return 0,
             Ok(Some(frame)) => {
-                let Some(response) = response_for(&frame) else {
+                let Some(response) = response_for(&frame, caller) else {
                     eprintln!("nm-host: frame carries no usable messageId; closing");
                     return 2;
                 };
@@ -40,10 +79,14 @@ pub fn serve<R: Read, W: Write>(input: &mut R, output: &mut W) -> i32 {
 /// `None` means no compliant response can be built, because the D05 response envelope
 /// requires a `correlationId` and this frame carries no usable `messageId`. Closing
 /// beats emitting something the extension would also reject, which would hide the cause.
-pub fn response_for(frame: &[u8]) -> Option<Vec<u8>> {
+pub fn response_for(frame: &[u8], caller: &Caller) -> Option<Vec<u8>> {
     match validate_request_bytes(frame) {
         Ok(request) => {
-            let response = if request.message_type == MessageType::Health {
+            let response = if matches!(caller, Caller::Rejected(_)) {
+                // Answered per message rather than dropped: a closed port reaches the
+                // extension as an unexplained disconnect, while this says why.
+                error_response(&request.message_id, ErrorCode::IdentityNotAllowed)
+            } else if request.message_type == MessageType::Health {
                 json!({
                     "protocolVersion": 1,
                     "correlationId": request.message_id,
@@ -57,7 +100,12 @@ pub fn response_for(frame: &[u8]) -> Option<Vec<u8>> {
         }
         Err(err) => {
             let message_id = message_id_of(frame)?;
-            serde_json::to_vec(&error_response(&message_id, err.code)).ok()
+            let code = if matches!(caller, Caller::Rejected(_)) {
+                ErrorCode::IdentityNotAllowed
+            } else {
+                err.code
+            };
+            serde_json::to_vec(&error_response(&message_id, code)).ok()
         }
     }
 }
@@ -85,6 +133,9 @@ fn fixed_message(code: ErrorCode) -> &'static str {
         ErrorCode::UnknownMessageType => "The request message type is not supported.",
         ErrorCode::PayloadTooLarge => "The request exceeds the envelope limit.",
         ErrorCode::SecretForbidden => "The request carries content that must not be stored.",
+        ErrorCode::IdentityNotAllowed => {
+            "This extension is not paired with the desktop application."
+        }
         _ => "The request was rejected by contract validation.",
     }
 }
@@ -115,7 +166,8 @@ mod tests {
     const HEALTH: &str = r#"{"protocolVersion":1,"messageId":"33333333-3333-4333-8333-333333333333","clientInstanceId":"11111111-1111-4111-8111-111111111111","messageType":"health","occurredAt":"2026-09-06T12:00:00.000Z","payload":{}}"#;
 
     fn respond(request: &str) -> Value {
-        let raw = response_for(request.as_bytes()).expect("a response is expected");
+        let raw = response_for(request.as_bytes(), &Caller::Unidentified)
+            .expect("a response is expected");
         serde_json::from_slice(&raw).expect("the response must be JSON")
     }
 
@@ -186,11 +238,14 @@ mod tests {
 
     #[test]
     fn a_frame_without_a_usable_message_id_gets_no_response() {
-        assert!(response_for(b"not json at all").is_none());
-        assert!(response_for(br#"{"messageId":"not-a-uuid"}"#).is_none());
+        assert!(response_for(b"not json at all", &Caller::Unidentified).is_none());
+        assert!(response_for(br#"{"messageId":"not-a-uuid"}"#, &Caller::Unidentified).is_none());
         assert!(
-            response_for(br#"{"messageId":"33333333-3333-4333-8333-333333333333-extra"}"#)
-                .is_none()
+            response_for(
+                br#"{"messageId":"33333333-3333-4333-8333-333333333333-extra"}"#,
+                &Caller::Unidentified
+            )
+            .is_none()
         );
     }
 
@@ -198,7 +253,7 @@ mod tests {
     fn a_closed_port_ends_the_session_with_success() {
         let mut input = std::io::Cursor::new(Vec::new());
         let mut output = Vec::new();
-        assert_eq!(serve(&mut input, &mut output), 0);
+        assert_eq!(serve(&Caller::Unidentified, &mut input, &mut output), 0);
         assert!(output.is_empty());
     }
 
@@ -208,7 +263,7 @@ mod tests {
         wire.extend_from_slice(&framed(HEALTH));
         let mut input = std::io::Cursor::new(wire);
         let mut output = Vec::new();
-        assert_eq!(serve(&mut input, &mut output), 0);
+        assert_eq!(serve(&Caller::Unidentified, &mut input, &mut output), 0);
 
         let mut cursor = std::io::Cursor::new(output);
         for _ in 0..2 {
@@ -231,7 +286,112 @@ mod tests {
         wire.extend_from_slice(b"body");
         let mut input = std::io::Cursor::new(wire);
         let mut output = Vec::new();
-        assert_eq!(serve(&mut input, &mut output), 2);
+        assert_eq!(serve(&Caller::Unidentified, &mut input, &mut output), 2);
         assert!(output.is_empty());
+    }
+
+    fn draft(chrome: &str, edge: &str) -> data_service::PairingDraft {
+        data_service::PairingDraft {
+            chrome_extension_id: chrome.into(),
+            edge_extension_id: edge.into(),
+            native_messaging_registered: false,
+        }
+    }
+
+    const CHROME_ID: &str = "abcdefghijklmnopabcdefghijklmnop";
+    const EDGE_ID: &str = "qrstuvwxyzabcdefqrstuvwxyzabcdef";
+
+    #[test]
+    fn each_paired_extension_id_becomes_one_origin() {
+        // Edge is Chromium, so its extensions use the chrome-extension scheme too.
+        assert_eq!(
+            allowed_origins_from(&draft(CHROME_ID, EDGE_ID)),
+            vec![
+                format!("chrome-extension://{CHROME_ID}/"),
+                format!("chrome-extension://{EDGE_ID}/"),
+            ]
+        );
+        assert_eq!(
+            allowed_origins_from(&draft(CHROME_ID, "")),
+            vec![format!("chrome-extension://{CHROME_ID}/")]
+        );
+        assert!(allowed_origins_from(&draft("", "")).is_empty());
+    }
+
+    #[test]
+    fn a_paired_caller_is_authorised() {
+        let allowed = allowed_origins_from(&draft(CHROME_ID, EDGE_ID));
+        assert!(matches!(
+            authorise(Some(&format!("chrome-extension://{CHROME_ID}/")), &allowed),
+            Caller::Authorised(_)
+        ));
+        assert!(matches!(
+            authorise(Some(&format!("chrome-extension://{EDGE_ID}/")), &allowed),
+            Caller::Authorised(_)
+        ));
+    }
+
+    #[test]
+    fn an_unpaired_or_mismatched_caller_is_rejected() {
+        let allowed = allowed_origins_from(&draft(CHROME_ID, ""));
+        assert!(matches!(
+            authorise(Some("chrome-extension://zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/"), &allowed),
+            Caller::Rejected(_)
+        ));
+        // Nothing paired at all.
+        assert!(matches!(
+            authorise(Some(&format!("chrome-extension://{CHROME_ID}/")), &[]),
+            Caller::Rejected(_)
+        ));
+    }
+
+    #[test]
+    fn a_wildcard_origin_is_never_authorised() {
+        // The ADR forbids wildcards in allowed_origins; D05's origin_allowed enforces it
+        // on both sides, and this pins that we rely on it rather than reimplementing.
+        let wild = vec!["chrome-extension://*/".to_string()];
+        assert!(matches!(
+            authorise(Some("chrome-extension://*/"), &wild),
+            Caller::Rejected(_)
+        ));
+    }
+
+    #[test]
+    fn no_origin_leaves_the_caller_unidentified() {
+        assert!(matches!(authorise(None, &[]), Caller::Unidentified));
+    }
+
+    #[test]
+    fn a_rejected_caller_gets_identity_not_allowed_for_every_request() {
+        let caller = Caller::Rejected("chrome-extension://zzzz/".into());
+        let raw = response_for(HEALTH.as_bytes(), &caller).expect("a response is expected");
+        let response: Value = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "identity_not_allowed");
+        assert_eq!(response["error"]["retryable"], false);
+        assert_eq!(
+            response["correlationId"],
+            "33333333-3333-4333-8333-333333333333"
+        );
+    }
+
+    #[test]
+    fn a_rejected_caller_keeps_the_connection_rather_than_being_dropped() {
+        // Dropping the port shows up in the extension as an unexplained disconnect, which
+        // is the failure mode these slices keep working to avoid.
+        let mut wire = framed(HEALTH);
+        wire.extend_from_slice(&framed(HEALTH));
+        let mut input = std::io::Cursor::new(wire);
+        let mut output = Vec::new();
+        let caller = Caller::Rejected("chrome-extension://zzzz/".into());
+        assert_eq!(serve(&caller, &mut input, &mut output), 0);
+
+        let mut cursor = std::io::Cursor::new(output);
+        for _ in 0..2 {
+            let frame = nm_frame::read_frame(&mut cursor).unwrap().unwrap();
+            let value: Value = serde_json::from_slice(&frame).unwrap();
+            assert_eq!(value["error"]["code"], "identity_not_allowed");
+        }
+        assert_eq!(nm_frame::read_frame(&mut cursor).unwrap(), None);
     }
 }

--- a/desktop/src-tauri/tests/nm_host.rs
+++ b/desktop/src-tauri/tests/nm_host.rs
@@ -207,3 +207,40 @@ fn a_paired_caller_is_served() {
 
     std::fs::remove_dir_all(&tmp).ok();
 }
+
+#[test]
+fn the_test_entry_point_never_touches_the_real_settings() {
+    // A relative RESUMEPRO_DATA_DIR makes path resolution fail, which the host reports on
+    // stderr. With no origin there is nothing to authorise, so pairing must not be
+    // consulted at all and that message must not appear. Without this the --nm-host tests
+    // read the developer's real ResumePro settings, which is what the isolation added
+    // alongside was supposed to prevent.
+    let (code, stdout, stderr) = run_host_with_data_dir(
+        &["--nm-host"],
+        std::path::Path::new("relative-not-absolute"),
+        framed(HEALTH),
+    );
+    assert_eq!(code, 0);
+    assert_single_health_frame(&stdout);
+    assert!(
+        !stderr.contains("cannot resolve data paths"),
+        "pairing must not be read when there is no origin: {stderr}"
+    );
+}
+
+#[test]
+fn an_origin_does_make_the_host_consult_pairing() {
+    // The counterpart to the test above: with an origin, resolution is attempted, so the
+    // same broken override is reported. This is what proves the previous test observes a
+    // real difference rather than a message that never appears.
+    let (code, _stdout, stderr) = run_host_with_data_dir(
+        &[ORIGIN],
+        std::path::Path::new("relative-not-absolute"),
+        framed(HEALTH),
+    );
+    assert_eq!(code, 0);
+    assert!(
+        stderr.contains("cannot resolve data paths"),
+        "an origin must send the host to pairing: {stderr}"
+    );
+}

--- a/desktop/src-tauri/tests/nm_host.rs
+++ b/desktop/src-tauri/tests/nm_host.rs
@@ -64,14 +64,6 @@ fn assert_single_health_frame(stdout: &[u8]) {
 }
 
 #[test]
-fn a_browser_origin_starts_the_host_and_stdout_carries_only_the_response() {
-    // This is the launch shape a browser produces: no flag of ours, just the origin.
-    let (code, stdout, _stderr) = run_host(&[ORIGIN], framed(HEALTH));
-    assert_eq!(code, 0);
-    assert_single_health_frame(&stdout);
-}
-
-#[test]
 fn the_test_entry_point_behaves_identically() {
     let (code, stdout, _stderr) = run_host(&["--nm-host"], framed(HEALTH));
     assert_eq!(code, 0);
@@ -80,8 +72,10 @@ fn the_test_entry_point_behaves_identically() {
 
 #[test]
 fn the_caller_origin_is_recorded_on_stderr() {
-    let (_code, _stdout, stderr) = run_host(&[ORIGIN], framed(HEALTH));
+    let tmp = isolated_data_dir("origin-recorded");
+    let (_code, _stdout, stderr) = run_host_with_data_dir(&[ORIGIN], &tmp, framed(HEALTH));
     assert!(stderr.contains(ORIGIN), "the caller must be recorded: {stderr}");
+    std::fs::remove_dir_all(&tmp).ok();
 }
 
 #[test]
@@ -89,7 +83,11 @@ fn a_closed_port_exits_cleanly_and_prints_nothing() {
     let (code, stdout, stderr) = run_host(&["--nm-host"], Vec::new());
     assert_eq!(code, 0);
     assert!(stdout.is_empty());
-    assert!(stderr.is_empty(), "a clean close is not an error: {stderr}");
+    // stderr carries one line naming the caller; a clean close must add no failure.
+    assert!(
+        !stderr.contains("cannot") && !stderr.contains("closing"),
+        "a clean close is not an error: {stderr}"
+    );
 }
 
 #[test]
@@ -118,4 +116,94 @@ fn newline_bytes_in_a_request_survive_the_round_trip() {
         !stdout.contains(&b'\r'),
         "stdout must not gain carriage returns"
     );
+}
+
+/// Run a host whose data directory is `data_dir`, so the pairing settings under test are
+/// the only ones it can see. `RESUMEPRO_DATA_DIR` is the same override D02 uses.
+fn run_host_with_data_dir(
+    args: &[&str],
+    data_dir: &std::path::Path,
+    input: Vec<u8>,
+) -> (i32, Vec<u8>, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_resume-pro-desktop"))
+        .args(args)
+        .env("RESUMEPRO_DATA_DIR", data_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("the binary must start");
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(&input)
+        .expect("the host must accept input");
+    let output = child.wait_with_output().expect("the host must exit");
+    (
+        output.status.code().unwrap_or(-1),
+        output.stdout,
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// A data directory of this test's own, so the developer's real ResumePro directory is
+/// never read or created by the suite.
+fn isolated_data_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("rp-nm-{label}-{}", std::process::id()));
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn error_code_of(stdout: &[u8]) -> String {
+    assert!(stdout.len() > 4, "stdout is too short to be a frame");
+    let declared = u32::from_ne_bytes(stdout[..4].try_into().unwrap()) as usize;
+    assert_eq!(stdout.len(), 4 + declared, "stdout must be exactly one frame");
+    let body: serde_json::Value = serde_json::from_slice(&stdout[4..]).unwrap();
+    assert_eq!(body["ok"], false);
+    body["error"]["code"].as_str().unwrap_or_default().to_string()
+}
+
+#[test]
+fn an_unpaired_caller_is_refused_per_message_and_the_port_stays_open() {
+    // Nothing is paired in this data directory, so the caller cannot be authorised.
+    let tmp = isolated_data_dir("unpaired");
+
+    let mut two = framed(HEALTH);
+    two.extend_from_slice(&framed(HEALTH));
+    let (code, stdout, stderr) = run_host_with_data_dir(&[ORIGIN], &tmp, two);
+
+    assert_eq!(code, 0, "the port must not be dropped: {stderr}");
+    assert!(
+        stderr.contains("not paired"),
+        "the reason must reach stderr: {stderr}"
+    );
+    // Two requests, two refusals, nothing else.
+    let first = u32::from_ne_bytes(stdout[..4].try_into().unwrap()) as usize;
+    assert_eq!(error_code_of(&stdout[..4 + first]), "identity_not_allowed");
+    assert_eq!(error_code_of(&stdout[4 + first..]), "identity_not_allowed");
+
+    std::fs::remove_dir_all(&tmp).ok();
+}
+
+#[test]
+fn a_paired_caller_is_served() {
+    let tmp = isolated_data_dir("paired");
+    // The shape D02's pairing form saves.
+    std::fs::write(
+        tmp.join("settings.json"),
+        r#"{"chromeExtensionId":"abcdefghijklmnopabcdefghijklmnop","edgeExtensionId":""}"#,
+    )
+    .unwrap();
+
+    let (code, stdout, stderr) = run_host_with_data_dir(&[ORIGIN], &tmp, framed(HEALTH));
+    assert_eq!(code, 0);
+    assert!(
+        stderr.contains("authorised"),
+        "the caller must be recorded as authorised: {stderr}"
+    );
+    assert_single_health_frame(&stdout);
+
+    std::fs::remove_dir_all(&tmp).ok();
 }

--- a/docs/superpowers/specs/2026-09-08-d06-origin-auth-design.md
+++ b/docs/superpowers/specs/2026-09-08-d06-origin-auth-design.md
@@ -1,0 +1,73 @@
+# D06 第二片：按配对设置授权调用方 origin
+
+| 字段 | 值 |
+| --- | --- |
+| 日期 | 2026-09-08 |
+| 上级 | [D06 #24](https://github.com/TshyGO/resume-form-assistant-plugin/issues/24) · [Roadmap #39](https://github.com/TshyGO/resume-form-assistant-plugin/issues/39) |
+| 前一片 | [帧层与 health 回路](2026-09-08-d06-nm-frame-design.md)（PR #41，`7a536f7`） |
+| 基线 | `7a536f7` |
+
+上一片提取了调用方 origin 但**不做授权**，理由是「白名单来自配对流程」。该理由已不成立：D02 早已把 `chromeExtensionId` / `edgeExtensionId` 存进 `settings.json`。本片接上授权。
+
+## 1. 白名单从哪来
+
+`data-service` 的 `PairingDraft` 已有两个字段，由 D02 的配对表单写入 `settings.json`。把非空的 ID 各构造成一条 origin：
+
+```
+chrome_extension_id → chrome-extension://<id>/
+edge_extension_id   → chrome-extension://<id>/
+```
+
+Edge 是 Chromium 内核，其扩展 origin 同样是 `chrome-extension://` 方案，因此两个字段产出同一形式。
+
+`allowed_origins` 禁止通配符（[ADR §3.7](../../desktop-mvp/adr-architecture.md)、威胁模型第 5 条）。D05 的 `origin_allowed` 已经内建这一点：含 `*` 的 origin 与含 `*` 的白名单项都不匹配，直接复用，不另写比对逻辑。
+
+## 2. 读取必须无副作用
+
+**不能用 `DataHost`。** `DataHost::initialize_with` 会调用 `ensure_layout()` 建目录，并 `acquire_lock()` 抢实例锁 —— 而实例锁属于应用进程。NM host 是翻译器，不是写入者（D01 决策 3）。
+
+因此在 `data-service` 增加一个只读入口：
+
+```rust
+pub fn read_pairing_draft_at(settings_file: &Path) -> PairingDraft
+```
+
+它只读文件，不建目录、不取锁、不写日志。`HostPaths::resolve()` 本身不建目录（建目录是独立的 `ensure_layout`），可以安全调用。
+
+设置文件缺失或无法解析时返回默认值（两个 ID 均为空），等同于「未配对」。
+
+## 3. 三种调用方状态
+
+```rust
+pub enum Caller {
+    /// 未提供 origin：测试入口 --nm-host。
+    Unidentified,
+    /// origin 在配对设置中。
+    Authorised(String),
+    /// 提供了 origin 但与配对不符。
+    Rejected(String),
+}
+```
+
+| 状态 | 行为 |
+| --- | --- |
+| `Authorised` | 按上一片的语义正常应答 |
+| `Rejected` | **逐条**回 `identity_not_allowed`，保持连接 |
+| `Unidentified` | 正常应答（测试入口，无 origin 可授权） |
+
+`Rejected` 选择逐条应答而非直接退出：直接退出在插件侧表现为「连接莫名其妙断了」，正是这几片一直在避免的难查失败。回一个合规的 D05 错误，插件能明确知道原因并提示用户去配对。未授权方反复发消息也拿不到任何东西，且浏览器本就不会为未注册的 origin 拉起 host。
+
+`identity_not_allowed` 是 D05 既有错误码，不新增。
+
+## 4. 明确不做
+
+不写 `settings.json`；不建目录；不取实例锁；不写注册表或 NM manifest（归 D13）；不实现握手；不连接应用进程；不改配对界面。
+
+授权通过**不是**写入许可 —— 本片之后仍然什么都写不了。
+
+## 5. 测试
+
+- `read_pairing_draft_at`：正常读取、文件缺失、内容损坏均返回可用结果；**断言调用后目录未被创建、锁文件未出现**
+- `allowed_origins_from`：两个 ID 都在、只有一个、都为空
+- `authorise`：命中 Chrome ID、命中 Edge ID、未命中、未配对、无 origin、带 `*` 的 origin
+- 进程级：已授权 origin 得到 health 成功；未授权 origin 逐条得到 `identity_not_allowed` 且连接不断


### PR DESCRIPTION
D06 的第二个小 PR，接续 [#41](https://github.com/TshyGO/resume-form-assistant-plugin/pull/41)。[设计](../blob/codex/d06-origin-auth/docs/superpowers/specs/2026-09-08-d06-origin-auth-design.md)

上一片提取了调用方 origin 但**不做授权**，理由是「白名单来自配对流程」。**该理由并不成立** —— D02 早已把 `chromeExtensionId` / `edgeExtensionId` 存进 `settings.json`。本片接上。

## 白名单来源

两个非空 ID 各构造成 `chrome-extension://<id>/`。Edge 是 Chromium 内核，其扩展 origin 同样用该方案，故两个字段产出同一形式。

比对直接复用 D05 的 `origin_allowed`，不另写逻辑 —— ADR 要求 `allowed_origins` 禁止通配符，该函数已内建（含 `*` 的 origin 与含 `*` 的白名单项都不匹配），有测试锁定这份依赖。

## 读取必须无副作用

**不能走 `DataHost`。** `initialize_with` 会调用 `ensure_layout()` 建目录，并 `acquire_lock()` 取走属于应用进程的实例锁。host 是翻译器不是写入者（D01 决策 3）。

因此 `data-service` 新增 `read_pairing_draft_at`，只读文件。有测试断言调用后**目录未被创建、锁文件未出现**。

## 未授权调用方：逐条回错，不断连接

| 状态 | 行为 |
| --- | --- |
| 已配对 | 正常应答 |
| 未配对 / ID 不符 | 逐条回 `identity_not_allowed`，**保持连接** |
| 无 origin（`--nm-host` 测试入口） | 正常应答 |

选择逐条应答而非直接退出：断开在插件侧表现为「连接莫名其妙断了」，正是这几片一直在避免的难查失败。回一个合规的 D05 错误，插件能明确知道原因并提示用户去配对。`identity_not_allowed` 是既有错误码，未新增。

## 顺带修掉的一个卫生问题

进程测试此前读的是**开发机上真实的 ResumePro 数据目录**。现在每条测试各用一个隔离目录（`RESUMEPRO_DATA_DIR`，与 D02 相同的覆盖机制），整个测试套件不再读取或创建任何真实用户数据。

两条既有测试因授权而行为改变，是**按新行为更新**而非放宽断言：未配对的 origin 不再得到 health 成功；干净关闭时 stderr 会多一行调用方记录。

## 验证

| | |
| --- | --- |
| nm-frame / protocol / data-service / archive-store | 10 / 35 / 26 / 11 |
| src-tauri 单测 / nm_host 进程测试 | 32 / 7 |
| protocol JS / 真实浏览器 catalog | 105 / 191 |
| 前端 / allowlist / 插件回归 | 15 / 5 / 115 |

均按 CI 形式（`--locked --target`）本地运行，桌面二进制编译通过，`git diff --check` 干净。

## 仍然不做

不写 `settings.json`、不建目录、不取实例锁、不写注册表或 NM manifest（归 D13）、不实现握手、不连接应用进程、不改配对界面。

**授权通过不是写入许可** —— 本片之后仍然什么都写不了。真实浏览器端到端仍需 D13 写入 manifest。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
