### PR TITLE
feat(d07): URL redaction and dedupe normalisation

### DIFF
--- a/link/normalize.mjs
+++ b/link/normalize.mjs
@@ -1,0 +1,76 @@
+// Normalisation for comparison only. §7 is explicit that the strings the user confirmed are
+// always kept as they were; these keys never replace them.
+//
+// The suffix lists are deliberately short. Folding too much is the worse error: it offers
+// the wrong existing application as a binding candidate, and the user is being asked to
+// confirm, not to audit.
+const CJK_SUFFIXES = [
+  '股份有限公司',
+  '有限责任公司',
+  '有限公司',
+  '集团有限公司'
+];
+
+const LATIN_SUFFIXES = [
+  'co.,ltd.',
+  'co.,ltd',
+  'co.ltd',
+  'coltd',
+  'ltd.',
+  'ltd',
+  'llc',
+  'inc.',
+  'inc',
+  'corporation',
+  'corp.',
+  'corp'
+];
+
+export function normalizeCompany(raw) {
+  let value = foldWidth(String(raw ?? '')).toLowerCase();
+  // Punctuation and spacing carry no identity for a company name, and they are exactly what
+  // differs between "Example, Inc." and "Example Inc".
+  value = value.replace(/[\s,，、.。·・]/g, '');
+  for (const suffix of CJK_SUFFIXES) {
+    if (value.length > suffix.length && value.endsWith(suffix)) {
+      value = value.slice(0, -suffix.length);
+      break;
+    }
+  }
+  for (const suffix of LATIN_SUFFIXES) {
+    if (value.length > suffix.length && value.endsWith(suffix)) {
+      value = value.slice(0, -suffix.length);
+      break;
+    }
+  }
+  return value;
+}
+
+export function normalizeTitle(raw) {
+  return foldWidth(String(raw ?? '')).trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * The comparison key for "is this the same posting the user already saved?".
+ *
+ * URL is part of it but never alone: §7 says a URL is a hint, not an identity, because
+ * stripping parameters can make two postings collide.
+ */
+export function normalizeTriple({ company, title, dedupeUrl }) {
+  return [
+    normalizeCompany(company),
+    normalizeTitle(title),
+    typeof dedupeUrl === 'string' ? dedupeUrl.toLowerCase() : ''
+    // A separator no normalised field can contain. Joining bare would let "星河" + "科技后端"
+    // and "星河科技" + "后端" collide, and the dedupe guard would then refuse to save a
+    // genuinely different posting.
+  ].join('\u0001');
+}
+
+// Full-width ASCII and the ideographic space are the same characters as their half-width
+// forms for identity purposes; an IME decides which one a user types.
+function foldWidth(text) {
+  return text
+    .replace(/[！-～]/g, ch => String.fromCharCode(ch.charCodeAt(0) - 0xfee0))
+    .replace(/　/g, ' ');
+}

--- a/link/redact.mjs
+++ b/link/redact.mjs
@@ -1,0 +1,78 @@
+import { RULES } from './protocol/schema-lite.mjs';
+
+// The credential parameter names and the reviewed allowlist both come from the vendored D05
+// rules. Keeping a second copy here would let the plugin believe a URL is clean while the
+// desktop refuses it — the failure mode is a queue that can never drain.
+export const SECRET_QUERY_KEYS = new Set(RULES.urlSecretQueryKeys || []);
+export const URL_ALLOWLIST = RULES.urlAllowlist || [];
+
+// Removed from dedupeUrl only. They are not credentials, so they stay in sourceUrl where
+// the user can still see where the posting came from; they just must not split one posting
+// into several candidates.
+const TRACKING_PREFIXES = ['utm_'];
+const TRACKING_NAMES = new Set(['gclid', 'fbclid', 'msclkid', 'mc_cid', 'mc_eid', 'igshid', 'ref_src']);
+
+/**
+ * Redact a page URL into the two forms D01 defines.
+ *
+ * Returns `{ sourceUrl, dedupeUrl }`, or null when there is nothing safe to keep. Redaction
+ * happens here, before the intent is queued, so no copy of the original ever reaches
+ * storage, a log or the wire.
+ */
+export function redactUrl(raw) {
+  if (typeof raw !== 'string' || !raw) return null;
+
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  // D05 accepts https only. An http page gets no URL rather than a rewritten one: pretending
+  // a plaintext address was https would be a claim about the page that is not true.
+  if (url.protocol !== 'https:') return null;
+
+  url.username = '';
+  url.password = '';
+  url.hash = '';
+
+  const kept = [];
+  for (const [name, value] of url.searchParams) {
+    if (isSecretParam(url.hostname, url.pathname, name, value)) continue;
+    kept.push([name, value]);
+  }
+
+  const sourceUrl = withParams(url, kept);
+  const dedupeUrl = withParams(url, kept.filter(([name]) => !isTracking(name)));
+  return { sourceUrl, dedupeUrl };
+}
+
+function isSecretParam(host, path, name, value) {
+  const normalised = name.toLowerCase().replaceAll('-', '_');
+  if (!SECRET_QUERY_KEYS.has(normalised)) return false;
+  // `code` and `key` are stripped by default. Only a reviewed, versioned site rule can keep
+  // one, and the rule may never cover an authentication path.
+  return !isAllowlisted(host, path, normalised, value);
+}
+
+function isAllowlisted(host, path, param, value) {
+  return URL_ALLOWLIST.some(rule =>
+    rule.host?.toLowerCase() === host.toLowerCase() &&
+    path.startsWith(rule.pathPrefix) &&
+    rule.param?.toLowerCase() === param &&
+    new RegExp(rule.valuePattern).test(value)
+  );
+}
+
+function isTracking(name) {
+  const lowered = name.toLowerCase();
+  return TRACKING_NAMES.has(lowered) || TRACKING_PREFIXES.some(prefix => lowered.startsWith(prefix));
+}
+
+function withParams(url, pairs) {
+  const out = new URL(url.toString());
+  out.search = '';
+  for (const [name, value] of pairs) out.searchParams.append(name, value);
+  return out.toString();
+}

--- a/tests/link-normalize.test.js
+++ b/tests/link-normalize.test.js
@@ -1,0 +1,86 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../link/normalize.mjs');
+
+test('a company folds its legal suffix away', async () => {
+  const { normalizeCompany } = await load();
+
+  assert.equal(normalizeCompany('星河科技有限公司'), normalizeCompany('星河科技'));
+  assert.equal(normalizeCompany('星河科技股份有限公司'), normalizeCompany('星河科技'));
+});
+
+test('two different companies do not fold into one', async () => {
+  const { normalizeCompany } = await load();
+  // Over-folding is worse than under-folding here: it silently offers the wrong existing
+  // application as a binding candidate.
+  assert.notEqual(normalizeCompany('星河科技有限公司'), normalizeCompany('星海科技有限公司'));
+  assert.notEqual(normalizeCompany('北京星河'), normalizeCompany('上海星河'));
+});
+
+test('full-width characters and stray spacing fold', async () => {
+  const { normalizeCompany } = await load();
+
+  assert.equal(normalizeCompany('　星河ＡＩ　'), normalizeCompany('星河AI'));
+});
+
+test('a latin company folds its suffix and case', async () => {
+  const { normalizeCompany } = await load();
+
+  assert.equal(normalizeCompany('Example, Inc.'), normalizeCompany('example'));
+  assert.equal(normalizeCompany('Example Co., Ltd.'), normalizeCompany('Example'));
+});
+
+test('a title collapses internal whitespace without folding meaning', async () => {
+  const { normalizeTitle } = await load();
+
+  assert.equal(normalizeTitle('  后端　 开发  '), normalizeTitle('后端 开发'));
+  assert.notEqual(normalizeTitle('后端开发'), normalizeTitle('测试开发'));
+});
+
+test('the triple is the same posting seen twice', async () => {
+  const { normalizeTriple } = await load();
+  const a = normalizeTriple({ company: '星河科技有限公司', title: '后端开发 ', dedupeUrl: 'https://jobs.example.com/apply' });
+  const b = normalizeTriple({ company: '星河科技', title: '后端开发', dedupeUrl: 'https://jobs.example.com/apply' });
+
+  assert.equal(a, b);
+});
+
+test('the same company hiring for two roles gives two triples', async () => {
+  const { normalizeTriple } = await load();
+  // Walkthrough 10.1: two roles at one company are two applications, never one.
+  const backend = normalizeTriple({ company: '星河科技', title: '后端开发', dedupeUrl: 'https://jobs.example.com/a' });
+  const qa = normalizeTriple({ company: '星河科技', title: '测试开发', dedupeUrl: 'https://jobs.example.com/b' });
+
+  assert.notEqual(backend, qa);
+});
+
+test('field boundaries cannot be shifted to fake a match', async () => {
+  const { normalizeTriple } = await load();
+  // Without a separator "星河" + "科技后端" and "星河科技" + "后端" produce the same key, and
+  // the dedupe check would then refuse to save a genuinely different posting.
+  const a = normalizeTriple({ company: '星河', title: '科技后端' });
+  const b = normalizeTriple({ company: '星河科技', title: '后端' });
+
+  assert.notEqual(a, b);
+});
+
+test('a missing URL still produces a usable triple', async () => {
+  const { normalizeTriple } = await load();
+
+  const withoutUrl = normalizeTriple({ company: '星河科技', title: '后端开发', dedupeUrl: null });
+
+  assert.equal(typeof withoutUrl, 'string');
+  assert.equal(withoutUrl, normalizeTriple({ company: '星河科技', title: '后端开发' }));
+});
+
+test('normalising does not touch the strings the user confirmed', async () => {
+  const { normalizeTriple } = await load();
+  // §7: the original strings are always kept; normalisation exists only for comparison.
+  const fields = { company: '星河科技有限公司', title: ' 后端  开发 ', dedupeUrl: 'https://jobs.example.com/apply' };
+  const snapshot = JSON.stringify(fields);
+
+  normalizeTriple(fields);
+
+  assert.equal(JSON.stringify(fields), snapshot);
+});

--- a/tests/link-redact.test.js
+++ b/tests/link-redact.test.js
@@ -1,0 +1,140 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+async function load() {
+  return {
+    redact: await import('../link/redact.mjs'),
+    validate: await import('../link/protocol/validate.mjs')
+  };
+}
+
+// The three worked examples in data-privacy.md §7.1, verbatim.
+test('a job URL keeps its tracking parameter but loses the credential ones', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://jobs.example.com/apply?code=REQ42&utm_source=mail&access_token=abc');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?utm_source=mail');
+  assert.equal(result.dedupeUrl, 'https://jobs.example.com/apply');
+});
+
+test('an OAuth callback loses its one and only parameter', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://auth.example.com/callback?code=ONE_TIME_SECRET');
+
+  assert.equal(result.sourceUrl, 'https://auth.example.com/callback');
+  assert.equal(result.dedupeUrl, 'https://auth.example.com/callback');
+});
+
+test('a password reset link loses its key', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://portal.example.com/reset?key=RESET_SECRET');
+
+  assert.equal(result.sourceUrl, 'https://portal.example.com/reset');
+  assert.equal(result.dedupeUrl, 'https://portal.example.com/reset');
+});
+
+test('userinfo and fragment never survive', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://user:pass@jobs.example.com/apply?ref=1#section-2');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?ref=1');
+  assert.equal(result.sourceUrl.includes('user'), false);
+  assert.equal(result.sourceUrl.includes('#'), false);
+});
+
+test('a percent-encoded credential name is still a credential', async () => {
+  const { redact } = await load();
+  // The desktop decodes the name before matching, so a plugin that matched the raw string
+  // would hand over a URL the desktop then refuses — or worse, would keep the token.
+  const result = redact.redactUrl('https://jobs.example.com/apply?access%5Ftoken=abc&role=backend');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?role=backend');
+});
+
+test('case and separator variations of a credential name are stripped', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://jobs.example.com/apply?Access-Token=a&API_KEY=b&SID=c&job=42');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?job=42');
+});
+
+test('a repeated credential parameter is stripped in every position', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://jobs.example.com/apply?token=a&job=42&token=b');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?job=42');
+});
+
+test('a very long credential value does not survive by being awkward', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl(`https://jobs.example.com/apply?secret=${'x'.repeat(5000)}&job=42`);
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?job=42');
+});
+
+test('every redacted URL passes the desktop URL check', async () => {
+  const { redact, validate } = await load();
+  const inputs = [
+    'https://jobs.example.com/apply?code=REQ42&utm_source=mail&access_token=abc',
+    'https://auth.example.com/callback?code=ONE_TIME_SECRET',
+    'https://portal.example.com/reset?key=RESET_SECRET',
+    'https://user:pass@jobs.example.com/apply?ref=1#/callback?access_token=abc',
+    'https://jobs.example.com/apply?access%5Ftoken=abc',
+    'https://JOBS.Example.COM/Apply?Signature=abc'
+  ];
+
+  for (const input of inputs) {
+    const result = redact.redactUrl(input);
+    // If this ever throws, the plugin believed a URL was clean while the desktop refused it.
+    validate.checkUrl(result.sourceUrl);
+    validate.checkUrl(result.dedupeUrl);
+  }
+});
+
+test('a plain http page yields no URL at all', async () => {
+  const { redact } = await load();
+  // D05 accepts https only. Sending http would be refused as secret_forbidden, so the field
+  // is simply left out rather than downgraded or rewritten.
+  assert.equal(redact.redactUrl('http://jobs.example.com/apply'), null);
+});
+
+test('something that is not a URL yields nothing rather than throwing', async () => {
+  const { redact } = await load();
+
+  assert.equal(redact.redactUrl('not a url'), null);
+  assert.equal(redact.redactUrl(''), null);
+  assert.equal(redact.redactUrl(undefined), null);
+});
+
+test('dedupe drops tracking parameters that source keeps', async () => {
+  const { redact } = await load();
+
+  const result = redact.redactUrl('https://jobs.example.com/apply?utm_source=mail&utm_campaign=x&gclid=y&job=42');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply?utm_source=mail&utm_campaign=x&gclid=y&job=42');
+  assert.equal(result.dedupeUrl, 'https://jobs.example.com/apply?job=42');
+});
+
+test('the shipped allowlist is empty and is the desktop copy', async () => {
+  const { redact } = await load();
+  // §7.1 requires a reviewed, versioned rule with the site's own positive and negative
+  // examples before any job number survives. None exists, so none ships; and the list comes
+  // from the vendored rules so the plugin can never keep a parameter the desktop refuses.
+  assert.deepEqual(redact.URL_ALLOWLIST, []);
+});
+
+test('a credential in a routed fragment does not slip through', async () => {
+  const { redact, validate } = await load();
+
+  const result = redact.redactUrl('https://jobs.example.com/apply#/callback?access_token=abc');
+
+  assert.equal(result.sourceUrl, 'https://jobs.example.com/apply');
+  validate.checkUrl(result.sourceUrl);
+});


### PR DESCRIPTION
D07 第二部分：两个纯函数模块，无 chrome、无网络、无存储。落地 [data-privacy.md §7.1](../blob/main/docs/desktop-mvp/data-privacy.md#71-url-脱敏与去重-url) 与 [product-requirements.md §7](../blob/main/docs/desktop-mvp/product-requirements.md#7-重复关联与冲突)。

依赖 #45（已合入）。

## `link/redact.mjs`

把页面 URL 变成 D01 定义的两种形式：`sourceUrl`（剥掉凭据）和 `dedupeUrl`（再剥掉 `utm_*` 等跟踪参数）。

**凭据参数名单和已审核 allowlist 都从 vendored 的 D05 rules 读，不在这里再写一份。** 两份副本迟早会不一致，而不一致的症状是队列永远排不空：插件认为 URL 干净，桌面拒收。

**allowlist 发空的。** §7.1 要求任何岗位号保留规则必须有该站点的正反例（含同 host 的认证路径反例）才能进 allowlist，目前没有这样的规则，所以一条都不发。规则结构留好了。

**http 页面不产出 URL，而不是改写成 https。** D05 只收 https；把明文地址说成 https 是对这个页面的虚假陈述。字段留空即可，`sourceUrl` 在 `job.save` 里本来就是可选的。

## `link/normalize.mjs`

公司 / 岗位 / URL 的规范化，产出比较用的三元组。**原始字符串永远保留**，规范化只用于比较（§7 明确）。

后缀词表故意很短。折叠过头比折叠不足更糟：它会把错误的已有申请当成绑定候选推给用户，而用户是在确认一个选择，不是在做审计。

三元组用 `\u0001` 分隔而不是直接拼接——不然「星河」+「科技后端」和「星河科技」+「后端」会碰撞，去重守卫就会拒绝保存一个真正不同的岗位。有测试盯着这条。

## 测试

24 个新测试，含 §7.1 三个合成例逐字对照、认证路径反例、重复参数、大小写变化、百分号编码参数名（`access%5Ftoken`）、超长值。

其中一条把两个 PR 焊在一起：**脱敏产出必须能过 PR #45 vendored 的 `checkUrl`**。

```bash
node --test tests/*.test.js
```

192 passed / 0 failed。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)