### PR TITLE
feat(d06): wire the host to the application over the local endpoint

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -61,6 +61,10 @@ jobs:
         working-directory: desktop
         run: node --test src/pairing-form.test.js src/applications.test.js src/applications-ui.test.js
 
+      - name: Development registration script tests
+        working-directory: desktop
+        run: node --test scripts/nm-dev-register.test.js
+
       - name: Frontend build
         working-directory: desktop
         run: npm run build

--- a/desktop/DEV-NATIVE-MESSAGING.md
+++ b/desktop/DEV-NATIVE-MESSAGING.md
@@ -50,3 +50,23 @@ node scripts/nm-dev-register.mjs unregister
 ## 验证
 
 注册后不需要先打开桌面窗口：插件发出的第一条消息会由 host 唤起应用进程。可以用设置页的「Native Messaging」一项确认状态，或直接在插件里发一条 `handshake`。
+
+## 真实浏览器验收
+
+```bash
+python scripts/nm_browser_check.py
+```
+
+需要先 `pip install playwright && python -m playwright install chromium`，以及一个已构建的桌面二进制（`--binary` 可指定路径）。**手工运行，不进 CI**：它要有头浏览器、会真的写一次 Native Messaging 注册、会启动桌面进程。
+
+它自己造一个临时 MV3 探针扩展，全程用临时 `RESUMEPRO_DATA_DIR`（由浏览器传给它启动的 host），临时浏览器配置目录，跑完按 receipt 取消注册、退出应用、删掉临时目录。依次核对：
+
+1. 未配对的扩展被 `identity_not_allowed` 拒绝；
+2. 写入 `settings.json` 配对后握手成功，并带回 `archiveId` / `restoreEpoch`；
+3. `job.save` 成功并返回 `resultId`——**全程没有打开过桌面窗口**；
+4. 同一 `messageId` 再发一次，返回同一个 `resultId`，不会多出一条申请；
+5. `application.queryCandidates` 能查回刚存的那条。
+
+冷启动可能超过 host 的 10 秒预算，这时 host 返回可重试的 `unavailable`，脚本按插件应有的方式重试。这是设计中的行为，不是失败。
+
+关闭顺序有讲究：**先让应用退出，再关浏览器**。host 是浏览器的子进程，应用又是 host 的子进程，浏览器的管道被这个孙进程持有，先关浏览器会一直等下去。

--- a/desktop/DEV-NATIVE-MESSAGING.md
+++ b/desktop/DEV-NATIVE-MESSAGING.md
@@ -1,0 +1,52 @@
+# 开发期 Native Messaging 注册
+
+只用于本机开发调试。**生产安装、正式扩展 ID 注册与卸载属于 D13**，不要把这里的脚本当成安装器。
+
+## 前提
+
+1. 先构建桌面二进制（host 与应用是同一个可执行文件）：
+
+```bash
+cargo build --manifest-path src-tauri/Cargo.toml
+```
+
+2. 在浏览器里以「加载已解压的扩展程序」装好插件，记下它的扩展 ID（32 个 a–p 字母）。
+
+## 注册
+
+```bash
+node scripts/nm-dev-register.mjs register --extension-id <你的扩展ID>
+```
+
+默认同时注册 Chrome 与 Edge，二进制默认取 `src-tauri/target/debug/`。可选参数：
+
+- `--binary <绝对路径>`：指定别的可执行文件（例如 release 构建）。
+- `--browser chrome | edge | both`：只注册其中一个。
+- `--extension-id`：可重复，Chrome 与 Edge 的 ID 不同就都写上。
+- `--dry-run`：只打印将要写什么，不落盘。
+
+写入位置：
+
+| 平台 | manifest | 指针 |
+| --- | --- | --- |
+| Windows | `%LOCALAPPDATA%\ResumePro\dev-nm\<浏览器>-com.resumepro.desktop.json` | `HKCU\Software\Google\Chrome\NativeMessagingHosts\com.resumepro.desktop` 与 Edge 对应键 |
+| macOS | `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.resumepro.desktop.json`、`~/Library/Application Support/Microsoft Edge/NativeMessagingHosts/...` | 无 |
+
+Chrome 与 Edge 分别注册，不依赖 Edge 回退到 Chromium 键。
+
+## 取消注册
+
+```bash
+node scripts/nm-dev-register.mjs unregister
+```
+
+## 这个脚本不会做什么
+
+- **不覆盖不是它写的 manifest。** 目标位置已经有别人的注册时会跳过并报告，因为 unregister 无法还原一个它从没见过的文件。要替换请自己先删掉。
+- **不按文件名删除。** 注册时把每个改动连同内容摘要记到 receipt（Windows 在 `%LOCALAPPDATA%\ResumePro\dev-nm\receipt.json`，macOS 在 `~/Library/Application Support/ResumePro/dev-nm/receipt.json`），unregister 只删摘要仍然吻合的文件；注册后被手改过的会留下并说明原因。
+- **不删掉别人的注册表值。** 键在注册前已经指向别处时，unregister 恢复原值而不是删键。
+- **不接受通配 origin。** `allowed_origins` 只接受形如 `chrome-extension://<32位ID>/` 的条目，其余一律拒绝写入。
+
+## 验证
+
+注册后不需要先打开桌面窗口：插件发出的第一条消息会由 host 唤起应用进程。可以用设置页的「Native Messaging」一项确认状态，或直接在插件里发一条 `handshake`。

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,8 +15,11 @@
     "test:app": "cargo test --manifest-path src-tauri/Cargo.toml --locked --bins --lib",
     "test:frontend": "vite build",
     "test:ui": "node --test src/pairing-form.test.js src/applications.test.js src/applications-ui.test.js",
+    "test:nm-register": "node --test scripts/nm-dev-register.test.js",
+    "nm:register": "node scripts/nm-dev-register.mjs register",
+    "nm:unregister": "node scripts/nm-dev-register.mjs unregister",
     "test:release-allowlist": "node --test scripts/check-plugin-release-allowlist.test.js && node scripts/check-plugin-release-allowlist.js",
-    "test": "npm run test:host && npm run test:store && npm run test:app && npm run test:frontend && npm run test:ui && npm run test:release-allowlist"
+    "test": "npm run test:host && npm run test:store && npm run test:app && npm run test:frontend && npm run test:ui && npm run test:nm-register && npm run test:release-allowlist"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.4",

--- a/desktop/scripts/nm-dev-register.mjs
+++ b/desktop/scripts/nm-dev-register.mjs
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const HOST_NAME = "com.resumepro.desktop";
 
@@ -167,15 +168,17 @@ const realIo = {
 
 /// Add the manifest and, on Windows, the key that points at it.
 ///
-/// A target that already carries someone else's registration is reported and skipped: an
-/// unregister cannot restore a file it never saw, so overwriting one would leave the
-/// developer's real setup broken with no way back.
+/// A target is only written when this script still owns it. Ownership means a receipt
+/// entry whose digest matches what is on disk now — the entry alone is not enough, since
+/// the file may have been replaced since, and overwriting it would destroy a registration
+/// no unregister can put back.
 export function register(
   { platform, home, localAppData, browsers, binaryPath, extensionIds, dryRun = false },
   io = realIo,
 ) {
   const manifest = manifestFor(binaryPath, extensionIds, platform);
   const body = `${JSON.stringify(manifest, null, 2)}\n`;
+  const sha256 = digest(body);
   const file = receiptPath({ platform, home, localAppData });
   const receipt = loadReceipt(file, io);
   const planned = [];
@@ -183,15 +186,30 @@ export function register(
 
   for (const target of targetsFor({ platform, home, localAppData, browsers })) {
     const ours = receipt.entries.find((e) => e.manifestPath === target.manifestPath);
-    if (io.exists(target.manifestPath) && !ours) {
-      skipped.push({
-        ...target,
-        reason: "a manifest is already registered here and was not written by this script",
-      });
-      continue;
+    if (io.exists(target.manifestPath)) {
+      if (!ours) {
+        skipped.push({
+          ...target,
+          reason: "a manifest is already registered here and was not written by this script",
+        });
+        continue;
+      }
+      if (digest(io.read(target.manifestPath)) !== ours.sha256) {
+        skipped.push({
+          ...target,
+          reason: "the manifest here changed after it was registered; something else owns it",
+        });
+        continue;
+      }
     }
-    const previousRegistryValue =
-      target.registryKey && !ours ? io.readRegistry(target.registryKey) : (ours?.previousRegistryValue ?? null);
+    // What the key pointed at before this script first claimed it. On a re-registration
+    // that is whatever the first run recorded: re-reading now would capture this
+    // script's own value and have unregister restore it into the key it just cleared.
+    const previousRegistryValue = ours
+      ? (ours.previousRegistryValue ?? null)
+      : target.registryKey
+        ? io.readRegistry(target.registryKey)
+        : null;
     planned.push({ ...target, previousRegistryValue });
   }
 
@@ -203,27 +221,34 @@ export function register(
     (e) => !planned.some((p) => p.manifestPath === e.manifestPath),
   );
   for (const target of planned) {
-    io.write(target.manifestPath, manifest);
-    if (target.registryKey) {
-      io.writeRegistry(target.registryKey, target.manifestPath);
-    }
     entries.push({
       browser: target.browser,
       manifestPath: target.manifestPath,
       registryKey: target.registryKey,
       previousRegistryValue: target.previousRegistryValue,
-      sha256: digest(body),
+      sha256,
     });
   }
+  // The receipt is written before anything it describes. A failure partway through then
+  // leaves a record unregister can act on, where recording afterwards would leave changes
+  // nothing knows how to undo.
   io.write(file, { entries });
+  for (const target of planned) {
+    io.write(target.manifestPath, manifest);
+    if (target.registryKey) {
+      io.writeRegistry(target.registryKey, target.manifestPath);
+    }
+  }
   return { planned, skipped, manifest, applied: true };
 }
 
 /// Remove exactly what `register` added.
 ///
-/// A manifest whose content has changed since it was written is left alone: something
-/// else now owns it, and deleting it would be destroying a file this script did not
-/// produce. A registry key that pointed somewhere before is restored rather than deleted.
+/// Each half is checked separately, because they can be taken over separately. The
+/// registry value is only restored or cleared while it still points at this script's
+/// manifest, and the file is only deleted while its content is still the one that was
+/// registered. A missing file is not a reason to abandon the key: leaving it aimed at a
+/// manifest that is gone is exactly the state that has no owner left to clean it.
 export function unregister({ platform, home, localAppData, dryRun = false }, io = realIo) {
   const file = receiptPath({ platform, home, localAppData });
   const receipt = loadReceipt(file, io);
@@ -231,17 +256,18 @@ export function unregister({ platform, home, localAppData, dryRun = false }, io 
   const left = [];
 
   for (const entry of receipt.entries) {
-    if (!io.exists(entry.manifestPath)) {
-      removed.push({ ...entry, note: "already gone" });
-      continue;
-    }
-    if (digest(io.read(entry.manifestPath)) !== entry.sha256) {
+    const present = io.exists(entry.manifestPath);
+    if (present && digest(io.read(entry.manifestPath)) !== entry.sha256) {
       left.push({ ...entry, reason: "the manifest changed after it was registered" });
       continue;
     }
+    const keyIsOurs =
+      !entry.registryKey || io.readRegistry(entry.registryKey) === entry.manifestPath;
     if (!dryRun) {
-      io.remove(entry.manifestPath);
-      if (entry.registryKey) {
+      if (present) {
+        io.remove(entry.manifestPath);
+      }
+      if (entry.registryKey && keyIsOurs) {
         if (entry.previousRegistryValue) {
           io.writeRegistry(entry.registryKey, entry.previousRegistryValue);
         } else {
@@ -249,7 +275,11 @@ export function unregister({ platform, home, localAppData, dryRun = false }, io 
         }
       }
     }
-    removed.push(entry);
+    removed.push({
+      ...entry,
+      note: present ? undefined : "the manifest was already gone",
+      registry: keyIsOurs ? undefined : "the key now points elsewhere and was left alone",
+    });
   }
 
   if (!dryRun) {
@@ -346,10 +376,10 @@ function main(argv) {
 
 function defaultBinary() {
   const name = process.platform === "win32" ? "resume-pro-desktop.exe" : "resume-pro-desktop";
-  const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  const here = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(here, "..", "src-tauri", "target", "debug", name);
 }
 
-if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, "/")}`).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   process.exitCode = main(process.argv.slice(2));
 }

--- a/desktop/scripts/nm-dev-register.mjs
+++ b/desktop/scripts/nm-dev-register.mjs
@@ -24,6 +24,19 @@ const EXTENSION_ID = /^[a-p]{32}$/;
 
 export const BROWSERS = ["chrome", "edge"];
 
+/// Path semantics of the machine being registered, not of the machine running the code.
+/// Without this a Windows layout can only be reasoned about on Windows, which is exactly
+/// where a cross-platform mistake hides until the other runner finds it.
+function pathFor(platform) {
+  if (platform === "win32") {
+    return path.win32;
+  }
+  if (platform === "darwin") {
+    return path.posix;
+  }
+  throw new Error(`unsupported platform for development registration: ${platform}`);
+}
+
 /// Where each browser looks for a user-level manifest, and — on Windows, where the
 /// manifest itself may live anywhere — the registry key that points at it.
 export function targetsFor({ platform, home, localAppData, browsers = BROWSERS }) {
@@ -31,38 +44,36 @@ export function targetsFor({ platform, home, localAppData, browsers = BROWSERS }
   if (unknown.length > 0) {
     throw new Error(`unknown browser: ${unknown.join(", ")}`);
   }
+  const p = pathFor(platform);
   if (platform === "win32") {
-    const root = path.join(localAppData, "ResumePro", "dev-nm");
+    const root = p.join(localAppData, "ResumePro", "dev-nm");
     return browsers.map((browser) => ({
       browser,
-      manifestPath: path.join(root, `${browser}-${HOST_NAME}.json`),
+      manifestPath: p.join(root, `${browser}-${HOST_NAME}.json`),
       registryKey:
         browser === "chrome"
           ? `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${HOST_NAME}`
           : `HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\${HOST_NAME}`,
     }));
   }
-  if (platform === "darwin") {
-    const support = path.join(home, "Library", "Application Support");
-    return browsers.map((browser) => ({
-      browser,
-      manifestPath: path.join(
-        support,
-        browser === "chrome" ? path.join("Google", "Chrome") : "Microsoft Edge",
-        "NativeMessagingHosts",
-        `${HOST_NAME}.json`,
-      ),
-      registryKey: null,
-    }));
-  }
-  throw new Error(`unsupported platform for development registration: ${platform}`);
+  const support = p.join(home, "Library", "Application Support");
+  return browsers.map((browser) => ({
+    browser,
+    manifestPath: p.join(
+      support,
+      browser === "chrome" ? p.join("Google", "Chrome") : "Microsoft Edge",
+      "NativeMessagingHosts",
+      `${HOST_NAME}.json`,
+    ),
+    registryKey: null,
+  }));
 }
 
 /// The manifest a browser reads. `allowed_origins` names the extensions that may start
 /// this host; a wildcard would let any installed extension reach the archive, so ids are
 /// checked rather than trusted.
-export function manifestFor(binaryPath, extensionIds) {
-  if (!path.isAbsolute(binaryPath)) {
+export function manifestFor(binaryPath, extensionIds, platform = process.platform) {
+  if (!pathFor(platform).isAbsolute(binaryPath)) {
     throw new Error(`the host path must be absolute, got ${binaryPath}`);
   }
   if (extensionIds.length === 0) {
@@ -83,11 +94,12 @@ export function manifestFor(binaryPath, extensionIds) {
 }
 
 export function receiptPath({ platform, home, localAppData }) {
+  const p = pathFor(platform);
   const root =
     platform === "win32"
-      ? path.join(localAppData, "ResumePro", "dev-nm")
-      : path.join(home, "Library", "Application Support", "ResumePro", "dev-nm");
-  return path.join(root, "receipt.json");
+      ? p.join(localAppData, "ResumePro", "dev-nm")
+      : p.join(home, "Library", "Application Support", "ResumePro", "dev-nm");
+  return p.join(root, "receipt.json");
 }
 
 function digest(text) {
@@ -162,7 +174,7 @@ export function register(
   { platform, home, localAppData, browsers, binaryPath, extensionIds, dryRun = false },
   io = realIo,
 ) {
-  const manifest = manifestFor(binaryPath, extensionIds);
+  const manifest = manifestFor(binaryPath, extensionIds, platform);
   const body = `${JSON.stringify(manifest, null, 2)}\n`;
   const file = receiptPath({ platform, home, localAppData });
   const receipt = loadReceipt(file, io);

--- a/desktop/scripts/nm-dev-register.mjs
+++ b/desktop/scripts/nm-dev-register.mjs
@@ -1,0 +1,343 @@
+// Development-only Native Messaging registration.
+//
+// This exists so a real Chrome or Edge can reach the host during development. Production
+// installation, the official extension id and uninstall belong to D13 — nothing here is
+// part of a shipped build.
+//
+// Two rules shape the whole script:
+//   1. It never overwrites a manifest it did not write. A developer machine may already
+//      have a real registration, and clobbering it is not something an unregister can put
+//      back.
+//   2. Every change is written to a receipt first, so `unregister` removes exactly what
+//      was added and restores what was replaced, rather than deleting by name.
+
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const HOST_NAME = "com.resumepro.desktop";
+
+/// Chrome extension ids are exactly 32 characters from a-p.
+const EXTENSION_ID = /^[a-p]{32}$/;
+
+export const BROWSERS = ["chrome", "edge"];
+
+/// Where each browser looks for a user-level manifest, and — on Windows, where the
+/// manifest itself may live anywhere — the registry key that points at it.
+export function targetsFor({ platform, home, localAppData, browsers = BROWSERS }) {
+  const unknown = browsers.filter((b) => !BROWSERS.includes(b));
+  if (unknown.length > 0) {
+    throw new Error(`unknown browser: ${unknown.join(", ")}`);
+  }
+  if (platform === "win32") {
+    const root = path.join(localAppData, "ResumePro", "dev-nm");
+    return browsers.map((browser) => ({
+      browser,
+      manifestPath: path.join(root, `${browser}-${HOST_NAME}.json`),
+      registryKey:
+        browser === "chrome"
+          ? `HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts\\${HOST_NAME}`
+          : `HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts\\${HOST_NAME}`,
+    }));
+  }
+  if (platform === "darwin") {
+    const support = path.join(home, "Library", "Application Support");
+    return browsers.map((browser) => ({
+      browser,
+      manifestPath: path.join(
+        support,
+        browser === "chrome" ? path.join("Google", "Chrome") : "Microsoft Edge",
+        "NativeMessagingHosts",
+        `${HOST_NAME}.json`,
+      ),
+      registryKey: null,
+    }));
+  }
+  throw new Error(`unsupported platform for development registration: ${platform}`);
+}
+
+/// The manifest a browser reads. `allowed_origins` names the extensions that may start
+/// this host; a wildcard would let any installed extension reach the archive, so ids are
+/// checked rather than trusted.
+export function manifestFor(binaryPath, extensionIds) {
+  if (!path.isAbsolute(binaryPath)) {
+    throw new Error(`the host path must be absolute, got ${binaryPath}`);
+  }
+  if (extensionIds.length === 0) {
+    throw new Error("at least one extension id is required");
+  }
+  for (const id of extensionIds) {
+    if (!EXTENSION_ID.test(id)) {
+      throw new Error(`not an extension id: ${id}`);
+    }
+  }
+  return {
+    name: HOST_NAME,
+    description: "Resume Pro desktop archive (development registration)",
+    path: binaryPath,
+    type: "stdio",
+    allowed_origins: extensionIds.map((id) => `chrome-extension://${id}/`),
+  };
+}
+
+export function receiptPath({ platform, home, localAppData }) {
+  const root =
+    platform === "win32"
+      ? path.join(localAppData, "ResumePro", "dev-nm")
+      : path.join(home, "Library", "Application Support", "ResumePro", "dev-nm");
+  return path.join(root, "receipt.json");
+}
+
+function digest(text) {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function loadReceipt(file, io) {
+  if (!io.exists(file)) {
+    return { entries: [] };
+  }
+  try {
+    return JSON.parse(io.read(file));
+  } catch {
+    // A receipt that cannot be parsed is worse than none: acting on it would delete by
+    // guesswork. Starting empty means nothing already registered is touched.
+    return { entries: [] };
+  }
+}
+
+export function readReceipt(file) {
+  return loadReceipt(file, realIo);
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+/// Read the value a registry key currently points at, or null when the key is absent.
+/// Injected in tests, because the real one talks to the machine the tests run on.
+export function readRegistry(key) {
+  try {
+    // stderr is silenced: a missing key is the normal case and reg.exe reports it as an
+    // error, which would otherwise print noise over the script's own output.
+    const out = execFileSync("reg", ["query", key, "/ve"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const match = out.match(/REG_SZ\s+(.*)\r?\n/);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeRegistry(key, value) {
+  execFileSync("reg", ["add", key, "/ve", "/t", "REG_SZ", "/d", value, "/f"], {
+    stdio: "ignore",
+  });
+}
+
+export function deleteRegistry(key) {
+  execFileSync("reg", ["delete", key, "/f"], { stdio: "ignore" });
+}
+
+const realIo = {
+  exists: (file) => fs.existsSync(file),
+  read: (file) => fs.readFileSync(file, "utf8"),
+  write: writeJson,
+  remove: (file) => fs.rmSync(file, { force: true }),
+  readRegistry,
+  writeRegistry,
+  deleteRegistry,
+};
+
+/// Add the manifest and, on Windows, the key that points at it.
+///
+/// A target that already carries someone else's registration is reported and skipped: an
+/// unregister cannot restore a file it never saw, so overwriting one would leave the
+/// developer's real setup broken with no way back.
+export function register(
+  { platform, home, localAppData, browsers, binaryPath, extensionIds, dryRun = false },
+  io = realIo,
+) {
+  const manifest = manifestFor(binaryPath, extensionIds);
+  const body = `${JSON.stringify(manifest, null, 2)}\n`;
+  const file = receiptPath({ platform, home, localAppData });
+  const receipt = loadReceipt(file, io);
+  const planned = [];
+  const skipped = [];
+
+  for (const target of targetsFor({ platform, home, localAppData, browsers })) {
+    const ours = receipt.entries.find((e) => e.manifestPath === target.manifestPath);
+    if (io.exists(target.manifestPath) && !ours) {
+      skipped.push({
+        ...target,
+        reason: "a manifest is already registered here and was not written by this script",
+      });
+      continue;
+    }
+    const previousRegistryValue =
+      target.registryKey && !ours ? io.readRegistry(target.registryKey) : (ours?.previousRegistryValue ?? null);
+    planned.push({ ...target, previousRegistryValue });
+  }
+
+  if (dryRun) {
+    return { planned, skipped, manifest, applied: false };
+  }
+
+  const entries = receipt.entries.filter(
+    (e) => !planned.some((p) => p.manifestPath === e.manifestPath),
+  );
+  for (const target of planned) {
+    io.write(target.manifestPath, manifest);
+    if (target.registryKey) {
+      io.writeRegistry(target.registryKey, target.manifestPath);
+    }
+    entries.push({
+      browser: target.browser,
+      manifestPath: target.manifestPath,
+      registryKey: target.registryKey,
+      previousRegistryValue: target.previousRegistryValue,
+      sha256: digest(body),
+    });
+  }
+  io.write(file, { entries });
+  return { planned, skipped, manifest, applied: true };
+}
+
+/// Remove exactly what `register` added.
+///
+/// A manifest whose content has changed since it was written is left alone: something
+/// else now owns it, and deleting it would be destroying a file this script did not
+/// produce. A registry key that pointed somewhere before is restored rather than deleted.
+export function unregister({ platform, home, localAppData, dryRun = false }, io = realIo) {
+  const file = receiptPath({ platform, home, localAppData });
+  const receipt = loadReceipt(file, io);
+  const removed = [];
+  const left = [];
+
+  for (const entry of receipt.entries) {
+    if (!io.exists(entry.manifestPath)) {
+      removed.push({ ...entry, note: "already gone" });
+      continue;
+    }
+    if (digest(io.read(entry.manifestPath)) !== entry.sha256) {
+      left.push({ ...entry, reason: "the manifest changed after it was registered" });
+      continue;
+    }
+    if (!dryRun) {
+      io.remove(entry.manifestPath);
+      if (entry.registryKey) {
+        if (entry.previousRegistryValue) {
+          io.writeRegistry(entry.registryKey, entry.previousRegistryValue);
+        } else {
+          io.deleteRegistry(entry.registryKey);
+        }
+      }
+    }
+    removed.push(entry);
+  }
+
+  if (!dryRun) {
+    io.write(file, { entries: left });
+  }
+  return { removed, left, applied: !dryRun };
+}
+
+function parseArgs(argv) {
+  const args = { browsers: BROWSERS, extensionIds: [], dryRun: false };
+  let i = 0;
+  args.command = argv[i++];
+  while (i < argv.length) {
+    const flag = argv[i++];
+    if (flag === "--extension-id") {
+      args.extensionIds.push(argv[i++]);
+    } else if (flag === "--binary") {
+      args.binaryPath = path.resolve(argv[i++]);
+    } else if (flag === "--browser") {
+      args.browsers = argv[i++] === "both" ? BROWSERS : [argv[i - 1]];
+    } else if (flag === "--dry-run") {
+      args.dryRun = true;
+    } else {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  return args;
+}
+
+const USAGE = `Development-only Native Messaging registration.
+
+  node scripts/nm-dev-register.mjs register --extension-id <id> [--extension-id <id>]
+                                            [--binary <path to resume-pro-desktop>]
+                                            [--browser chrome|edge|both] [--dry-run]
+  node scripts/nm-dev-register.mjs unregister [--dry-run]
+
+Production registration is D13's, not this script's.`;
+
+function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    console.error(`${err.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const env = {
+    platform: process.platform,
+    home: os.homedir(),
+    localAppData: process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local"),
+    dryRun: args.dryRun,
+  };
+
+  if (args.command === "unregister") {
+    const result = unregister(env);
+    for (const entry of result.removed) {
+      console.log(`removed ${entry.browser}: ${entry.manifestPath}`);
+    }
+    for (const entry of result.left) {
+      console.log(`left alone ${entry.browser}: ${entry.manifestPath} — ${entry.reason}`);
+    }
+    return 0;
+  }
+
+  if (args.command !== "register") {
+    console.error(USAGE);
+    return 2;
+  }
+
+  try {
+    const result = register({
+      ...env,
+      browsers: args.browsers,
+      binaryPath: args.binaryPath ?? defaultBinary(),
+      extensionIds: args.extensionIds,
+      dryRun: args.dryRun,
+    });
+    const verb = result.applied ? "registered" : "would register";
+    for (const target of result.planned) {
+      console.log(`${verb} ${target.browser}: ${target.manifestPath}`);
+    }
+    for (const target of result.skipped) {
+      console.log(`skipped ${target.browser}: ${target.manifestPath} — ${target.reason}`);
+    }
+    if (result.skipped.length > 0) {
+      console.log("\nRemove those registrations yourself if you meant to replace them.");
+    }
+    return 0;
+  } catch (err) {
+    console.error(`${err.message}\n\n${USAGE}`);
+    return 2;
+  }
+}
+
+function defaultBinary() {
+  const name = process.platform === "win32" ? "resume-pro-desktop.exe" : "resume-pro-desktop";
+  const here = path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+  return path.resolve(here, "..", "src-tauri", "target", "debug", name);
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, "/")}`).href) {
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/desktop/scripts/nm-dev-register.test.js
+++ b/desktop/scripts/nm-dev-register.test.js
@@ -215,3 +215,75 @@ test("a missing receipt reads as empty rather than throwing", () => {
   assert.deepEqual(readReceipt("/no/such/receipt.json"), { entries: [] });
   assert.ok(receiptFile(WINDOWS).endsWith("ResumePro\\dev-nm\\receipt.json"));
 });
+
+test("re-registering over a manifest that was edited since is skipped", () => {
+  // A receipt entry alone is not ownership. The file may have been replaced by a real
+  // installer after this script wrote it, and overwriting it would destroy a registration
+  // no unregister can put back.
+  const io = fakeIo();
+  const options = {
+    ...WINDOWS,
+    browsers: ["chrome"],
+    binaryPath: BINARY_WIN,
+    extensionIds: [ID],
+  };
+  register(options, io);
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  io.files.set(chrome.manifestPath, '{"name":"replaced by an installer"}\n');
+
+  const result = register(options, io);
+  assert.equal(result.planned.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.match(result.skipped[0].reason, /changed after it was registered/);
+  assert.equal(io.files.get(chrome.manifestPath), '{"name":"replaced by an installer"}\n');
+});
+
+test("a registry key repointed after registration is left alone", () => {
+  // Something else owns the key now. Restoring the older value would silently remove a
+  // registration this script never made.
+  const io = fakeIo();
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  register({ ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  io.registry.set(chrome.registryKey, "C:\\Newer\\manifest.json");
+
+  const result = unregister(WINDOWS, io);
+  assert.equal(io.registry.get(chrome.registryKey), "C:\\Newer\\manifest.json");
+  assert.match(result.removed[0].registry, /points elsewhere/);
+  // The manifest half is still this script's to remove.
+  assert.equal(io.files.has(chrome.manifestPath), false);
+});
+
+test("a key is still cleared when the manifest is already gone", () => {
+  // Otherwise the browser is left pointed at a manifest that does not exist, and the
+  // receipt entry that could have explained it is dropped.
+  const io = fakeIo();
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  register({ ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  io.files.delete(chrome.manifestPath);
+
+  unregister(WINDOWS, io);
+  assert.equal(io.registry.has(chrome.registryKey), false);
+});
+
+test("a write that fails partway still leaves something unregister can act on", () => {
+  // The receipt is written before the changes it describes, so a failure does not leave
+  // a registry value with no record of how to undo it.
+  const io = fakeIo();
+  const failing = {
+    ...io,
+    writeRegistry: (key, value) => {
+      if (key.includes("Edge")) {
+        throw new Error("access denied");
+      }
+      io.registry.set(key, value);
+    },
+  };
+  assert.throws(
+    () => register({ ...WINDOWS, binaryPath: BINARY_WIN, extensionIds: [ID] }, failing),
+    /access denied/,
+  );
+
+  const result = unregister(WINDOWS, io);
+  assert.equal(result.removed.length, 2, "both targets are still accounted for");
+  assert.equal(io.registry.size, 0);
+});

--- a/desktop/scripts/nm-dev-register.test.js
+++ b/desktop/scripts/nm-dev-register.test.js
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  HOST_NAME,
+  manifestFor,
+  readReceipt,
+  register,
+  targetsFor,
+  unregister,
+} from "./nm-dev-register.mjs";
+
+/// A filesystem and registry that live in memory, so these tests never touch the browser
+/// configuration of the machine they run on.
+function fakeIo(initial = {}) {
+  const files = new Map(Object.entries(initial));
+  const registry = new Map();
+  return {
+    files,
+    registry,
+    exists: (file) => files.has(file),
+    read: (file) => files.get(file),
+    write: (file, value) => files.set(file, `${JSON.stringify(value, null, 2)}\n`),
+    remove: (file) => files.delete(file),
+    readRegistry: (key) => registry.get(key) ?? null,
+    writeRegistry: (key, value) => registry.set(key, value),
+    deleteRegistry: (key) => registry.delete(key),
+  };
+}
+
+const WINDOWS = {
+  platform: "win32",
+  home: "C:\\Users\\dev",
+  localAppData: "C:\\Users\\dev\\AppData\\Local",
+};
+const MAC = { platform: "darwin", home: "/Users/dev", localAppData: "" };
+const ID = "abcdefghijklmnopabcdefghijklmnop";
+const BINARY_WIN = "C:\\Program Files\\Resume Pro\\resume-pro-desktop.exe";
+const BINARY_MAC = "/Applications/Resume Pro.app/Contents/MacOS/resume-pro-desktop";
+
+function receiptFile(env) {
+  const io = fakeIo();
+  register({ ...env, binaryPath: env.platform === "win32" ? BINARY_WIN : BINARY_MAC, extensionIds: [ID] }, io);
+  return [...io.files.keys()].find((f) => f.endsWith("receipt.json"));
+}
+
+test("a manifest names only the extensions that were asked for", () => {
+  const manifest = manifestFor(BINARY_WIN, [ID]);
+  assert.equal(manifest.name, HOST_NAME);
+  assert.equal(manifest.type, "stdio");
+  assert.equal(manifest.path, BINARY_WIN);
+  assert.deepEqual(manifest.allowed_origins, [`chrome-extension://${ID}/`]);
+});
+
+test("a wildcard or malformed origin is refused rather than written", () => {
+  // A manifest is what decides who may start the host. Anything that is not an id would
+  // either be rejected by the browser or, worse, widen who can reach the archive.
+  assert.throws(() => manifestFor(BINARY_WIN, ["*"]), /not an extension id/);
+  assert.throws(() => manifestFor(BINARY_WIN, ["chrome-extension://*/"]), /not an extension id/);
+  assert.throws(() => manifestFor(BINARY_WIN, []), /at least one extension id/);
+});
+
+test("the host path must be absolute", () => {
+  // A relative path resolves against the browser's working directory, not the developer's.
+  assert.throws(() => manifestFor("resume-pro-desktop.exe", [ID]), /must be absolute/);
+});
+
+test("Windows registration writes both browser keys and points them at the manifest", () => {
+  const io = fakeIo();
+  const result = register({ ...WINDOWS, binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  assert.equal(result.applied, true);
+  assert.equal(result.planned.length, 2);
+  for (const target of result.planned) {
+    assert.equal(io.registry.get(target.registryKey), target.manifestPath);
+    assert.equal(JSON.parse(io.files.get(target.manifestPath)).path, BINARY_WIN);
+  }
+  // Chrome must not be reached through Edge's fallback to the Chromium key: each browser
+  // gets its own registration.
+  assert.ok([...io.registry.keys()].some((k) => k.includes("Google\\Chrome")));
+  assert.ok([...io.registry.keys()].some((k) => k.includes("Microsoft\\Edge")));
+});
+
+test("macOS registration writes the two user-level directories and no registry", () => {
+  const io = fakeIo();
+  const result = register({ ...MAC, binaryPath: BINARY_MAC, extensionIds: [ID] }, io);
+  assert.equal(result.planned.length, 2);
+  assert.equal(io.registry.size, 0);
+  const written = [...io.files.keys()];
+  assert.ok(
+    written.some((f) => f.includes(path.join("Google", "Chrome", "NativeMessagingHosts"))),
+  );
+  assert.ok(
+    written.some((f) => f.includes(path.join("Microsoft Edge", "NativeMessagingHosts"))),
+  );
+});
+
+test("an existing registration this script did not write is skipped, not replaced", () => {
+  // The developer may already have a real host installed. An unregister cannot put back a
+  // file it never saw, so replacing one would break their setup with no way back.
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  const io = fakeIo({ [chrome.manifestPath]: '{"name":"someone.elses.host"}\n' });
+  const result = register(
+    { ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] },
+    io,
+  );
+  assert.equal(result.planned.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.equal(io.files.get(chrome.manifestPath), '{"name":"someone.elses.host"}\n');
+});
+
+test("unregister removes exactly what register added", () => {
+  const io = fakeIo();
+  register({ ...WINDOWS, binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  const manifests = [...io.files.keys()].filter((f) => !f.endsWith("receipt.json"));
+  assert.equal(manifests.length, 2);
+
+  const result = unregister(WINDOWS, io);
+  assert.equal(result.removed.length, 2);
+  assert.equal(result.left.length, 0);
+  for (const file of manifests) {
+    assert.equal(io.files.has(file), false);
+  }
+  assert.equal(io.registry.size, 0, "the keys this script added are gone");
+});
+
+test("a registry key that pointed somewhere before is restored, not deleted", () => {
+  // Deleting it would silently remove a registration that existed before this script ran.
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  const io = fakeIo();
+  io.registry.set(chrome.registryKey, "C:\\Other\\manifest.json");
+  register({ ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  assert.equal(io.registry.get(chrome.registryKey), chrome.manifestPath);
+
+  unregister(WINDOWS, io);
+  assert.equal(io.registry.get(chrome.registryKey), "C:\\Other\\manifest.json");
+});
+
+test("a manifest edited after registration is left alone", () => {
+  // Something else owns it now. Removing it would destroy a file this script did not
+  // produce, which is the failure the receipt exists to prevent.
+  const io = fakeIo();
+  register({ ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  io.files.set(chrome.manifestPath, '{"name":"edited by hand"}\n');
+
+  const result = unregister(WINDOWS, io);
+  assert.equal(result.removed.length, 0);
+  assert.equal(result.left.length, 1);
+  assert.match(result.left[0].reason, /changed after it was registered/);
+  assert.ok(io.files.has(chrome.manifestPath));
+});
+
+test("unregistering twice is not an error", () => {
+  const io = fakeIo();
+  register({ ...WINDOWS, binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  unregister(WINDOWS, io);
+  const second = unregister(WINDOWS, io);
+  assert.equal(second.removed.length, 0);
+  assert.equal(second.left.length, 0);
+});
+
+test("a dry run reports what it would do and changes nothing", () => {
+  const io = fakeIo();
+  const result = register(
+    { ...WINDOWS, binaryPath: BINARY_WIN, extensionIds: [ID], dryRun: true },
+    io,
+  );
+  assert.equal(result.applied, false);
+  assert.equal(result.planned.length, 2);
+  assert.equal(io.files.size, 0);
+  assert.equal(io.registry.size, 0);
+});
+
+test("registering the same target twice does not lose the original registry value", () => {
+  // The second run must not record the first run's own value as what was there before,
+  // or unregister would restore a path back into the key it was supposed to clear.
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  const io = fakeIo();
+  const options = {
+    ...WINDOWS,
+    browsers: ["chrome"],
+    binaryPath: BINARY_WIN,
+    extensionIds: [ID],
+  };
+  register(options, io);
+  register(options, io);
+  unregister(WINDOWS, io);
+  assert.equal(io.registry.has(chrome.registryKey), false);
+});
+
+test("the receipt records the digest of what was written", () => {
+  const io = fakeIo();
+  register({ ...WINDOWS, browsers: ["chrome"], binaryPath: BINARY_WIN, extensionIds: [ID] }, io);
+  const file = [...io.files.keys()].find((f) => f.endsWith("receipt.json"));
+  const receipt = JSON.parse(io.files.get(file));
+  const [chrome] = targetsFor({ ...WINDOWS, browsers: ["chrome"] });
+  const expected = createHash("sha256")
+    .update(io.files.get(chrome.manifestPath), "utf8")
+    .digest("hex");
+  assert.equal(receipt.entries[0].sha256, expected);
+});
+
+test("an unsupported platform is refused rather than guessed at", () => {
+  assert.throws(() => targetsFor({ platform: "linux", home: "/home/dev" }), /unsupported platform/);
+});
+
+test("an unknown browser name is refused", () => {
+  assert.throws(() => targetsFor({ ...WINDOWS, browsers: ["safari"] }), /unknown browser/);
+});
+
+test("a missing receipt reads as empty rather than throwing", () => {
+  assert.deepEqual(readReceipt("/no/such/receipt.json"), { entries: [] });
+  assert.ok(receiptFile(WINDOWS).endsWith(path.join("ResumePro", "dev-nm", "receipt.json")));
+});

--- a/desktop/scripts/nm-dev-register.test.js
+++ b/desktop/scripts/nm-dev-register.test.js
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import path from "node:path";
 import test from "node:test";
 
 import {
@@ -47,7 +46,7 @@ function receiptFile(env) {
 }
 
 test("a manifest names only the extensions that were asked for", () => {
-  const manifest = manifestFor(BINARY_WIN, [ID]);
+  const manifest = manifestFor(BINARY_WIN, [ID], "win32");
   assert.equal(manifest.name, HOST_NAME);
   assert.equal(manifest.type, "stdio");
   assert.equal(manifest.path, BINARY_WIN);
@@ -57,14 +56,20 @@ test("a manifest names only the extensions that were asked for", () => {
 test("a wildcard or malformed origin is refused rather than written", () => {
   // A manifest is what decides who may start the host. Anything that is not an id would
   // either be rejected by the browser or, worse, widen who can reach the archive.
-  assert.throws(() => manifestFor(BINARY_WIN, ["*"]), /not an extension id/);
-  assert.throws(() => manifestFor(BINARY_WIN, ["chrome-extension://*/"]), /not an extension id/);
-  assert.throws(() => manifestFor(BINARY_WIN, []), /at least one extension id/);
+  assert.throws(() => manifestFor(BINARY_WIN, ["*"], "win32"), /not an extension id/);
+  assert.throws(
+    () => manifestFor(BINARY_WIN, ["chrome-extension://*/"], "win32"),
+    /not an extension id/,
+  );
+  assert.throws(() => manifestFor(BINARY_WIN, [], "win32"), /at least one extension id/);
 });
 
 test("the host path must be absolute", () => {
   // A relative path resolves against the browser's working directory, not the developer's.
-  assert.throws(() => manifestFor("resume-pro-desktop.exe", [ID]), /must be absolute/);
+  assert.throws(
+    () => manifestFor("resume-pro-desktop.exe", [ID], "win32"),
+    /must be absolute/,
+  );
 });
 
 test("Windows registration writes both browser keys and points them at the manifest", () => {
@@ -88,12 +93,8 @@ test("macOS registration writes the two user-level directories and no registry",
   assert.equal(result.planned.length, 2);
   assert.equal(io.registry.size, 0);
   const written = [...io.files.keys()];
-  assert.ok(
-    written.some((f) => f.includes(path.join("Google", "Chrome", "NativeMessagingHosts"))),
-  );
-  assert.ok(
-    written.some((f) => f.includes(path.join("Microsoft Edge", "NativeMessagingHosts"))),
-  );
+  assert.ok(written.some((f) => f.includes("/Google/Chrome/NativeMessagingHosts/")));
+  assert.ok(written.some((f) => f.includes("/Microsoft Edge/NativeMessagingHosts/")));
 });
 
 test("an existing registration this script did not write is skipped, not replaced", () => {
@@ -212,5 +213,5 @@ test("an unknown browser name is refused", () => {
 
 test("a missing receipt reads as empty rather than throwing", () => {
   assert.deepEqual(readReceipt("/no/such/receipt.json"), { entries: [] });
-  assert.ok(receiptFile(WINDOWS).endsWith(path.join("ResumePro", "dev-nm", "receipt.json")));
+  assert.ok(receiptFile(WINDOWS).endsWith("ResumePro\\dev-nm\\receipt.json"));
 });

--- a/desktop/scripts/nm_browser_check.py
+++ b/desktop/scripts/nm_browser_check.py
@@ -1,0 +1,381 @@
+"""Drive the D06 Native Messaging path from a real browser.
+
+This is the acceptance check that code alone cannot give: a browser starts the host, the
+host reaches the application, and a job reaches the archive with no desktop window ever
+opened.
+
+Run it by hand, not in CI. It needs a headed browser, it writes a real Native Messaging
+registration, and it starts the desktop process.
+
+    python scripts/nm_browser_check.py [--binary <path>] [--keep]
+
+Everything it creates is isolated: the archive lives in a temporary RESUMEPRO_DATA_DIR
+that the browser passes down to the host it starts, the browser runs on a temporary
+profile, and the registration is removed again through the same receipt-based unregister
+the developer scripts use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+DESKTOP = Path(__file__).resolve().parent.parent
+PROTOCOL_JS = DESKTOP / "crates" / "protocol" / "js"
+HOST_NAME = "com.resumepro.desktop"
+
+MANIFEST = {
+    "manifest_version": 3,
+    "name": "Resume Pro D06 probe",
+    "version": "0.0.1",
+    "permissions": ["nativeMessaging"],
+    "background": {"service_worker": "sw.js", "type": "module"},
+}
+
+PROBE_HTML = """<!doctype html>
+<meta charset="utf-8">
+<title>probe</title>
+<script type="module" src="probe.js"></script>
+<body><p id="state">idle</p></body>
+"""
+
+# One place builds the envelope, so the digest the desktop verifies is the digest of what
+# was actually sent rather than of a second copy assembled for the test.
+PROBE_JS = """
+import { payloadBodySha256 } from "./validate.mjs";
+
+const CLIENT = "11111111-1111-4111-8111-111111111111";
+
+async function envelope(messageType, messageId, payload, identity) {
+  const body = { ...payload };
+  // Only the write messages carry a source epoch and a digest; the query payload forbids
+  // both, and adding them would be rejected as an unexpected field.
+  const isWrite = ["job.save", "fill.submit", "submit.confirm"].includes(messageType);
+  if (identity && isWrite) {
+    body.sourceRestoreEpoch = identity.restoreEpoch;
+  }
+  if (isWrite) {
+    body.payloadSha256 = await payloadBodySha256(body);
+  }
+  const message = {
+    protocolVersion: 1,
+    messageId,
+    clientInstanceId: CLIENT,
+    messageType,
+    occurredAt: new Date().toISOString().replace(/(\\.\\d{3})?Z$/, ".000Z"),
+    payload: body,
+  };
+  if (identity) {
+    message.archiveId = identity.archiveId;
+    message.restoreEpoch = identity.restoreEpoch;
+  }
+  return message;
+}
+
+function send(message) {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendNativeMessage("__HOST_NAME__", message, (reply) => {
+      const err = chrome.runtime.lastError;
+      if (err) {
+        reject(new Error(err.message));
+        return;
+      }
+      resolve(reply);
+    });
+  });
+}
+
+window.runProbe = async () => {
+  const steps = {};
+  // Before pairing: the host must refuse this extension by origin, whatever it asks for.
+  steps.unpaired = await send(
+    await envelope("handshake", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa0", {
+      pluginVersion: "0.0.1",
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    }),
+  );
+  await window.pairThisExtension();
+
+  // A cold start is a real application launch, and the host answers `unavailable` when it
+  // outlasts the connect budget. That code is retryable, and retrying is what the plugin
+  // is supposed to do rather than reporting a failure to the user.
+  let handshake;
+  let attempts = 0;
+  do {
+    attempts += 1;
+    handshake = await send(
+      await envelope("handshake", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1", {
+        pluginVersion: "0.0.1",
+        minProtocolVersion: 1,
+        maxProtocolVersion: 1,
+      }),
+    );
+    if (handshake?.ok) {
+      break;
+    }
+    if (handshake?.error?.retryable !== true) {
+      break;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  } while (attempts < 10);
+  steps.handshake = handshake;
+  steps.handshakeAttempts = attempts;
+  const identity = {
+    archiveId: handshake?.payload?.archiveId,
+    restoreEpoch: handshake?.payload?.restoreEpoch,
+  };
+
+  const job = {
+    company: "Synthetic Ltd",
+    title: "Engineer",
+    sourceUrl: "https://jobs.example.test/d06",
+  };
+  const first = await envelope("job.save", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2", job, identity);
+  steps.save = await send(first);
+  // The same message again: a retry after a lost answer must not make a second
+  // application.
+  steps.retry = await send(first);
+  steps.candidates = await send(
+    await envelope(
+      "application.queryCandidates",
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3",
+      { company: job.company, title: job.title, sourceUrl: job.sourceUrl },
+      identity,
+    ),
+  );
+  return steps;
+};
+"""
+
+
+def build_extension(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "manifest.json").write_text(json.dumps(MANIFEST, indent=2), encoding="utf-8")
+    # An empty worker exists only so the extension id can be read before anything is
+    # registered against it.
+    (directory / "sw.js").write_text("// present so the extension has an id to read\n", encoding="utf-8")
+    (directory / "probe.html").write_text(PROBE_HTML, encoding="utf-8")
+    (directory / "probe.js").write_text(PROBE_JS.replace("__HOST_NAME__", HOST_NAME), encoding="utf-8")
+    for module in ("validate.mjs", "schema-lite.mjs", "schema-data.mjs", "time.mjs"):
+        shutil.copy(PROTOCOL_JS / module, directory / module)
+
+
+def default_binary() -> Path:
+    name = "resume-pro-desktop.exe" if sys.platform == "win32" else "resume-pro-desktop"
+    for profile in ("debug", "release"):
+        candidate = DESKTOP / "src-tauri" / "target" / profile / name
+        if candidate.exists():
+            return candidate
+    raise SystemExit(
+        "no desktop binary found; run: cargo build --manifest-path src-tauri/Cargo.toml"
+    )
+
+
+def pair(data_root: Path, extension_id: str) -> None:
+    """Write the pairing draft the desktop reads when it authorises a caller.
+
+    Written directly rather than through the settings window: the point of this check is
+    that no window is needed, and the draft is the same settings.json the window writes.
+    """
+    (data_root / "settings.json").write_text(
+        json.dumps(
+            {
+                "chromeExtensionId": extension_id,
+                "edgeExtensionId": "",
+                "nativeMessagingRegistered": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def stop_application(binary: Path, env: dict) -> None:
+    """Ask the running application to exit.
+
+    Done before the browser is closed. The host is a child of the browser and the
+    application a child of the host, and Playwright's close waits for the browser's pipes;
+    a surviving descendant holds them open, which used to make the close never return.
+    """
+    subprocess.run(
+        [str(binary), "--quit"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=60,
+    )
+
+
+def node(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", str(DESKTOP / "scripts" / "nm-dev-register.mjs"), *args],
+        cwd=DESKTOP,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def check(steps: dict, failures: list[str]) -> None:
+    unpaired = steps.get("unpaired") or {}
+    if unpaired.get("ok") is not False:
+        failures.append(f"an unpaired extension was not refused: {unpaired}")
+    elif unpaired.get("error", {}).get("code") != "identity_not_allowed":
+        failures.append(f"an unpaired extension was refused for the wrong reason: {unpaired}")
+
+    handshake = steps.get("handshake") or {}
+    if handshake.get("ok") is not True:
+        failures.append(f"handshake was not accepted: {handshake}")
+        return
+    if not handshake.get("payload", {}).get("archiveId"):
+        failures.append("handshake carried no archive identity to stamp writes with")
+    print(f"handshake succeeded on attempt {steps.get('handshakeAttempts')}")
+
+    save = steps.get("save") or {}
+    if save.get("ok") is not True:
+        failures.append(f"job.save was not accepted: {save}")
+        return
+    result_id = save.get("resultId")
+    if not result_id:
+        failures.append("job.save did not name what it produced")
+
+    retry = steps.get("retry") or {}
+    if retry.get("resultId") != result_id:
+        failures.append(
+            f"a retry produced a different result: {retry.get('resultId')} != {result_id}"
+        )
+
+    candidates = steps.get("candidates") or {}
+    exact = candidates.get("payload", {}).get("exact", [])
+    if len(exact) != 1:
+        failures.append(f"the saved job was not found again, got {exact}")
+    elif exact[0].get("applicationId") != result_id:
+        failures.append("the candidate query returned a different application")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, default=None)
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="leave the temporary archive in place for inspection",
+    )
+    args = parser.parse_args()
+    binary = (args.binary or default_binary()).resolve()
+    if not binary.exists():
+        raise SystemExit(f"no such binary: {binary}")
+
+    workspace = Path(tempfile.mkdtemp(prefix="resumepro-d06-"))
+    data_dir = workspace / "data"
+    data_dir.mkdir()
+    extension = workspace / "extension"
+    build_extension(extension)
+
+    env = {**os.environ, "RESUMEPRO_DATA_DIR": str(data_dir)}
+    failures: list[str] = []
+    registered = False
+    try:
+        with sync_playwright() as p:
+            context = p.chromium.launch_persistent_context(
+                user_data_dir=str(workspace / "profile"),
+                headless=False,
+                env=env,
+                args=[
+                    f"--disable-extensions-except={extension}",
+                    f"--load-extension={extension}",
+                ],
+            )
+            try:
+                worker = context.service_workers[0] if context.service_workers else context.wait_for_event(
+                    "serviceworker", timeout=30_000
+                )
+                extension_id = worker.url.split("/")[2]
+                print(f"extension id: {extension_id}")
+
+                # Registered only now: the id is not known before the browser assigns it.
+                result = node(
+                    "register",
+                    "--extension-id",
+                    extension_id,
+                    "--browser",
+                    "chrome",
+                    "--binary",
+                    str(binary),
+                )
+                print(result.stdout.strip() or result.stderr.strip())
+                if result.returncode != 0:
+                    failures.append("registration failed")
+                    return report(failures)
+                if "skipped" in result.stdout:
+                    failures.append(
+                        "a registration was already present; remove it and run this again"
+                    )
+                    return report(failures)
+                registered = True
+
+                page = context.new_page()
+                page.goto(f"chrome-extension://{extension_id}/probe.html")
+                page.expose_function(
+                    "pairThisExtension", lambda: pair(data_dir, extension_id)
+                )
+                steps = page.evaluate("() => window.runProbe()")
+                print(json.dumps(steps, indent=2, ensure_ascii=False))
+                check(steps, failures)
+            finally:
+                stop_application(binary, env)
+                context.close()
+    finally:
+        if registered:
+            print(node("unregister").stdout.strip())
+        # The host started the application, and it holds the archive lock until told to
+        # stop. Leaving it running would keep a process on a directory about to be deleted.
+        # Also here: an early failure can leave an application running that the block
+        # above never reached.
+        stop_application(binary, env)
+        if args.keep:
+            print(f"left in place: {workspace}")
+        else:
+            # The application holds the archive open until it has finished exiting, and a
+            # locked file cannot be removed on Windows. Retrying is therefore also the
+            # check that it really stopped.
+            deadline = time.monotonic() + 20
+            while True:
+                try:
+                    shutil.rmtree(workspace)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        print(
+                            f"WARNING: {workspace} could not be removed; something is still "
+                            "holding it open",
+                            file=sys.stderr,
+                        )
+                        break
+                    time.sleep(1)
+
+    return report(failures)
+
+
+def report(failures: list[str]) -> int:
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+    print("OK: the browser reached the archive through the host with no window open")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2085,6 +2085,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "local-ipc"
+version = "0.1.0"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +2926,7 @@ version = "0.1.0"
 dependencies = [
  "archive-store",
  "data-service",
+ "local-ipc",
  "nm-frame",
  "resume-pro-protocol",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 archive-store = { path = "../crates/archive-store" }
 data-service = { path = "../crates/data-service" }
+local-ipc = { path = "../crates/local-ipc" }
 nm-frame = { path = "../crates/nm-frame" }
 resume-pro-protocol = { path = "../crates/protocol" }
 serde = { version = "1", features = ["derive"] }

--- a/desktop/src-tauri/src/cli.rs
+++ b/desktop/src-tauri/src/cli.rs
@@ -101,7 +101,9 @@ pub fn prepare_stdio() {
     }
     #[cfg(windows)]
     unsafe {
-        use windows_sys::Win32::System::Console::{AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS};
+        use windows_sys::Win32::System::Console::{
+            AllocConsole, AttachConsole, ATTACH_PARENT_PROCESS,
+        };
         if AttachConsole(ATTACH_PARENT_PROCESS) == 0 {
             let _ = AllocConsole();
         }

--- a/desktop/src-tauri/src/ipc_client.rs
+++ b/desktop/src-tauri/src/ipc_client.rs
@@ -41,13 +41,20 @@ pub fn connect_or_start(data_root: &Path, program: &Path) -> Result<local_ipc::S
 }
 
 fn start_hidden(program: &Path) -> std::io::Result<()> {
-    std::process::Command::new(program)
+    let mut child = std::process::Command::new(program)
         .arg("--hidden")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .spawn()
-        .map(|_child| ())
+        .spawn()?;
+    // Dropping a Child does not reap it. On Unix the application would then sit as a
+    // zombie for as long as this host lives, and a connectNative port lives as long as
+    // the browser keeps it open. The wait happens on its own thread so the cold start
+    // stays non-blocking, which is the whole point of not waiting here.
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
 }
 
 /// Retry until the endpoint answers or the deadline passes.

--- a/desktop/src-tauri/src/ipc_client.rs
+++ b/desktop/src-tauri/src/ipc_client.rs
@@ -1,0 +1,143 @@
+//! The Native Messaging host's side of the local IPC.
+//!
+//! The host is a translator: it validates, forwards, and relays the answer. It does not
+//! open the archive and it does not invent a successful response, so "persisted before
+//! the answer" stays a property of the application process.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use local_ipc::{Endpoint, IpcError};
+
+/// How long to wait for a cold-started application to answer its endpoint.
+const COLD_START_TIMEOUT: Duration = Duration::from_secs(10);
+const RETRY_INTERVAL: Duration = Duration::from_millis(150);
+
+/// Reach the application, starting it if nothing is listening.
+///
+/// Several hosts can run at once — a browser starts one per message, and Chrome and Edge
+/// each have their own — so several may find the application missing and try to start it
+/// together. No extra mutex is needed: the single-instance rule means the extra processes
+/// exit and the winner takes `host.lock` and listens, which the others reach by retrying.
+pub fn connect_or_start(data_root: &Path, program: &Path) -> Result<local_ipc::Stream, IpcError> {
+    let endpoint = Endpoint::for_data_root(data_root)?;
+    match local_ipc::connect(&endpoint) {
+        Ok(stream) => return Ok(stream),
+        // Busy means it is running and saturated, so waiting is right and starting a
+        // second one would be wrong.
+        Err(IpcError::Busy) => return wait_for(&endpoint, COLD_START_TIMEOUT),
+        Err(IpcError::NotRunning) => {}
+        Err(other) => return Err(other),
+    }
+
+    if let Err(err) = start_hidden(program) {
+        // A missing executable, a security product, a crash on startup: none of them can
+        // be told apart from here, and none is worth failing differently. The wait below
+        // decides, so this is reported and not returned.
+        eprintln!("nm-host: could not start the application: {err}");
+    }
+    wait_for(&endpoint, COLD_START_TIMEOUT)
+}
+
+fn start_hidden(program: &Path) -> std::io::Result<()> {
+    std::process::Command::new(program)
+        .arg("--hidden")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map(|_child| ())
+}
+
+/// Retry until the endpoint answers or the deadline passes.
+fn wait_for(endpoint: &Endpoint, budget: Duration) -> Result<local_ipc::Stream, IpcError> {
+    let deadline = Instant::now() + budget;
+    loop {
+        match local_ipc::connect(endpoint) {
+            Ok(stream) => return Ok(stream),
+            Err(IpcError::NotRunning) | Err(IpcError::Busy) => {
+                if Instant::now() >= deadline {
+                    return Err(IpcError::NotRunning);
+                }
+                std::thread::sleep(RETRY_INTERVAL);
+            }
+            // An untrusted or unusable endpoint will not become usable by waiting.
+            Err(other) => return Err(other),
+        }
+    }
+}
+
+/// The executable to start for a cold start: this same binary, which is also what the
+/// Windows transport expects the listening process to be running.
+pub fn own_program() -> Result<PathBuf, IpcError> {
+    std::env::current_exe().map_err(IpcError::Io)
+}
+
+/// Send one frame to the application and return its answer.
+pub fn exchange<S: Read + Write>(stream: &mut S, frame: &[u8]) -> Result<Vec<u8>, IpcError> {
+    nm_frame::write_frame(stream, frame).map_err(frame_error)?;
+    match nm_frame::read_frame(stream).map_err(frame_error)? {
+        Some(reply) => Ok(reply),
+        None => Err(IpcError::Io(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "the application closed the connection without answering",
+        ))),
+    }
+}
+
+fn frame_error(err: nm_frame::FrameError) -> IpcError {
+    IpcError::Io(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        format!("{err:?}"),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_application_is_reported_after_the_wait_rather_than_hanging() {
+        // A cold start that cannot happen must end, and end as NotRunning so the caller
+        // answers unavailable instead of blocking the browser forever.
+        let dir = tempfile::tempdir().unwrap();
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+        let started = Instant::now();
+        let outcome = wait_for(&endpoint, Duration::from_millis(400));
+        assert!(matches!(outcome, Err(IpcError::NotRunning)));
+        assert!(
+            started.elapsed() >= Duration::from_millis(400),
+            "the budget must actually be spent"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "and not overspent"
+        );
+    }
+
+    #[test]
+    fn a_program_that_cannot_start_still_ends_as_not_running() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-program");
+        // The wait dominates the runtime, so this uses the real budget only once.
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+        assert!(start_hidden(&missing).is_err());
+        assert!(matches!(
+            wait_for(&endpoint, Duration::from_millis(200)),
+            Err(IpcError::NotRunning)
+        ));
+    }
+
+    #[test]
+    fn a_running_application_is_reached_without_starting_another() {
+        let dir = tempfile::tempdir().unwrap();
+        let _service = crate::ipc_server::start(dir.path()).unwrap();
+        // A program path that cannot exist: if connect_or_start tried to start anything,
+        // this would fail rather than reach the listener already there.
+        let impossible = dir.path().join("must-not-be-started");
+        let stream = connect_or_start(dir.path(), &impossible).unwrap();
+        drop(stream);
+        assert!(!impossible.exists());
+    }
+}

--- a/desktop/src-tauri/src/ipc_client.rs
+++ b/desktop/src-tauri/src/ipc_client.rs
@@ -87,10 +87,7 @@ pub fn exchange<S: Read + Write>(stream: &mut S, frame: &[u8]) -> Result<Vec<u8>
 }
 
 fn frame_error(err: nm_frame::FrameError) -> IpcError {
-    IpcError::Io(std::io::Error::new(
-        std::io::ErrorKind::Other,
-        format!("{err:?}"),
-    ))
+    IpcError::Io(std::io::Error::other(format!("{err:?}")))
 }
 
 #[cfg(test)]
@@ -132,7 +129,14 @@ mod tests {
     #[test]
     fn a_running_application_is_reached_without_starting_another() {
         let dir = tempfile::tempdir().unwrap();
-        let _service = crate::ipc_server::start(dir.path()).unwrap();
+        struct NoArchive;
+        impl crate::ipc_server::Application for NoArchive {
+            fn identity(&self) -> Option<resume_pro_protocol::CurrentArchive> {
+                None
+            }
+        }
+        let _service =
+            crate::ipc_server::start(dir.path(), std::sync::Arc::new(NoArchive)).unwrap();
         // A program path that cannot exist: if connect_or_start tried to start anything,
         // this would fail rather than reach the listener already there.
         let impossible = dir.path().join("must-not-be-started");

--- a/desktop/src-tauri/src/ipc_server.rs
+++ b/desktop/src-tauri/src/ipc_server.rs
@@ -1,0 +1,162 @@
+//! The application side of the local IPC.
+//!
+//! Listening is bound to holding `host.lock`: the unique writer and the unique listener
+//! are the same fact rather than two that could disagree (D01 decision 3). The caller
+//! therefore starts this only after `DataHost::initialize` succeeded, and the returned
+//! handle closes the endpoint when the application shuts down.
+
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use local_ipc::{Endpoint, IpcError, Listener};
+
+/// Keeps the accept loop alive. Dropping it stops serving and releases the endpoint.
+pub struct IpcService {
+    running: Arc<AtomicBool>,
+    endpoint: String,
+}
+
+impl IpcService {
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for IpcService {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Serve frames on the endpoint for `data_root` until the returned handle is dropped.
+///
+/// Each connection is handled on its own thread. A Native Messaging host connects once
+/// per browser message, so connections are short and numerous rather than long-lived.
+pub fn start(data_root: &Path) -> Result<IpcService, IpcError> {
+    let endpoint = Endpoint::for_data_root(data_root)?;
+    let mut listener = Listener::bind(&endpoint)?;
+    let running = Arc::new(AtomicBool::new(true));
+    let service = IpcService {
+        running: Arc::clone(&running),
+        endpoint: endpoint.display(),
+    };
+
+    std::thread::spawn(move || {
+        while running.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok(stream) => {
+                    std::thread::spawn(move || serve_connection(stream));
+                }
+                Err(err) => {
+                    // The endpoint is gone or unusable; nothing here can recover it, and
+                    // spinning on a broken listener would burn a core.
+                    eprintln!("ipc: accept failed, no longer serving: {err}");
+                    return;
+                }
+            }
+        }
+    });
+
+    Ok(service)
+}
+
+/// Answer frames on one connection until the peer closes it.
+///
+/// The request is validated again here even though the host already did. The host is a
+/// separate process on the other side of a pipe; treating its output as trusted because
+/// it is ours would be the same mistake as trusting a local endpoint for being local.
+fn serve_connection<S: Read + Write>(mut stream: S) {
+    loop {
+        match nm_frame::read_frame(&mut stream) {
+            Ok(None) => return,
+            Ok(Some(frame)) => {
+                // The application is the writer, so a caller reaching it is authorised by
+                // construction; origin authorisation happened in the host.
+                let Some(response) = crate::nm::response_for(&frame, &crate::nm::Caller::Unidentified)
+                else {
+                    eprintln!("ipc: frame carries no usable messageId; closing");
+                    return;
+                };
+                if let Err(err) = nm_frame::write_frame(&mut stream, &response) {
+                    eprintln!("ipc: cannot write response: {err:?}");
+                    return;
+                }
+            }
+            Err(err) => {
+                eprintln!("ipc: cannot read frame: {err:?}");
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEALTH: &str = r#"{"protocolVersion":1,"messageId":"33333333-3333-4333-8333-333333333333","clientInstanceId":"11111111-1111-4111-8111-111111111111","messageType":"health","occurredAt":"2026-09-06T12:00:00.000Z","payload":{}}"#;
+
+    fn framed(body: &str) -> Vec<u8> {
+        let mut wire = (body.len() as u32).to_ne_bytes().to_vec();
+        wire.extend_from_slice(body.as_bytes());
+        wire
+    }
+
+    #[test]
+    fn a_client_gets_an_answer_over_the_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = start(dir.path()).unwrap();
+        assert!(!service.endpoint().is_empty());
+
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+        let mut client = local_ipc::connect(&endpoint).unwrap();
+        nm_frame::write_frame(&mut client, framed(HEALTH)[4..].to_vec().as_slice()).unwrap();
+        let reply = nm_frame::read_frame(&mut client).unwrap().unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+        assert_eq!(value["ok"], true);
+        assert_eq!(
+            value["correlationId"],
+            "33333333-3333-4333-8333-333333333333"
+        );
+    }
+
+    #[test]
+    fn two_clients_are_served_by_the_one_listener() {
+        // A Native Messaging host connects once per browser message, so several arrive at
+        // the same endpoint. None of them may need a second application process.
+        let dir = tempfile::tempdir().unwrap();
+        let _service = start(dir.path()).unwrap();
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+
+        for _ in 0..2 {
+            let mut client = local_ipc::connect(&endpoint).unwrap();
+            nm_frame::write_frame(&mut client, framed(HEALTH)[4..].to_vec().as_slice()).unwrap();
+            let reply = nm_frame::read_frame(&mut client).unwrap().unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+            assert_eq!(value["ok"], true);
+        }
+    }
+
+    #[test]
+    fn dropping_the_service_releases_the_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let service = start(dir.path()).unwrap();
+        drop(service);
+        // The accept loop may still be inside accept(); rebinding is what proves the
+        // endpoint is free, and it must not report AlreadyListening forever.
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+        let mut attempts = 0;
+        loop {
+            match Listener::bind(&endpoint) {
+                Ok(_) => break,
+                Err(IpcError::AlreadyListening) if attempts < 20 => {
+                    attempts += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(err) => panic!("the endpoint was never released: {err}"),
+            }
+        }
+    }
+}

--- a/desktop/src-tauri/src/ipc_server.rs
+++ b/desktop/src-tauri/src/ipc_server.rs
@@ -72,6 +72,8 @@ impl Application for OpenArchive {
 pub struct IpcService {
     running: Arc<AtomicBool>,
     endpoint: String,
+    data_root: std::path::PathBuf,
+    worker: Option<std::thread::JoinHandle<()>>,
 }
 
 impl IpcService {
@@ -83,6 +85,20 @@ impl IpcService {
 impl Drop for IpcService {
     fn drop(&mut self) {
         self.running.store(false, Ordering::Relaxed);
+        // Clearing the flag is not enough on its own. The loop spends nearly all its life
+        // parked inside accept and does not look at the flag again until a caller
+        // arrives, so it would hold the endpoint open indefinitely — and on Windows the
+        // next bind then reports the name as taken by a listener that is no longer
+        // serving anything.
+        let woken = Endpoint::for_data_root(&self.data_root)
+            .and_then(|endpoint| local_ipc::connect(&endpoint))
+            .is_ok();
+        if woken {
+            // Only then: waiting on a loop that was never woken would hang the caller.
+            if let Some(worker) = self.worker.take() {
+                let _ = worker.join();
+            }
+        }
     }
 }
 
@@ -97,13 +113,11 @@ pub fn start<A: Application>(
     let endpoint = Endpoint::for_data_root(data_root)?;
     let mut listener = Listener::bind(&endpoint)?;
     let running = Arc::new(AtomicBool::new(true));
-    let service = IpcService {
-        running: Arc::clone(&running),
-        endpoint: endpoint.display(),
-    };
+    let display = endpoint.display();
 
-    std::thread::spawn(move || {
-        while running.load(Ordering::Relaxed) {
+    let alive = Arc::clone(&running);
+    let worker = std::thread::spawn(move || {
+        while alive.load(Ordering::Relaxed) {
             match listener.accept() {
                 Ok(stream) => {
                     let application = Arc::clone(&application);
@@ -119,7 +133,12 @@ pub fn start<A: Application>(
         }
     });
 
-    Ok(service)
+    Ok(IpcService {
+        running,
+        endpoint: display,
+        data_root: data_root.to_path_buf(),
+        worker: Some(worker),
+    })
 }
 
 /// Answer frames on one connection until the peer closes it.
@@ -285,6 +304,37 @@ mod tests {
             let reply = nm_frame::read_frame(&mut client).unwrap().unwrap();
             let value: serde_json::Value = serde_json::from_slice(&reply).unwrap();
             assert_eq!(value["ok"], true);
+        }
+    }
+
+    #[test]
+    fn dropping_the_service_releases_an_endpoint_that_is_waiting_for_a_caller() {
+        // The accept loop spends nearly all its life blocked waiting for the next caller.
+        // Dropping the handle while it is parked there is the case that matters, and the
+        // sibling test below can pass without covering it: the loop may not have reached
+        // accept yet when the drop happens.
+        let dir = tempfile::tempdir().unwrap();
+        let service = start(dir.path(), open_archive()).unwrap();
+        let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
+
+        // One completed exchange proves the loop is now parked in accept, not still
+        // starting up.
+        let mut client = local_ipc::connect(&endpoint).unwrap();
+        nm_frame::write_frame(&mut client, framed(HEALTH)[4..].to_vec().as_slice()).unwrap();
+        nm_frame::read_frame(&mut client).unwrap().unwrap();
+        drop(client);
+
+        drop(service);
+        let mut attempts = 0;
+        loop {
+            match Listener::bind(&endpoint) {
+                Ok(_) => break,
+                Err(IpcError::AlreadyListening) if attempts < 40 => {
+                    attempts += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+                Err(err) => panic!("the endpoint was never released: {err}"),
+            }
         }
     }
 

--- a/desktop/src-tauri/src/ipc_server.rs
+++ b/desktop/src-tauri/src/ipc_server.rs
@@ -8,9 +8,65 @@
 use std::io::{Read, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use archive_store::ArchiveStore;
 
 use local_ipc::{Endpoint, IpcError, Listener};
+use resume_pro_protocol::{CurrentArchive, ErrorCode, Request};
+
+use crate::plugin_bridge::Answer;
+
+/// The application as a caller can see it: who it is, and what it will commit.
+///
+/// Identity is read per request rather than captured at startup. `restore_epoch` is
+/// re-minted when an archive is restored, and a handshake that answered with a stale one
+/// would hand the extension an identity its next write would be rejected against.
+pub trait Application: Send + Sync + 'static {
+    fn identity(&self) -> Option<CurrentArchive>;
+
+    /// Commit one request against the archive. The default has no archive to commit to,
+    /// which is the truthful answer for a process that never opened one.
+    fn apply(&self, _request: &Request) -> Result<Answer, ErrorCode> {
+        Err(ErrorCode::Unavailable)
+    }
+}
+
+/// The archive this process currently has open.
+///
+/// Shares the application's own store slot rather than a copy of what it said at startup:
+/// `rotate_restore_epoch` changes the epoch in place when an archive is restored, and a
+/// closed or never-opened archive has neither an identity nor anywhere to commit.
+pub struct OpenArchive {
+    store: Arc<Mutex<Option<ArchiveStore>>>,
+}
+
+impl OpenArchive {
+    pub fn new(store: Arc<Mutex<Option<ArchiveStore>>>) -> Self {
+        Self { store }
+    }
+}
+
+impl Application for OpenArchive {
+    fn identity(&self) -> Option<CurrentArchive> {
+        // A poisoned lock means a writer panicked mid-change; the epoch behind it cannot
+        // be trusted, so this reports no identity rather than a possibly torn one.
+        let guard = self.store.lock().ok()?;
+        let identity = guard.as_ref()?.identity();
+        Some(CurrentArchive {
+            archive_id: identity.archive_id,
+            restore_epoch: identity.restore_epoch,
+        })
+    }
+
+    fn apply(&self, request: &Request) -> Result<Answer, ErrorCode> {
+        // The same lock the window's own commands take. One writer means one queue: a
+        // browser write and a window edit cannot interleave inside the archive.
+        let guard = self.store.lock().map_err(|_| ErrorCode::Unavailable)?;
+        let store = guard.as_ref().ok_or(ErrorCode::Unavailable)?;
+        crate::plugin_bridge::apply(request, store)
+    }
+}
 
 /// Keeps the accept loop alive. Dropping it stops serving and releases the endpoint.
 pub struct IpcService {
@@ -34,7 +90,10 @@ impl Drop for IpcService {
 ///
 /// Each connection is handled on its own thread. A Native Messaging host connects once
 /// per browser message, so connections are short and numerous rather than long-lived.
-pub fn start(data_root: &Path) -> Result<IpcService, IpcError> {
+pub fn start<A: Application>(
+    data_root: &Path,
+    application: Arc<A>,
+) -> Result<IpcService, IpcError> {
     let endpoint = Endpoint::for_data_root(data_root)?;
     let mut listener = Listener::bind(&endpoint)?;
     let running = Arc::new(AtomicBool::new(true));
@@ -47,7 +106,8 @@ pub fn start(data_root: &Path) -> Result<IpcService, IpcError> {
         while running.load(Ordering::Relaxed) {
             match listener.accept() {
                 Ok(stream) => {
-                    std::thread::spawn(move || serve_connection(stream));
+                    let application = Arc::clone(&application);
+                    std::thread::spawn(move || serve_connection(stream, application.as_ref()));
                 }
                 Err(err) => {
                     // The endpoint is gone or unusable; nothing here can recover it, and
@@ -67,15 +127,14 @@ pub fn start(data_root: &Path) -> Result<IpcService, IpcError> {
 /// The request is validated again here even though the host already did. The host is a
 /// separate process on the other side of a pipe; treating its output as trusted because
 /// it is ours would be the same mistake as trusting a local endpoint for being local.
-fn serve_connection<S: Read + Write>(mut stream: S) {
+fn serve_connection<S: Read + Write, A: Application + ?Sized>(mut stream: S, application: &A) {
     loop {
         match nm_frame::read_frame(&mut stream) {
             Ok(None) => return,
             Ok(Some(frame)) => {
                 // The application is the writer, so a caller reaching it is authorised by
                 // construction; origin authorisation happened in the host.
-                let Some(response) = crate::nm::response_for(&frame, &crate::nm::Caller::Unidentified)
-                else {
+                let Some(response) = answer(&frame, application) else {
                     eprintln!("ipc: frame carries no usable messageId; closing");
                     return;
                 };
@@ -92,9 +151,99 @@ fn serve_connection<S: Read + Write>(mut stream: S) {
     }
 }
 
+/// Answer one frame as the application.
+///
+/// Validated again here even though the host already did. The host is a separate process
+/// on the other side of a pipe; treating its output as trusted because it is ours would
+/// be the same mistake as trusting a local endpoint for being local.
+fn answer<A: Application + ?Sized>(frame: &[u8], application: &A) -> Option<Vec<u8>> {
+    use resume_pro_protocol::{handshake_response_payload, validate_request_bytes, MessageType};
+
+    match validate_request_bytes(frame) {
+        Ok(request) if request.message_type == MessageType::Handshake => {
+            let Some(current) = application.identity() else {
+                // No archive open means no identity to hand out. Saying so is retryable;
+                // answering with a placeholder would have the extension stamp writes with
+                // an identity that never existed.
+                return crate::nm::error_frame(&request.message_id, ErrorCode::Unavailable);
+            };
+            let payload = handshake_response_payload(&current, env!("CARGO_PKG_VERSION"));
+            serde_json::to_vec(&serde_json::json!({
+                "protocolVersion": 1,
+                "correlationId": request.message_id,
+                "ok": true,
+                "payload": payload
+            }))
+            .ok()
+        }
+        Ok(request) if request.message_type == MessageType::Health => {
+            serde_json::to_vec(&serde_json::json!({
+                "protocolVersion": 1,
+                "correlationId": request.message_id,
+                "ok": true,
+                "payload": {}
+            }))
+            .ok()
+        }
+        // The write has already committed by the time this returns, so the answer states
+        // a fact rather than an intention.
+        Ok(request) => match application.apply(&request) {
+            Ok(answer) => {
+                let mut response = serde_json::json!({
+                    "protocolVersion": 1,
+                    "correlationId": request.message_id,
+                    "ok": true,
+                    "payload": answer.payload
+                });
+                if let Some(result_id) = answer.result_id {
+                    response["resultId"] = serde_json::json!(result_id);
+                }
+                // A response that does not satisfy the contract is a defect on this side,
+                // and sending it anyway would push the defect into the extension. Note
+                // that the write has already committed: this reports the answer as
+                // unusable, not the write as undone.
+                if let Err(err) =
+                    resume_pro_protocol::validate_response_for_request(&response, &request)
+                {
+                    eprintln!(
+                        "ipc: refusing to send a response that fails validation: {}",
+                        err.code
+                    );
+                    return crate::nm::error_frame(&request.message_id, ErrorCode::Unavailable);
+                }
+                serde_json::to_vec(&response).ok()
+            }
+            Err(code) => crate::nm::error_frame(&request.message_id, code),
+        },
+        Err(err) => {
+            let message_id = crate::nm::message_id_of(frame)?;
+            crate::nm::error_frame(&message_id, err.code)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An archive that is open, or one that is not. Both are real states the application
+    /// can be in when a caller arrives.
+    struct FakeIdentity(Option<CurrentArchive>);
+
+    impl Application for FakeIdentity {
+        fn identity(&self) -> Option<CurrentArchive> {
+            self.0.clone()
+        }
+    }
+
+    fn open_archive() -> Arc<FakeIdentity> {
+        Arc::new(FakeIdentity(Some(CurrentArchive {
+            archive_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".into(),
+            restore_epoch: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb".into(),
+        })))
+    }
+
+    const HANDSHAKE: &str = r#"{"protocolVersion":1,"messageId":"33333333-3333-4333-8333-333333333333","clientInstanceId":"11111111-1111-4111-8111-111111111111","messageType":"handshake","occurredAt":"2026-09-06T12:00:00.000Z","payload":{"pluginVersion":"0.3.0","minProtocolVersion":1,"maxProtocolVersion":1}}"#;
 
     const HEALTH: &str = r#"{"protocolVersion":1,"messageId":"33333333-3333-4333-8333-333333333333","clientInstanceId":"11111111-1111-4111-8111-111111111111","messageType":"health","occurredAt":"2026-09-06T12:00:00.000Z","payload":{}}"#;
 
@@ -107,7 +256,7 @@ mod tests {
     #[test]
     fn a_client_gets_an_answer_over_the_endpoint() {
         let dir = tempfile::tempdir().unwrap();
-        let service = start(dir.path()).unwrap();
+        let service = start(dir.path(), open_archive()).unwrap();
         assert!(!service.endpoint().is_empty());
 
         let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
@@ -127,7 +276,7 @@ mod tests {
         // A Native Messaging host connects once per browser message, so several arrive at
         // the same endpoint. None of them may need a second application process.
         let dir = tempfile::tempdir().unwrap();
-        let _service = start(dir.path()).unwrap();
+        let _service = start(dir.path(), open_archive()).unwrap();
         let endpoint = Endpoint::for_data_root(dir.path()).unwrap();
 
         for _ in 0..2 {
@@ -142,7 +291,7 @@ mod tests {
     #[test]
     fn dropping_the_service_releases_the_endpoint() {
         let dir = tempfile::tempdir().unwrap();
-        let service = start(dir.path()).unwrap();
+        let service = start(dir.path(), open_archive()).unwrap();
         drop(service);
         // The accept loop may still be inside accept(); rebinding is what proves the
         // endpoint is free, and it must not report AlreadyListening forever.
@@ -158,5 +307,192 @@ mod tests {
                 Err(err) => panic!("the endpoint was never released: {err}"),
             }
         }
+    }
+
+    #[test]
+    fn a_handshake_carries_the_identity_writes_will_be_stamped_with() {
+        let reply = answer(&framed(HANDSHAKE)[4..], open_archive().as_ref()).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+        assert_eq!(value["ok"], true);
+        assert_eq!(
+            value["payload"]["archiveId"],
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+        );
+        assert_eq!(
+            value["payload"]["restoreEpoch"],
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+        );
+        assert_eq!(value["payload"]["minProtocolVersion"], 1);
+        assert!(
+            value["payload"]["capabilities"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c == "job.save"),
+            "the extension learns what it may send from this list"
+        );
+    }
+
+    #[test]
+    fn a_handshake_without_an_open_archive_is_retryable_not_invented() {
+        // Answering with a placeholder identity would have the extension stamp writes
+        // with one that never existed, and every such write would then be rejected.
+        let closed = Arc::new(FakeIdentity(None));
+        let reply = answer(&framed(HANDSHAKE)[4..], closed.as_ref()).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["error"]["code"], "unavailable");
+        assert_eq!(value["error"]["retryable"], true);
+        assert!(value["payload"].get("archiveId").is_none());
+    }
+
+    #[test]
+    fn the_identity_is_read_per_request_not_captured_once() {
+        // restore_epoch is re-minted when an archive is restored. A handshake answering
+        // with a stale one would hand out an identity the next write is rejected against.
+        struct Rotating(Mutex<u32>);
+        impl Application for Rotating {
+            fn identity(&self) -> Option<CurrentArchive> {
+                let mut n = self.0.lock().unwrap();
+                *n += 1;
+                Some(CurrentArchive {
+                    archive_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".into(),
+                    restore_epoch: format!("bbbbbbbb-bbbb-4bbb-8bbb-{:012}", n),
+                })
+            }
+        }
+        let rotating = Arc::new(Rotating(Mutex::new(0)));
+        let first = answer(&framed(HANDSHAKE)[4..], rotating.as_ref()).unwrap();
+        let second = answer(&framed(HANDSHAKE)[4..], rotating.as_ref()).unwrap();
+        let a: serde_json::Value = serde_json::from_slice(&first).unwrap();
+        let b: serde_json::Value = serde_json::from_slice(&second).unwrap();
+        assert_ne!(a["payload"]["restoreEpoch"], b["payload"]["restoreEpoch"]);
+    }
+
+    /// A real archive behind a real endpoint, with no window ever created.
+    fn open_store(
+        dir: &Path,
+    ) -> (
+        Arc<Mutex<Option<ArchiveStore>>>,
+        archive_store::ArchiveIdentity,
+    ) {
+        let archive = dir.join("archive");
+        std::fs::create_dir_all(&archive).unwrap();
+        let store = crate::commands::open_store(&archive, &dir.join("current.json")).unwrap();
+        let identity = store.identity();
+        (Arc::new(Mutex::new(Some(store))), identity)
+    }
+
+    fn job_save(identity: &archive_store::ArchiveIdentity) -> Vec<u8> {
+        let mut payload = serde_json::json!({
+            "sourceRestoreEpoch": identity.restore_epoch,
+            "company": "Synthetic Ltd",
+            "title": "Engineer",
+            "sourceUrl": "https://jobs.example.test/1"
+        });
+        payload["payloadSha256"] =
+            serde_json::json!(resume_pro_protocol::payload_body_sha256(&payload).unwrap());
+        serde_json::to_vec(&serde_json::json!({
+            "protocolVersion": 1,
+            "messageId": "22222222-2222-4222-8222-222222222222",
+            "clientInstanceId": "11111111-1111-4111-8111-111111111111",
+            "messageType": "job.save",
+            "occurredAt": "2026-09-06T12:00:00.000Z",
+            "archiveId": identity.archive_id,
+            "restoreEpoch": identity.restore_epoch,
+            "payload": payload
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn a_job_saved_from_the_browser_is_in_the_archive_with_no_window_open() {
+        // The whole point of the host: nothing here creates a window, and the row is in
+        // the archive by the time the extension has its answer.
+        let dir = tempfile::tempdir().unwrap();
+        let (shared, identity) = open_store(dir.path());
+        let _service = start(dir.path(), Arc::new(OpenArchive::new(Arc::clone(&shared)))).unwrap();
+
+        // The host side, reached the way the browser reaches it. The program path cannot
+        // exist, so a cold start would fail rather than quietly succeed.
+        let mut backend = crate::nm::AppBackend {
+            data_root: dir.path().to_path_buf(),
+            program: dir.path().join("must-not-be-started"),
+        };
+        let caller = crate::nm::Caller::Authorised("chrome-extension://abcdefghijklmnop/".into());
+        let raw = crate::nm::response_for_with(&job_save(&identity), &caller, &mut backend)
+            .expect("the host must answer");
+        let response: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(response["ok"], true, "response was {response}");
+        let result_id = response["resultId"]
+            .as_str()
+            .expect("a write names what it produced");
+
+        let guard = shared.lock().unwrap();
+        let found = guard
+            .as_ref()
+            .unwrap()
+            .query_candidates(
+                "Synthetic Ltd",
+                "Engineer",
+                Some("https://jobs.example.test/1"),
+            )
+            .unwrap();
+        assert_eq!(found.exact.len(), 1);
+        assert_eq!(found.exact[0].id, result_id);
+    }
+
+    #[test]
+    fn the_same_browser_message_twice_over_two_connections_saves_one_application() {
+        // Two tabs, or one tab retrying after a lost answer: each browser message opens
+        // its own connection, and neither may produce a second application.
+        let dir = tempfile::tempdir().unwrap();
+        let (shared, identity) = open_store(dir.path());
+        let _service = start(dir.path(), Arc::new(OpenArchive::new(Arc::clone(&shared)))).unwrap();
+        let mut backend = crate::nm::AppBackend {
+            data_root: dir.path().to_path_buf(),
+            program: dir.path().join("must-not-be-started"),
+        };
+        let caller = crate::nm::Caller::Authorised("chrome-extension://abcdefghijklmnop/".into());
+
+        let mut result_ids = Vec::new();
+        for _ in 0..2 {
+            let raw = crate::nm::response_for_with(&job_save(&identity), &caller, &mut backend)
+                .expect("the host must answer");
+            let response: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+            assert_eq!(response["ok"], true, "response was {response}");
+            result_ids.push(response["resultId"].as_str().unwrap().to_string());
+        }
+        assert_eq!(result_ids[0], result_ids[1]);
+
+        let guard = shared.lock().unwrap();
+        let found = guard
+            .as_ref()
+            .unwrap()
+            .query_candidates(
+                "Synthetic Ltd",
+                "Engineer",
+                Some("https://jobs.example.test/1"),
+            )
+            .unwrap();
+        assert_eq!(
+            found.exact.len(),
+            1,
+            "a retry must not duplicate the application"
+        );
+    }
+
+    #[test]
+    fn a_write_that_cannot_be_committed_is_reported_as_an_error_not_as_success() {
+        // No archive open: the answer must say so rather than claim a save that no
+        // storage ever received.
+        let dir = tempfile::tempdir().unwrap();
+        let (_shared, identity) = open_store(dir.path());
+        let empty: Arc<Mutex<Option<ArchiveStore>>> = Arc::new(Mutex::new(None));
+        let reply = answer(&job_save(&identity), &OpenArchive::new(empty)).unwrap();
+        let response: serde_json::Value = serde_json::from_slice(&reply).unwrap();
+        assert_eq!(response["ok"], false);
+        assert_eq!(response["error"]["code"], "unavailable");
+        assert!(response.get("resultId").is_none());
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod ipc_client;
 mod ipc_server;
 mod lifecycle;
 mod nm;
+mod plugin_bridge;
 
 use archive_store::ArchiveStore;
 use commands::{
@@ -20,7 +21,7 @@ use data_service::{
     PairingDraft,
 };
 use serde::Serialize;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -32,7 +33,7 @@ struct AppState {
     host: Mutex<Option<DataHost>>,
     host_error: Mutex<Option<HostErrorDto>>,
     paths: Mutex<Option<HostPaths>>,
-    store: Mutex<Option<ArchiveStore>>,
+    store: Arc<Mutex<Option<ArchiveStore>>>,
     store_error: Mutex<Option<CommandError>>,
     hidden_launch: bool,
     /// Serving the local endpoint. Held here so it lives exactly as long as the
@@ -601,7 +602,7 @@ pub fn run() {
             ipc: Mutex::new(None),
             host_error: Mutex::new(None),
             paths: Mutex::new(HostPaths::resolve().ok()),
-            store: Mutex::new(None),
+            store: Arc::new(Mutex::new(None)),
             store_error: Mutex::new(None),
             hidden_launch,
         })
@@ -629,7 +630,10 @@ pub fn run() {
                     }
                     // Only now: holding host.lock is what entitles this process to be
                     // the one listening (D01 decision 3).
-                    match ipc_server::start(&host.paths().data_root) {
+                    let application = Arc::new(ipc_server::OpenArchive::new(Arc::clone(
+                        &app.state::<AppState>().store,
+                    )));
+                    match ipc_server::start(&host.paths().data_root, application) {
                         Ok(service) => {
                             eprintln!("ipc: serving on {}", service.endpoint());
                             if let Ok(mut slot) = app.state::<AppState>().ipc.lock() {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,8 @@ mod cli;
 mod commands;
 #[cfg(test)]
 mod commands_regression;
+mod ipc_client;
+mod ipc_server;
 mod lifecycle;
 mod nm;
 
@@ -33,6 +35,9 @@ struct AppState {
     store: Mutex<Option<ArchiveStore>>,
     store_error: Mutex<Option<CommandError>>,
     hidden_launch: bool,
+    /// Serving the local endpoint. Held here so it lives exactly as long as the
+    /// application does, which is what ties the unique listener to the unique writer.
+    ipc: Mutex<Option<ipc_server::IpcService>>,
 }
 
 fn with_store<T>(
@@ -498,7 +503,32 @@ pub fn run() {
         };
         let mut input = std::io::stdin();
         let mut output = std::io::stdout();
-        std::process::exit(nm::serve(&caller, &mut input, &mut output));
+        // Anything the host cannot answer alone goes to the application over the local
+        // endpoint, started with --hidden if it is not there. Without a resolvable data
+        // directory there is nothing to reach, and every such request answers
+        // unavailable through the backend's own error path.
+        let exit = match (
+            data_service::HostPaths::resolve(),
+            ipc_client::own_program(),
+        ) {
+            (Ok(paths), Ok(program)) => {
+                let mut backend = nm::AppBackend {
+                    data_root: paths.data_root,
+                    program,
+                };
+                nm::serve_with(&caller, &mut input, &mut output, &mut backend)
+            }
+            (paths, program) => {
+                if let Err(err) = paths {
+                    eprintln!("nm-host: no data directory to reach the application in: {err:?}");
+                }
+                if let Err(err) = program {
+                    eprintln!("nm-host: cannot identify this executable: {err}");
+                }
+                nm::serve(&caller, &mut input, &mut output)
+            }
+        };
+        std::process::exit(exit);
     }
     if args.apps_loop {
         match run_apps_loop() {
@@ -568,6 +598,7 @@ pub fn run() {
         }))
         .manage(AppState {
             host: Mutex::new(None),
+            ipc: Mutex::new(None),
             host_error: Mutex::new(None),
             paths: Mutex::new(HostPaths::resolve().ok()),
             store: Mutex::new(None),
@@ -594,6 +625,21 @@ pub fn run() {
                             if let Ok(mut slot) = app.state::<AppState>().store_error.lock() {
                                 *slot = Some(err);
                             }
+                        }
+                    }
+                    // Only now: holding host.lock is what entitles this process to be
+                    // the one listening (D01 decision 3).
+                    match ipc_server::start(&host.paths().data_root) {
+                        Ok(service) => {
+                            eprintln!("ipc: serving on {}", service.endpoint());
+                            if let Ok(mut slot) = app.state::<AppState>().ipc.lock() {
+                                *slot = Some(service);
+                            }
+                        }
+                        Err(err) => {
+                            // The window and the archive still work; only the browser
+                            // connection is unavailable, and it says so on its own.
+                            eprintln!("ipc: not serving: {err}");
                         }
                     }
                     if let Ok(mut slot) = app.state::<AppState>().host.lock() {

--- a/desktop/src-tauri/src/nm.rs
+++ b/desktop/src-tauri/src/nm.rs
@@ -112,11 +112,15 @@ pub fn serve_with<R: Read, W: Write, B: Backend>(
     }
 }
 
-/// Build the response for one received frame.
+/// Build the response for one received frame with no application behind it.
+///
+/// Test-only: the real path always has a backend, and answering without one would let
+/// the host invent a response the archive never agreed to.
 ///
 /// `None` means no compliant response can be built, because the D05 response envelope
 /// requires a `correlationId` and this frame carries no usable `messageId`. Closing
 /// beats emitting something the extension would also reject, which would hide the cause.
+#[cfg(test)]
 pub fn response_for(frame: &[u8], caller: &Caller) -> Option<Vec<u8>> {
     response_for_with(frame, caller, &mut NoBackend)
 }
@@ -172,7 +176,7 @@ pub fn response_for_with<B: Backend>(
 
 /// A fixed message per code. Validator messages quote the offending value, so forwarding
 /// one would hand rejected content back to the extension.
-fn error_response(correlation_id: &str, code: ErrorCode) -> Value {
+pub fn error_response(correlation_id: &str, code: ErrorCode) -> Value {
     json!({
         "protocolVersion": 1,
         "correlationId": correlation_id,
@@ -184,6 +188,12 @@ fn error_response(correlation_id: &str, code: ErrorCode) -> Value {
             "message": fixed_message(code)
         }
     })
+}
+
+/// A complete error frame, ready to write. Shared so the host and the application build
+/// their errors the same way rather than drifting into two shapes.
+pub fn error_frame(correlation_id: &str, code: ErrorCode) -> Option<Vec<u8>> {
+    serde_json::to_vec(&error_response(correlation_id, code)).ok()
 }
 
 fn fixed_message(code: ErrorCode) -> &'static str {
@@ -202,7 +212,7 @@ fn fixed_message(code: ErrorCode) -> &'static str {
 
 /// The top-level `messageId`, only when it is a syntactically valid UUID. Anything else
 /// cannot correlate a response.
-fn message_id_of(frame: &[u8]) -> Option<String> {
+pub fn message_id_of(frame: &[u8]) -> Option<String> {
     let value: Value = serde_json::from_slice(frame).ok()?;
     let id = value.get("messageId")?.as_str()?;
     let mut groups = id.split('-');
@@ -300,13 +310,11 @@ mod tests {
     fn a_frame_without_a_usable_message_id_gets_no_response() {
         assert!(response_for(b"not json at all", &Caller::Unidentified).is_none());
         assert!(response_for(br#"{"messageId":"not-a-uuid"}"#, &Caller::Unidentified).is_none());
-        assert!(
-            response_for(
-                br#"{"messageId":"33333333-3333-4333-8333-333333333333-extra"}"#,
-                &Caller::Unidentified
-            )
-            .is_none()
-        );
+        assert!(response_for(
+            br#"{"messageId":"33333333-3333-4333-8333-333333333333-extra"}"#,
+            &Caller::Unidentified
+        )
+        .is_none());
     }
 
     #[test]
@@ -395,7 +403,10 @@ mod tests {
     fn an_unpaired_or_mismatched_caller_is_rejected() {
         let allowed = allowed_origins_from(&draft(CHROME_ID, ""));
         assert!(matches!(
-            authorise(Some("chrome-extension://zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/"), &allowed),
+            authorise(
+                Some("chrome-extension://zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz/"),
+                &allowed
+            ),
             Caller::Rejected(_)
         ));
         // Nothing paired at all.

--- a/desktop/src-tauri/src/nm.rs
+++ b/desktop/src-tauri/src/nm.rs
@@ -53,11 +53,49 @@ pub fn authorise(origin: Option<&str>, allowed: &[String]) -> Caller {
 /// Diagnostics go to stderr only. Anything on stdout other than a protocol frame breaks
 /// the channel, and the browser reports it as an unexplained disconnect.
 pub fn serve<R: Read, W: Write>(caller: &Caller, input: &mut R, output: &mut W) -> i32 {
+    serve_with(caller, input, output, &mut NoBackend)
+}
+
+/// Where a request goes when the host cannot answer it alone.
+pub trait Backend {
+    /// Forward one validated frame and return the application's answer.
+    fn exchange(&mut self, frame: &[u8]) -> Result<Vec<u8>, String>;
+}
+
+/// No application behind the host. Used by the tests that exercise framing alone.
+struct NoBackend;
+
+impl Backend for NoBackend {
+    fn exchange(&mut self, _frame: &[u8]) -> Result<Vec<u8>, String> {
+        Err("no application backend is configured".into())
+    }
+}
+
+/// The application process, reached over the local endpoint and cold-started if absent.
+pub struct AppBackend {
+    pub data_root: std::path::PathBuf,
+    pub program: std::path::PathBuf,
+}
+
+impl Backend for AppBackend {
+    fn exchange(&mut self, frame: &[u8]) -> Result<Vec<u8>, String> {
+        let mut stream = crate::ipc_client::connect_or_start(&self.data_root, &self.program)
+            .map_err(|e| e.to_string())?;
+        crate::ipc_client::exchange(&mut stream, frame).map_err(|e| e.to_string())
+    }
+}
+
+pub fn serve_with<R: Read, W: Write, B: Backend>(
+    caller: &Caller,
+    input: &mut R,
+    output: &mut W,
+    backend: &mut B,
+) -> i32 {
     loop {
         match nm_frame::read_frame(input) {
             Ok(None) => return 0,
             Ok(Some(frame)) => {
-                let Some(response) = response_for(&frame, caller) else {
+                let Some(response) = response_for_with(&frame, caller, backend) else {
                     eprintln!("nm-host: frame carries no usable messageId; closing");
                     return 2;
                 };
@@ -80,23 +118,45 @@ pub fn serve<R: Read, W: Write>(caller: &Caller, input: &mut R, output: &mut W) 
 /// requires a `correlationId` and this frame carries no usable `messageId`. Closing
 /// beats emitting something the extension would also reject, which would hide the cause.
 pub fn response_for(frame: &[u8], caller: &Caller) -> Option<Vec<u8>> {
+    response_for_with(frame, caller, &mut NoBackend)
+}
+
+pub fn response_for_with<B: Backend>(
+    frame: &[u8],
+    caller: &Caller,
+    backend: &mut B,
+) -> Option<Vec<u8>> {
     match validate_request_bytes(frame) {
         Ok(request) => {
-            let response = if matches!(caller, Caller::Rejected(_)) {
+            if matches!(caller, Caller::Rejected(_)) {
                 // Answered per message rather than dropped: a closed port reaches the
                 // extension as an unexplained disconnect, while this says why.
-                error_response(&request.message_id, ErrorCode::IdentityNotAllowed)
-            } else if request.message_type == MessageType::Health {
-                json!({
+                let response = error_response(&request.message_id, ErrorCode::IdentityNotAllowed);
+                return serde_json::to_vec(&response).ok();
+            }
+            if request.message_type == MessageType::Health {
+                // The only request the host can answer alone: it asks nothing of the
+                // archive, so routing it through the application would add a cold start
+                // to a liveness check.
+                let response = json!({
                     "protocolVersion": 1,
                     "correlationId": request.message_id,
                     "ok": true,
                     "payload": {}
-                })
-            } else {
-                error_response(&request.message_id, ErrorCode::Unavailable)
-            };
-            serde_json::to_vec(&response).ok()
+                });
+                return serde_json::to_vec(&response).ok();
+            }
+            // Everything else belongs to the writer. The host relays the application's
+            // answer rather than inventing one, so "persisted before the answer" stays a
+            // property of the process that does the persisting.
+            match backend.exchange(frame) {
+                Ok(reply) => Some(reply),
+                Err(reason) => {
+                    eprintln!("nm-host: cannot reach the application: {reason}");
+                    let response = error_response(&request.message_id, ErrorCode::Unavailable);
+                    serde_json::to_vec(&response).ok()
+                }
+            }
         }
         Err(err) => {
             let message_id = message_id_of(frame)?;

--- a/desktop/src-tauri/src/plugin_bridge.rs
+++ b/desktop/src-tauri/src/plugin_bridge.rs
@@ -1,0 +1,666 @@
+//! Mapping one validated D05 envelope onto the D03 transactional interface.
+//!
+//! Everything here runs inside the application process, which is the only writer. The
+//! store commits the business row and its receipt in one transaction, so an answer is
+//! only produced after the write is durable — the host never invents a success.
+
+use archive_store::{
+    ApplicationCandidate, ArchiveIdentity, ArchiveStore, FillOutcome, FillSubmitInput,
+    JobSaveInput, Occurred, PluginOp, PluginWriteContext, PluginWriteOutcome, ReconcileOutcome,
+    ReconcileQueryItem, StoreError, SubmitConfirmInput,
+};
+use resume_pro_protocol::{ErrorCode, MessageType, Request};
+use serde_json::{json, Map, Value};
+
+/// A successful answer: the envelope-level `resultId` and the response payload.
+pub struct Answer {
+    pub result_id: Option<String>,
+    pub payload: Value,
+}
+
+/// The response schema caps both candidate lists at 32.
+const MAX_CANDIDATES: usize = 32;
+
+/// Handle one request against the open archive.
+///
+/// Errors are returned as a bare protocol code. Store messages quote the offending value
+/// — an applicationId, a company name — and the caller turns a code into a fixed message,
+/// so nothing from the archive travels back to the extension.
+pub fn apply(request: &Request, store: &ArchiveStore) -> Result<Answer, ErrorCode> {
+    match request.message_type {
+        MessageType::QueryCandidates => query_candidates(request, store),
+        MessageType::JobSave | MessageType::FillSubmit | MessageType::SubmitConfirm => {
+            write(request, store)
+        }
+        MessageType::OutboxReconcile => reconcile(request, store),
+        // The wire carries chunk bytes, and nothing in the archive stores bytes yet.
+        // Acknowledging a chunk would move the plugin cursor past data that was never
+        // written, and a complete ACK is its permission to drop its own copy.
+        MessageType::SnapshotChunk => Err(ErrorCode::Unavailable),
+        MessageType::Health | MessageType::Handshake => Err(ErrorCode::UnknownMessageType),
+    }
+}
+
+/// The identity the envelope claims. `None` reaches D03 as `identity_missing` rather than
+/// being silently replaced with the current one, which would let an envelope from a
+/// restored-over archive write as if it belonged here.
+fn envelope_identity(request: &Request) -> Option<ArchiveIdentity> {
+    Some(ArchiveIdentity {
+        archive_id: request.archive_id.clone()?,
+        restore_epoch: request.restore_epoch.clone()?,
+    })
+}
+
+fn context(request: &Request) -> Result<PluginWriteContext, ErrorCode> {
+    Ok(PluginWriteContext {
+        envelope_identity: envelope_identity(request),
+        client_instance_id: request.client_instance_id.clone(),
+        message_id: request.message_id.clone(),
+        source_restore_epoch: resume_pro_protocol::source_restore_epoch(request)
+            .ok_or(ErrorCode::InvalidPayload)?,
+        payload_sha256: resume_pro_protocol::payload_sha256(request)
+            .ok_or(ErrorCode::InvalidPayload)?,
+    })
+}
+
+/// When the client says the event happened. The validator has already established this is
+/// a real UTC timestamp, so it is passed on rather than replaced with the arrival time.
+fn occurred(request: &Request) -> Occurred {
+    Occurred::DateTime {
+        rfc3339: request.occurred_at.clone(),
+        time_zone: None,
+    }
+}
+
+fn text(payload: &Value, key: &str) -> Option<String> {
+    payload.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn count(payload: &Value, key: &str) -> Option<i64> {
+    payload.get(key).and_then(Value::as_i64)
+}
+
+fn write(request: &Request, store: &ArchiveStore) -> Result<Answer, ErrorCode> {
+    let ctx = context(request)?;
+    let payload = &request.payload;
+    let op = match request.message_type {
+        MessageType::JobSave => PluginOp::JobSave(JobSaveInput {
+            target_application_id: text(payload, "applicationId"),
+            company: text(payload, "company").ok_or(ErrorCode::InvalidPayload)?,
+            title: text(payload, "title").ok_or(ErrorCode::InvalidPayload)?,
+            source_url: text(payload, "sourceUrl"),
+            location: text(payload, "location"),
+            occurred: occurred(request),
+        }),
+        MessageType::FillSubmit => PluginOp::FillSubmit(FillSubmitInput {
+            application_id: text(payload, "applicationId").ok_or(ErrorCode::InvalidPayload)?,
+            outcome: fill_outcome(payload)?,
+            field_count: count(payload, "fieldCount"),
+            filled_count: count(payload, "filledCount"),
+            unconfirmed_count: count(payload, "unconfirmedCount"),
+            durations_ms: payload.get("durationsMs").cloned(),
+            url_redacted: text(payload, "urlRedacted"),
+            template_name: text(payload, "templateName"),
+            template_version: text(payload, "templateVersion"),
+            snapshot_id: text(payload, "snapshotId"),
+            plugin_version: text(payload, "pluginVersion"),
+            occurred: occurred(request),
+        }),
+        MessageType::SubmitConfirm => PluginOp::SubmitConfirm(SubmitConfirmInput {
+            application_id: text(payload, "applicationId").ok_or(ErrorCode::InvalidPayload)?,
+            // The archive records who confirmed. Only the extension reaches this path, so
+            // recording `desktop` here would misattribute every plugin confirmation.
+            via: "plugin".into(),
+            note: None,
+            occurred: occurred(request),
+        }),
+        _ => return Err(ErrorCode::UnknownMessageType),
+    };
+
+    // A replay is answered exactly like the original commit, with the original resultId:
+    // that is what makes the plugin retry safe rather than duplicating an application.
+    let (result_id, result_kind) = match store.submit_plugin_message(&ctx, op).map_err(code_of)? {
+        PluginWriteOutcome::Committed {
+            result_id,
+            result_kind,
+        }
+        | PluginWriteOutcome::Replayed {
+            result_id,
+            result_kind,
+        } => (result_id, result_kind),
+    };
+    Ok(Answer {
+        result_id: Some(result_id),
+        payload: json!({ "resultKind": result_kind }),
+    })
+}
+
+fn fill_outcome(payload: &Value) -> Result<FillOutcome, ErrorCode> {
+    match payload.get("outcome").and_then(Value::as_str) {
+        Some("started") => Ok(FillOutcome::Started),
+        Some("completed") => Ok(FillOutcome::Completed),
+        Some("partial") => Ok(FillOutcome::Partial),
+        Some("failed") => Ok(FillOutcome::Failed),
+        Some("cancelled") => Ok(FillOutcome::Cancelled),
+        _ => Err(ErrorCode::InvalidPayload),
+    }
+}
+
+fn query_candidates(request: &Request, store: &ArchiveStore) -> Result<Answer, ErrorCode> {
+    let company = text(&request.payload, "company").ok_or(ErrorCode::InvalidPayload)?;
+    let title = text(&request.payload, "title").unwrap_or_default();
+    let source_url = text(&request.payload, "sourceUrl");
+    let found = store
+        .query_candidates(&company, &title, source_url.as_deref())
+        .map_err(code_of)?;
+    Ok(Answer {
+        result_id: None,
+        payload: json!({
+            "exact": candidates(&found.exact),
+            "sameCompany": candidates(&found.same_company),
+        }),
+    })
+}
+
+fn candidates(items: &[ApplicationCandidate]) -> Vec<Value> {
+    items
+        .iter()
+        .take(MAX_CANDIDATES)
+        .map(|c| {
+            let mut item = Map::new();
+            item.insert("applicationId".into(), json!(c.id));
+            item.insert("company".into(), json!(c.company));
+            item.insert("title".into(), json!(c.title));
+            item.insert("stage".into(), json!(c.current_stage.as_str()));
+            item.insert("updatedAt".into(), json!(c.updated_at));
+            if let Some(url) = &c.source_url {
+                item.insert("sourceUrl".into(), json!(url));
+            }
+            Value::Object(item)
+        })
+        .collect()
+}
+
+fn reconcile(request: &Request, store: &ArchiveStore) -> Result<Answer, ErrorCode> {
+    let raw = request
+        .payload
+        .get("items")
+        .and_then(Value::as_array)
+        .ok_or(ErrorCode::InvalidPayload)?;
+    let mut items = Vec::with_capacity(raw.len());
+    for item in raw {
+        items.push(ReconcileQueryItem {
+            client_instance_id: text(item, "clientInstanceId").ok_or(ErrorCode::InvalidPayload)?,
+            message_id: text(item, "messageId").ok_or(ErrorCode::InvalidPayload)?,
+            source_restore_epoch: text(item, "sourceRestoreEpoch")
+                .ok_or(ErrorCode::InvalidPayload)?,
+            payload_sha256: text(item, "payloadSha256").ok_or(ErrorCode::InvalidPayload)?,
+            snapshot_id: text(item, "snapshotId"),
+            chunk_index: count(item, "chunkIndex"),
+        });
+    }
+    let replies = store
+        .reconcile_lookup(
+            envelope_identity(request).as_ref(),
+            &request.client_instance_id,
+            &items,
+        )
+        .map_err(code_of)?;
+
+    let answered = replies
+        .iter()
+        .map(|reply| {
+            let mut item = Map::new();
+            item.insert(
+                "clientInstanceId".into(),
+                json!(reply.item.client_instance_id),
+            );
+            item.insert("messageId".into(), json!(reply.item.message_id));
+            item.insert(
+                "sourceRestoreEpoch".into(),
+                json!(reply.item.source_restore_epoch),
+            );
+            item.insert("payloadSha256".into(), json!(reply.item.payload_sha256));
+            if let Some(snapshot) = &reply.item.snapshot_id {
+                item.insert("snapshotId".into(), json!(snapshot));
+            }
+            if let Some(index) = reply.item.chunk_index {
+                item.insert("chunkIndex".into(), json!(index));
+            }
+            // `resultId` accompanies `applied` and nothing else, and the reason strings
+            // stay here: they quote archive content, which must not reach the extension.
+            match &reply.outcome {
+                ReconcileOutcome::Applied { result_id } => {
+                    item.insert("status".into(), json!("applied"));
+                    item.insert("resultId".into(), json!(result_id));
+                }
+                ReconcileOutcome::Purged => {
+                    item.insert("status".into(), json!("purged"));
+                }
+                ReconcileOutcome::NotFound => {
+                    item.insert("status".into(), json!("not_found"));
+                }
+                ReconcileOutcome::Conflict { .. } => {
+                    item.insert("status".into(), json!("conflict"));
+                }
+                ReconcileOutcome::Unverifiable { .. } => {
+                    item.insert("status".into(), json!("unverifiable"));
+                }
+            }
+            Value::Object(item)
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Answer {
+        result_id: None,
+        payload: json!({ "items": answered }),
+    })
+}
+
+/// Translate a store failure into the protocol vocabulary.
+///
+/// The vocabulary has no code for "this archive is broken", and the closest one that
+/// exists — `unavailable` — is retryable. That is the safe direction: the plugin keeps
+/// its outbox copy and tries again, where a permanent-looking code would have it drop
+/// work that was never written.
+fn code_of(err: StoreError) -> ErrorCode {
+    match err.code() {
+        "identity_missing" => ErrorCode::IdentityMissing,
+        "restore_epoch_mismatch" => ErrorCode::RestoreEpochMismatch,
+        "conflict" => ErrorCode::Conflict,
+        "previously_purged" => ErrorCode::PreviouslyPurged,
+        // The request named something that is not there, or is not acceptable. Both are
+        // faults in what arrived rather than in the archive.
+        "not_found" | "validation_failed" => ErrorCode::InvalidPayload,
+        _ => ErrorCode::Unavailable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use resume_pro_protocol::{payload_body_sha256, sha256_hex, validate_request_bytes};
+    use tempfile::TempDir;
+
+    const CLIENT: &str = "11111111-1111-4111-8111-111111111111";
+    const JOB_URL: &str = "https://jobs.example.test/1";
+
+    fn store() -> (TempDir, ArchiveStore) {
+        let dir = TempDir::new().unwrap();
+        let archive = dir.path().join("archive");
+        std::fs::create_dir_all(&archive).unwrap();
+        let store =
+            crate::commands::open_store(&archive, &dir.path().join("current.json")).unwrap();
+        (dir, store)
+    }
+
+    /// Build the envelope the extension would send, digest included, so these tests go
+    /// through the same validator the wire does rather than around it.
+    fn request(
+        message_type: &str,
+        message_id: &str,
+        identity: Option<&ArchiveIdentity>,
+        mut payload: Value,
+    ) -> Request {
+        if let Some(id) = identity {
+            let stamped = !matches!(
+                message_type,
+                "outbox.reconcile" | "application.queryCandidates"
+            );
+            if stamped && payload.get("sourceRestoreEpoch").is_none() {
+                payload["sourceRestoreEpoch"] = json!(id.restore_epoch);
+            }
+        }
+        if !matches!(
+            message_type,
+            "application.queryCandidates" | "outbox.reconcile" | "snapshot.chunk"
+        ) {
+            payload["payloadSha256"] = json!(payload_body_sha256(&payload).unwrap());
+        }
+        let mut envelope = json!({
+            "protocolVersion": 1,
+            "messageId": message_id,
+            "clientInstanceId": CLIENT,
+            "messageType": message_type,
+            "occurredAt": "2026-09-06T12:00:00.000Z",
+            "payload": payload
+        });
+        if let Some(id) = identity {
+            envelope["archiveId"] = json!(id.archive_id);
+            envelope["restoreEpoch"] = json!(id.restore_epoch);
+        }
+        validate_request_bytes(&serde_json::to_vec(&envelope).unwrap())
+            .expect("the test envelope must be one the validator accepts")
+    }
+
+    fn job(message_id: &str, identity: &ArchiveIdentity, title: &str) -> Request {
+        request(
+            "job.save",
+            message_id,
+            Some(identity),
+            json!({"company": "Synthetic Ltd", "title": title, "sourceUrl": JOB_URL}),
+        )
+    }
+
+    #[test]
+    fn a_saved_job_is_in_the_archive_by_the_time_the_answer_exists() {
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let answer = apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .expect("a job the archive can take must be saved");
+        let result_id = answer.result_id.expect("a write names what it produced");
+
+        // Read through the store, not through the answer: the point is that the row is
+        // already there, not that the response said so.
+        let found = store
+            .query_candidates("Synthetic Ltd", "Engineer", Some(JOB_URL))
+            .unwrap();
+        assert_eq!(found.exact.len(), 1);
+        assert_eq!(found.exact[0].id, result_id);
+    }
+
+    #[test]
+    fn the_same_message_sent_twice_saves_one_application() {
+        // The plugin retries when an answer is lost. A second application for the same
+        // message would be a duplicate the user has to clean up by hand.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let first = apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap()
+        .result_id;
+        let second = apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap()
+        .result_id;
+        assert_eq!(first, second, "a replay returns the original resultId");
+        let found = store
+            .query_candidates("Synthetic Ltd", "Engineer", Some(JOB_URL))
+            .unwrap();
+        assert_eq!(found.exact.len(), 1);
+    }
+
+    #[test]
+    fn a_different_message_id_saves_a_second_application() {
+        // The guard above must come from the receipt, not from refusing anything that
+        // looks similar: two genuine saves of the same posting are the user's to make.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap();
+        apply(
+            &job(
+                "33333333-3333-4333-8333-333333333333",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap();
+        let found = store
+            .query_candidates("Synthetic Ltd", "Engineer", Some(JOB_URL))
+            .unwrap();
+        assert_eq!(found.exact.len(), 2);
+    }
+
+    #[test]
+    fn an_envelope_from_before_a_restore_is_refused_rather_than_written() {
+        // After a restore the epoch is re-minted. A write stamped with the old one was
+        // composed against an archive that is no longer current, and applying it would
+        // silently attach it to different data.
+        let (_dir, store) = store();
+        let stale = ArchiveIdentity {
+            archive_id: store.identity().archive_id,
+            restore_epoch: "44444444-4444-4444-8444-444444444444".into(),
+        };
+        let outcome = apply(
+            &job("22222222-2222-4222-8222-222222222222", &stale, "Engineer"),
+            &store,
+        );
+        assert!(matches!(outcome, Err(ErrorCode::RestoreEpochMismatch)));
+        let found = store
+            .query_candidates("Synthetic Ltd", "Engineer", Some(JOB_URL))
+            .unwrap();
+        assert!(
+            found.exact.is_empty(),
+            "nothing may be written on a refused epoch"
+        );
+    }
+
+    #[test]
+    fn an_envelope_with_no_identity_is_refused() {
+        // The validator rejects this before the bridge ever sees it, so the check here is
+        // deliberately duplicated: an unstamped write must not become one stamped with
+        // whatever archive happens to be open, whichever way it arrives.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let mut anonymous = job(
+            "22222222-2222-4222-8222-222222222222",
+            &identity,
+            "Engineer",
+        );
+        anonymous.archive_id = None;
+        anonymous.restore_epoch = None;
+        assert!(matches!(
+            apply(&anonymous, &store),
+            Err(ErrorCode::IdentityMissing)
+        ));
+        assert!(store
+            .query_candidates("Synthetic Ltd", "Engineer", Some(JOB_URL))
+            .unwrap()
+            .exact
+            .is_empty());
+    }
+
+    #[test]
+    fn a_fill_event_for_an_application_that_does_not_exist_is_not_a_server_fault() {
+        // Reporting this as unavailable would have the plugin retry forever; the fault is
+        // in the applicationId that arrived.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let orphan = request(
+            "fill.submit",
+            "22222222-2222-4222-8222-222222222222",
+            Some(&identity),
+            json!({
+                "applicationId": "55555555-5555-4555-8555-555555555555",
+                "outcome": "completed"
+            }),
+        );
+        assert!(matches!(
+            apply(&orphan, &store),
+            Err(ErrorCode::InvalidPayload)
+        ));
+    }
+
+    #[test]
+    fn a_fill_event_lands_on_the_application_it_names() {
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let saved = apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap()
+        .result_id
+        .unwrap();
+        let filled = request(
+            "fill.submit",
+            "33333333-3333-4333-8333-333333333333",
+            Some(&identity),
+            json!({
+                "applicationId": saved,
+                "outcome": "completed",
+                "fieldCount": 12,
+                "filledCount": 12
+            }),
+        );
+        let answer = apply(&filled, &store).expect("a fill event on a real application is savable");
+        assert!(answer.result_id.is_some());
+        assert!(!store.list_events(&saved).unwrap().is_empty());
+    }
+
+    #[test]
+    fn candidates_are_answered_in_two_layers_and_write_nothing() {
+        // The plugin asks before it saves, so this must not create anything. The exact
+        // layer needs the posting URL as well; without it the same row is only a
+        // same-company hint, which is what stops a silent bind to the wrong application.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap();
+
+        let with_url = apply(
+            &request(
+                "application.queryCandidates",
+                "33333333-3333-4333-8333-333333333333",
+                Some(&identity),
+                json!({"company": "Synthetic Ltd", "title": "Engineer", "sourceUrl": JOB_URL}),
+            ),
+            &store,
+        )
+        .unwrap();
+        assert!(
+            with_url.result_id.is_none(),
+            "a query produces no result object"
+        );
+        let exact = with_url.payload["exact"].as_array().unwrap();
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0]["company"], "Synthetic Ltd");
+        assert!(exact[0]["applicationId"].is_string());
+        assert_eq!(exact[0]["stage"], "saved");
+
+        let without_url = apply(
+            &request(
+                "application.queryCandidates",
+                "44444444-4444-4444-8444-444444444444",
+                Some(&identity),
+                json!({"company": "Synthetic Ltd", "title": "Engineer"}),
+            ),
+            &store,
+        )
+        .unwrap();
+        assert!(without_url.payload["exact"].as_array().unwrap().is_empty());
+        assert_eq!(
+            without_url.payload["sameCompany"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn reconcile_reports_a_committed_message_as_applied_and_an_unknown_one_as_not_found() {
+        // not_found does not mean "never happened", so it must not carry a resultId that
+        // would let the plugin treat it as done.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let saved = apply(
+            &job(
+                "22222222-2222-4222-8222-222222222222",
+                &identity,
+                "Engineer",
+            ),
+            &store,
+        )
+        .unwrap()
+        .result_id
+        .unwrap();
+        let digest = job(
+            "22222222-2222-4222-8222-222222222222",
+            &identity,
+            "Engineer",
+        )
+        .payload["payloadSha256"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let asked = request(
+            "outbox.reconcile",
+            "33333333-3333-4333-8333-333333333333",
+            Some(&identity),
+            json!({"items": [
+                {
+                    "clientInstanceId": CLIENT,
+                    "messageId": "22222222-2222-4222-8222-222222222222",
+                    "sourceRestoreEpoch": identity.restore_epoch,
+                    "payloadSha256": digest
+                },
+                {
+                    "clientInstanceId": CLIENT,
+                    "messageId": "66666666-6666-4666-8666-666666666666",
+                    "sourceRestoreEpoch": identity.restore_epoch,
+                    "payloadSha256": "0".repeat(64)
+                }
+            ]}),
+        );
+        let answer = apply(&asked, &store).unwrap();
+        let items = answer.payload["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["status"], "applied");
+        assert_eq!(items[0]["resultId"], saved);
+        assert_eq!(items[1]["status"], "not_found");
+        assert!(items[1].get("resultId").is_none());
+    }
+
+    #[test]
+    fn a_snapshot_chunk_is_never_acknowledged_while_the_bytes_have_nowhere_to_go() {
+        // A chunk ACK moves the plugin cursor, and a complete ACK is its permission to
+        // drop its own copy. Neither may be sent for bytes that were not stored.
+        let (_dir, store) = store();
+        let identity = store.identity();
+        let bytes = [0u8, 0, 0];
+        let digest = sha256_hex(&bytes);
+        let chunk = request(
+            "snapshot.chunk",
+            "22222222-2222-4222-8222-222222222222",
+            Some(&identity),
+            json!({
+                "snapshotId": "77777777-7777-4777-8777-777777777777",
+                "applicationId": "55555555-5555-4555-8555-555555555555",
+                "chunkIndex": 0,
+                "chunkCount": 1,
+                "chunkSha256": digest,
+                "snapshotSha256": digest,
+                "byteSize": bytes.len(),
+                "bytesBase64": "AAAA"
+            }),
+        );
+        assert!(matches!(apply(&chunk, &store), Err(ErrorCode::Unavailable)));
+    }
+}

--- a/desktop/src-tauri/tests/nm_host.rs
+++ b/desktop/src-tauri/tests/nm_host.rs
@@ -74,7 +74,10 @@ fn the_test_entry_point_behaves_identically() {
 fn the_caller_origin_is_recorded_on_stderr() {
     let tmp = isolated_data_dir("origin-recorded");
     let (_code, _stdout, stderr) = run_host_with_data_dir(&[ORIGIN], &tmp, framed(HEALTH));
-    assert!(stderr.contains(ORIGIN), "the caller must be recorded: {stderr}");
+    assert!(
+        stderr.contains(ORIGIN),
+        "the caller must be recorded: {stderr}"
+    );
     std::fs::remove_dir_all(&tmp).ok();
 }
 
@@ -159,10 +162,17 @@ fn isolated_data_dir(label: &str) -> std::path::PathBuf {
 fn error_code_of(stdout: &[u8]) -> String {
     assert!(stdout.len() > 4, "stdout is too short to be a frame");
     let declared = u32::from_ne_bytes(stdout[..4].try_into().unwrap()) as usize;
-    assert_eq!(stdout.len(), 4 + declared, "stdout must be exactly one frame");
+    assert_eq!(
+        stdout.len(),
+        4 + declared,
+        "stdout must be exactly one frame"
+    );
     let body: serde_json::Value = serde_json::from_slice(&stdout[4..]).unwrap();
     assert_eq!(body["ok"], false);
-    body["error"]["code"].as_str().unwrap_or_default().to_string()
+    body["error"]["code"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string()
 }
 
 #[test]
@@ -254,10 +264,17 @@ const JOB_SAVE: &str = r#"{"protocolVersion":1,"messageId":"44444444-4444-4444-8
 fn error_of(stdout: &[u8]) -> (String, bool) {
     assert!(stdout.len() > 4, "stdout is too short to be a frame");
     let declared = u32::from_ne_bytes(stdout[..4].try_into().unwrap()) as usize;
-    assert_eq!(stdout.len(), 4 + declared, "stdout must be exactly one frame");
+    assert_eq!(
+        stdout.len(),
+        4 + declared,
+        "stdout must be exactly one frame"
+    );
     let body: serde_json::Value = serde_json::from_slice(&stdout[4..]).unwrap();
     (
-        body["error"]["code"].as_str().unwrap_or_default().to_string(),
+        body["error"]["code"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string(),
         body["ok"].as_bool().unwrap_or(false),
     )
 }
@@ -266,7 +283,10 @@ fn paired_dir(label: &str) -> std::path::PathBuf {
     let dir = isolated_data_dir(label);
     std::fs::write(
         dir.join("settings.json"),
-        format!(r#"{{"chromeExtensionId":"{}","edgeExtensionId":""}}"#, EXT_ID),
+        format!(
+            r#"{{"chromeExtensionId":"{}","edgeExtensionId":""}}"#,
+            EXT_ID
+        ),
     )
     .unwrap();
     dir
@@ -290,7 +310,10 @@ fn a_request_the_host_cannot_answer_alone_is_not_reported_as_success() {
     );
     assert_eq!(code, 0, "{stderr}");
     let (error, ok) = error_of(&stdout);
-    assert!(!ok, "a write with nothing behind it must not report success");
+    assert!(
+        !ok,
+        "a write with nothing behind it must not report success"
+    );
     assert_eq!(error, "unavailable", "and must be retryable: {stderr}");
 }
 

--- a/desktop/src-tauri/tests/nm_host.rs
+++ b/desktop/src-tauri/tests/nm_host.rs
@@ -244,3 +244,69 @@ fn an_origin_does_make_the_host_consult_pairing() {
         "an origin must send the host to pairing: {stderr}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// End to end: a real host process reaching a real application process.
+// ---------------------------------------------------------------------------
+
+const JOB_SAVE: &str = r#"{"protocolVersion":1,"messageId":"44444444-4444-4444-8444-444444444444","clientInstanceId":"11111111-1111-4111-8111-111111111111","messageType":"job.save","occurredAt":"2026-09-06T12:00:00.000Z","payload":{"sourceRestoreEpoch":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","company":"合成公司","title":"后端实习","payloadSha256":"1ea8fcf15e56dd83a5e7f8e9adb0c34b94bc28fd5c1b51400ecf597d1f5cc8c4"},"archiveId":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","restoreEpoch":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"}"#;
+
+fn error_of(stdout: &[u8]) -> (String, bool) {
+    assert!(stdout.len() > 4, "stdout is too short to be a frame");
+    let declared = u32::from_ne_bytes(stdout[..4].try_into().unwrap()) as usize;
+    assert_eq!(stdout.len(), 4 + declared, "stdout must be exactly one frame");
+    let body: serde_json::Value = serde_json::from_slice(&stdout[4..]).unwrap();
+    (
+        body["error"]["code"].as_str().unwrap_or_default().to_string(),
+        body["ok"].as_bool().unwrap_or(false),
+    )
+}
+
+fn paired_dir(label: &str) -> std::path::PathBuf {
+    let dir = isolated_data_dir(label);
+    std::fs::write(
+        dir.join("settings.json"),
+        format!(r#"{{"chromeExtensionId":"{}","edgeExtensionId":""}}"#, EXT_ID),
+    )
+    .unwrap();
+    dir
+}
+
+const EXT_ID: &str = "abcdefghijklmnopabcdefghijklmnop";
+
+#[test]
+fn a_request_the_host_cannot_answer_alone_is_not_reported_as_success() {
+    // A relative RESUMEPRO_DATA_DIR leaves no data directory to reach an application in,
+    // so the host has nowhere to forward to. It must say the service is unavailable
+    // rather than invent a successful write.
+    //
+    // The data directory is deliberately unusable rather than merely empty: a usable one
+    // would send the host into a real cold start, launching a desktop application from
+    // the test suite and leaving it running.
+    let (code, stdout, stderr) = run_host_with_data_dir(
+        &["--nm-host"],
+        std::path::Path::new("relative-not-absolute"),
+        framed(JOB_SAVE),
+    );
+    assert_eq!(code, 0, "{stderr}");
+    let (error, ok) = error_of(&stdout);
+    assert!(!ok, "a write with nothing behind it must not report success");
+    assert_eq!(error, "unavailable", "and must be retryable: {stderr}");
+}
+
+#[test]
+fn health_is_answered_without_starting_the_application() {
+    // health asks nothing of the archive, so routing it through the application would put
+    // a cold start in front of a liveness check. An empty but usable data directory means
+    // nothing is listening, so a health that waited would take the full cold-start budget.
+    let tmp = paired_dir("health-alone");
+    let started = std::time::Instant::now();
+    let (code, stdout, _stderr) = run_host_with_data_dir(&[ORIGIN], &tmp, framed(HEALTH));
+    assert_eq!(code, 0);
+    assert_single_health_frame(&stdout);
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "health must not wait on a cold start"
+    );
+    std::fs::remove_dir_all(&tmp).ok();
+}


### PR DESCRIPTION
完成 D06 剩下的部分：应用侧应答、写入落到 D03 事务接口、开发期注册脚本，以及一次真实浏览器验收。

## 这个 PR 做了什么

**本地 IPC 接通（`ipc_server.rs` / `ipc_client.rs`）**
应用在拿到 `host.lock` 之后才开始监听——唯一写入者和唯一监听者是同一件事，而不是两件可能不一致的事（D01 决策 3）。host 每条浏览器消息连一次，连不上就冷启动应用并等待；`Busy` 表示对方在运行且忙，等待是对的，再起一个是错的。

**握手带回真实身份**
`Application::identity()` 每次请求都去读当前打开的档案，而不是启动时抄一份。`rotate_restore_epoch` 在恢复档案时会就地换掉 epoch，用旧值应答等于发给插件一个它下一次写入就会被拒的身份。没有打开档案时返回可重试的 `unavailable`，不编一个占位身份。

**写入交给 D03（`plugin_bridge.rs`）**
`job.save` / `fill.submit` / `submit.confirm` / `outbox.reconcile` / `application.queryCandidates` 映射到 D03 的插件门面。业务行和回执在同一个事务里提交，所以应答报告的是既成事实，管道两侧都没有编造成功。错误只回协议错误码：store 的消息会引用被拒的值本身，固定文案才不会把库里的内容送回扩展。

`snapshot.chunk` 仍然返回 `unavailable`。档案里目前没有任何地方存块字节，而 chunk ACK 会推进插件游标、完整 ACK 更是它丢弃自己副本的许可——都不能为没落盘的字节发出。

**开发期注册脚本（`scripts/nm-dev-register.mjs`）**
D06 范围内的隔离开发注册/取消注册。它不覆盖不是自己写的 manifest：开发机上可能已经有真实注册，而 unregister 还不了一个它没见过的文件。每次改动连同内容摘要记进 receipt，取消时只删摘要仍吻合的文件，注册前指向别处的注册表值恢复原值而不是删键。`allowed_origins` 只接受具体扩展 ID，通配一律拒绝。

## 验收证据

`python scripts/nm_browser_check.py` 用一个临时 MV3 探针扩展、临时浏览器配置、临时 `RESUMEPRO_DATA_DIR` 跑通全程，Windows 上实测通过：

1. 未配对扩展被 `identity_not_allowed` 拒绝；
2. 配对后握手成功，带回 `archiveId` / `restoreEpoch`；
3. `job.save` 返回 `resultId`，**全程没有打开过桌面窗口**；
4. 同一 `messageId` 重发返回同一 `resultId`，没有多出申请；
5. 候选查询能查回刚存的那条。

冷启动可能超过 host 的 10 秒预算，此时返回可重试的 `unavailable`，探针按插件应有的方式重试后成功——这是设计行为。

自动化测试：`src-tauri` 54 个单测（含 host→IPC→档案的端到端）、`nm_host` 11 个进程级测试、注册脚本 16 个测试（跑在内存文件系统和注册表上，不碰运行机器的浏览器配置）。

## 还没做的

- `snapshot.chunk` 的字节存储；
- macOS 上的真实浏览器验收（脚本已支持 darwin 路径，未在机器上跑过）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)