### PR TITLE
feat(d07): save a job offline as a SaveIntent

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,10 @@
+import { installDesktopLink } from "./link/worker.mjs";
+
+// The desktop link owns its own message listener. It deliberately does not touch
+// chrome.action.onClicked or ENSURE_AI_HOST below: those belong to the existing plugin and
+// keep working whether or not a desktop is installed.
+installDesktopLink(chrome);
+
 chrome.action.onClicked.addListener(async (tab) => {
   if (tab.id) {
     try { await chrome.tabs.sendMessage(tab.id, { type: "TOGGLE_MANAGER" }); } catch {}

--- a/content.css
+++ b/content.css
@@ -382,3 +382,119 @@
   font: 11px/1.6 ui-monospace, monospace;
   resize: vertical;
 }
+
+/* Desktop link: save a job, and the pending-sync queue. */
+.resume-pro__desktop {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.resume-pro__save-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.resume-pro__field em {
+  color: #dc2626;
+  font-style: normal;
+  margin-left: 2px;
+}
+
+.resume-pro__save-form input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.resume-pro__save-form input[readonly] {
+  background: rgba(226, 232, 240, 0.6);
+  color: #475569;
+}
+
+.resume-pro__save-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.resume-pro__save-note {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: #64748b;
+}
+
+.resume-pro__desktop-status {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.resume-pro__desktop-status:empty {
+  display: none;
+}
+
+.resume-pro__desktop-status p {
+  margin: 0;
+}
+
+.resume-pro__desktop-status.is-pending {
+  color: #b45309;
+}
+
+.resume-pro__desktop-status.is-warn {
+  color: #b91c1c;
+}
+
+.resume-pro__desktop-status.is-info {
+  color: #334155;
+}
+
+.resume-pro__desktop-status.is-success {
+  color: #15803d;
+}
+
+.resume-pro__extension-id {
+  display: block;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(15, 23, 42, 0.06);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.resume-pro__pending-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.resume-pro__pending-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 8px;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: rgba(241, 245, 249, 0.9);
+  font-size: 12px;
+}
+
+.resume-pro__pending-row em {
+  grid-column: 1 / -1;
+  font-style: normal;
+  font-size: 11px;
+  color: #b45309;
+}

--- a/content.js
+++ b/content.js
@@ -135,6 +135,38 @@
           <textarea id="resume-pro-diagnostics-text" readonly aria-label="填写诊断摘要，可选择复制" rows="14"></textarea>
         </details>
         <div class="resume-pro__divider"></div>
+        <div class="resume-pro__desktop">
+          <button class="resume-pro__manager-button" id="resume-pro-save-job" type="button">保存岗位到本地</button>
+          <form class="resume-pro__save-form" id="resume-pro-save-form" hidden>
+            <label class="resume-pro__field">
+              <span>公司<em>*</em></span>
+              <input type="text" id="resume-pro-save-company" autocomplete="off" required>
+            </label>
+            <label class="resume-pro__field">
+              <span>岗位<em>*</em></span>
+              <input type="text" id="resume-pro-save-title" autocomplete="off" required>
+            </label>
+            <label class="resume-pro__field">
+              <span>地点</span>
+              <input type="text" id="resume-pro-save-location" autocomplete="off">
+            </label>
+            <label class="resume-pro__field">
+              <span>来源链接</span>
+              <input type="text" id="resume-pro-save-url" readonly>
+            </label>
+            <p class="resume-pro__save-note" id="resume-pro-save-note"></p>
+            <div class="resume-pro__save-actions">
+              <button class="resume-pro__ai-button" type="submit">确认保存</button>
+              <button class="resume-pro__manager-button" type="button" id="resume-pro-save-cancel">取消</button>
+            </div>
+          </form>
+          <div class="resume-pro__desktop-status" id="resume-pro-desktop-status" aria-live="polite"></div>
+          <details class="resume-pro__pending" id="resume-pro-pending" hidden>
+            <summary>待同步 <span id="resume-pro-pending-count">0</span> 条</summary>
+            <div class="resume-pro__pending-list" id="resume-pro-pending-list"></div>
+          </details>
+        </div>
+        <div class="resume-pro__divider"></div>
         <div class="resume-pro__groups" id="resume-pro-groups"></div>
         <div class="resume-pro__footer">
           <button class="resume-pro__manager-button" id="resume-pro-open-manager" type="button">打开管理面板</button>
@@ -208,6 +240,7 @@
     aiFillButton.addEventListener("click", handleAiFillClick);
     sidebar.querySelector("#resume-pro-repeat-fill").addEventListener("click", handleRepeatFillClick);
     openManagerButton?.addEventListener("click", () => setManagerVisibility(true));
+    bindDesktopEvents(sidebar);
 
     const chipActions = shadowRoot.querySelector("#resume-pro-chip-actions");
     chipActions?.addEventListener("mousedown", (event) => {
@@ -1609,6 +1642,185 @@
       .replaceAll(">", "&gt;")
       .replaceAll('"', "&quot;")
       .replaceAll("'", "&#39;");
+  }
+
+  // --- Desktop link ---------------------------------------------------------
+  //
+  // The sidebar reads the page and shows the result; the service worker owns the native
+  // messaging port and both queues. Content scripts cannot open that port at all, so every
+  // desktop operation is a message.
+  //
+  // Extraction and URL redaction run here rather than in the worker because the worker has
+  // no DOM, and because §5.2 puts the credential stripping before anything leaves the page.
+
+  let desktopModules = null;
+  let pendingFields = null;
+
+  async function loadDesktopModules() {
+    if (!desktopModules) {
+      const [extract, copy] = await Promise.all([
+        import(chrome.runtime.getURL("link/extract.mjs")),
+        import(chrome.runtime.getURL("link/copy.mjs"))
+      ]);
+      desktopModules = { extract, copy };
+    }
+    return desktopModules;
+  }
+
+  function bindDesktopEvents(sidebar) {
+    sidebar.querySelector("#resume-pro-save-job")?.addEventListener("click", handleSaveJobClick);
+    sidebar.querySelector("#resume-pro-save-cancel")?.addEventListener("click", closeSaveForm);
+    sidebar.querySelector("#resume-pro-save-form")?.addEventListener("submit", (event) => {
+      event.preventDefault();
+      submitSaveForm({ force: false });
+    });
+    refreshPendingList();
+  }
+
+  async function handleSaveJobClick() {
+    const form = shadowRoot?.querySelector("#resume-pro-save-form");
+    if (!form) return;
+
+    try {
+      const { extract } = await loadDesktopModules();
+      const fields = extract.extractJobFields(document, location.href);
+      form.querySelector("#resume-pro-save-company").value = fields.company;
+      form.querySelector("#resume-pro-save-title").value = fields.title;
+      form.querySelector("#resume-pro-save-location").value = fields.location;
+      form.querySelector("#resume-pro-save-url").value = fields.sourceUrl;
+      pendingFields = fields;
+      const note = form.querySelector("#resume-pro-save-note");
+      // Blanks are expected: nothing is guessed. Saying so is what stops a user from
+      // assuming the extension already knows the employer.
+      note.textContent = fields.company
+        ? "请核对，缺的可以自己补。"
+        : "这个页面没有声明公司名，请手动填写；插件不会替你猜。";
+      form.hidden = false;
+      setDesktopStatus(null);
+    } catch (error) {
+      setDesktopStatus({ tone: "warn", text: "读取页面信息失败，请手动填写后再保存。" });
+    }
+  }
+
+  function closeSaveForm() {
+    const form = shadowRoot?.querySelector("#resume-pro-save-form");
+    if (form) form.hidden = true;
+    pendingFields = null;
+  }
+
+  async function submitSaveForm({ force }) {
+    const form = shadowRoot?.querySelector("#resume-pro-save-form");
+    if (!form) return;
+
+    const fields = {
+      company: form.querySelector("#resume-pro-save-company").value.trim(),
+      title: form.querySelector("#resume-pro-save-title").value.trim(),
+      location: form.querySelector("#resume-pro-save-location").value.trim(),
+      // The URL is whatever redaction produced when the form opened. It is not editable and
+      // is never re-read from the address bar here, so no un-redacted URL can reach storage.
+      sourceUrl: pendingFields?.sourceUrl || "",
+      dedupeUrl: pendingFields?.dedupeUrl || ""
+    };
+
+    const { copy } = await loadDesktopModules();
+    let result;
+    try {
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_SAVE_JOB", fields, force });
+    } catch (error) {
+      result = { status: "error" };
+    }
+
+    setDesktopStatus(copy.describeSaveResult(result ?? { status: "error" }));
+    if (result?.status === "queued") {
+      closeSaveForm();
+    }
+    refreshPendingList();
+  }
+
+  function setDesktopStatus(copy) {
+    const box = shadowRoot?.querySelector("#resume-pro-desktop-status");
+    if (!box) return;
+    box.textContent = "";
+    box.className = "resume-pro__desktop-status";
+    if (!copy) return;
+
+    box.classList.add(`is-${copy.tone}`);
+    const line = document.createElement("p");
+    line.textContent = copy.text;
+    box.appendChild(line);
+
+    if (copy.extensionId) {
+      const id = document.createElement("code");
+      id.className = "resume-pro__extension-id";
+      id.textContent = copy.extensionId;
+      box.appendChild(id);
+      const copyButton = document.createElement("button");
+      copyButton.type = "button";
+      copyButton.className = "resume-pro__manager-button";
+      copyButton.textContent = "复制扩展 ID";
+      copyButton.addEventListener("click", () => copyText(copy.extensionId));
+      box.appendChild(copyButton);
+    }
+
+    if (copy.hint) {
+      const hint = document.createElement("p");
+      hint.className = "resume-pro__save-note";
+      hint.textContent = copy.hint;
+      box.appendChild(hint);
+    }
+
+    if (copy.offerForce) {
+      const again = document.createElement("button");
+      again.type = "button";
+      again.className = "resume-pro__manager-button";
+      again.textContent = "再存一次";
+      again.addEventListener("click", () => submitSaveForm({ force: true }));
+      box.appendChild(again);
+    }
+  }
+
+  async function refreshPendingList() {
+    const details = shadowRoot?.querySelector("#resume-pro-pending");
+    const list = shadowRoot?.querySelector("#resume-pro-pending-list");
+    if (!details || !list) return;
+
+    let intents = [];
+    try {
+      const reply = await chrome.runtime.sendMessage({ type: "DESKTOP_LIST_QUEUE" });
+      intents = reply?.intents || [];
+    } catch {
+      return;
+    }
+
+    details.hidden = intents.length === 0;
+    shadowRoot.querySelector("#resume-pro-pending-count").textContent = String(intents.length);
+    list.textContent = "";
+
+    for (const intent of intents) {
+      const row = document.createElement("div");
+      row.className = "resume-pro__pending-row";
+
+      const label = document.createElement("span");
+      label.textContent = `${intent.fields.company} · ${intent.fields.title}`;
+      label.title = intent.fields.sourceUrl || "";
+      row.appendChild(label);
+
+      const state = document.createElement("em");
+      state.textContent = intent.status === "pending_bind" ? "待绑定申请" : "待同步（尚未绑定申请）";
+      row.appendChild(state);
+
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.className = "resume-pro__manager-button";
+      remove.textContent = "删除";
+      remove.addEventListener("click", async () => {
+        await chrome.runtime.sendMessage({ type: "DESKTOP_REMOVE_INTENT", intentId: intent.intentId });
+        refreshPendingList();
+      });
+      row.appendChild(remove);
+
+      list.appendChild(row);
+    }
   }
 
   chrome.runtime.onMessage.addListener((message) => {

--- a/docs/superpowers/plans/2026-09-09-d07-pr-breakdown.md
+++ b/docs/superpowers/plans/2026-09-09-d07-pr-breakdown.md
@@ -1,0 +1,369 @@
+# D07 保存岗位与离线补传 PR 拆分计划
+
+> **For agentic workers:** 本文是 **PR 级拆分**，不是可直接执行的任务清单。每个 PR 开工时先用 superpowers:writing-plans 为该 PR 写 bite-sized 实现计划（存到 `docs/superpowers/plans/YYYY-MM-DD-d07-prN-<name>.md`），再用 superpowers:subagent-driven-development 或 superpowers:executing-plans 执行。
+
+**Goal:** 让用户在招聘页点一次「保存岗位到本地」，字段确认后无论桌面是否在线都不丢，桌面可用时恰好产生一条申请。
+
+**Architecture:** 插件侧新增 `link/` 目录，全部逻辑是可被 `node --test` 直接 import 的 ES module，`chrome.*` 只经由注入的 `deps` 对象接触。Service worker 改为 `type: module`，独占 Native Messaging 与两条队列；content.js 只做侧边栏 UI，通过 `chrome.runtime.sendMessage` 与 SW 通信（content script 拿不到 `chrome.runtime.connectNative` / `sendNativeMessage`）。D05 的 JS 校验器以 vendored 副本进插件，用测试锁住与源文件一致。
+
+**Tech Stack:** MV3（`minimum_chrome_version` 116）、原生 ES module、Web Crypto（`crypto.subtle`）、`chrome.storage.local`、`chrome.alarms`、`node --test`。无打包器、无新增第三方依赖。
+
+**Spec 来源：** [#20](https://github.com/TshyGO/resume-form-assistant-plugin/issues/20)（范围与验收）· [product-requirements.md §5.2 / §7 / §8.10 / §8.11 / §9](../../desktop-mvp/product-requirements.md) · [data-privacy.md §7.1](../../desktop-mvp/data-privacy.md) · [protocol/README.md](../../../desktop/crates/protocol/README.md) · [protocol/INTEGRATION.md](../../../desktop/crates/protocol/INTEGRATION.md)
+
+**基线：** `47f21d7`（D06 四个 PR 已合入 `main`）
+
+---
+
+## 已核实的外部事实（基线 47f21d7，实现时直接用，不必再查）
+
+**协议 JS 入口** `desktop/crates/protocol/js/`，四个文件自足、无 `node:` / `Buffer` 依赖，import 图是 `validate.mjs → time.mjs`、`schema-lite.mjs → {time.mjs, schema-data.mjs}`：
+
+- `MAX_ENVELOPE_BYTES = 65536`、`MAX_RECONCILE_ITEMS = 32`、`MAX_CHUNK_COUNT = 128`、`MAX_SNAPSHOT_BYTES = 2097152`
+- `async validateRequest(value)` · `async validateRequestBytes(bytes)` · `validateResponseForRequest(value, request)` · `checkCurrentIdentity(req, current)` · `async payloadBodySha256(payload)` · `checkUrl(raw)` · `originAllowed(origin, allowed)` · `utf8JsonLen(value)`
+- 摘要用 `crypto.subtle.digest`，所以 `validateRequest` / `payloadBodySha256` 是 **async**。Node 18+ 有全局 `crypto.subtle`，`node --test` 可直接跑。
+
+**信封形状**（`desktop/crates/protocol/fixtures/requests/*.json` 是权威样例）：
+
+```json
+{ "protocolVersion": 1, "messageId": "<uuidv4>", "clientInstanceId": "<uuidv4>",
+  "messageType": "job.save", "occurredAt": "2026-09-06T12:00:00.000Z",
+  "payload": { }, "archiveId": "<uuidv4>", "restoreEpoch": "<uuidv4>" }
+```
+
+- `health` / `handshake`：**禁止**信封 `archiveId` / `restoreEpoch`。
+- `application.queryCandidates` / `job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm` / `outbox.reconcile`：**必须**带，且必须是 **最新握手的 current**。
+- 写类型（`job.save` / `fill.submit` / `snapshot.chunk` / `submit.confirm`）的 payload 里另有 `sourceRestoreEpoch` 与 `payloadSha256`；`queryCandidates` 与 `outbox.reconcile` 的 payload **不接受**这两个字段（`additionalProperties: false`，多写即 `invalid_payload`）。
+- `job.save` payload：必填 `sourceRestoreEpoch` / `payloadSha256` / `company` / `title`，可选 `sourceUrl` / `location` / `applicationId`。
+- `application.queryCandidates` payload：必填 `company`，可选 `title` / `sourceUrl`；应答 `{ exact: [], sameCompany: [] }`，每项 `{applicationId, company, title, stage?, sourceUrl?, updatedAt?}`，各 ≤ 32 条。
+- `submit.confirm` payload：必填 `sourceRestoreEpoch` / `payloadSha256` / `applicationId`，**没有**别的字段（`via` / `note` 是 D03 内部字段，不进信封）。
+- `outbox.reconcile` payload：`items[]`，每项 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`，批次 ≤ 32；应答逐项回显身份并给 `applied` / `purged` / `not_found` / `conflict` / `unverifiable`，只有 `applied` 带已核实的 `resultId`。
+- `occurredAt`：UTC `Z` 子集，`new Date().toISOString()` 合法（允许小数秒），必须是真实日历日期。
+- 应答校验一律 `validateResponseForRequest(response, req)`；`validateResponse` 看不到请求，多条同类型在途时会把 A 的回复记到 B 头上。
+
+**错误码：** `identity_missing` · `identity_not_allowed` · `restore_epoch_mismatch` · `protocol_incompatible` · `unknown_message_type` · `invalid_payload` · `payload_too_large` · `conflict` · `previously_purged` · `unavailable`（**唯一默认 retryable**） · `secret_forbidden`。`ok:true` 的写入必有 `resultId`；`ok:false` 一定没有。
+
+**Host：** 名称 `com.resumepro.desktop`，开发期注册见 [desktop/DEV-NATIVE-MESSAGING.md](../../../desktop/DEV-NATIVE-MESSAGING.md)。`nm.rs::serve` 是「读帧直到管道关闭」的循环，长连接与一次性调用都支持。握手成功返回 `{appVersion, minProtocolVersion, maxProtocolVersion, archiveId, restoreEpoch, capabilities[]}`。
+
+**D06 留给 D07 的三条实测行为：**
+
+1. **冷启动可能超过 host 的 10 秒预算**，此时返回可重试的 `unavailable`。必须重试，不得报错给用户。
+2. **`snapshot.chunk` 目前一律 `unavailable`**（字节存储属于 D08）。D07 不发快照；若队列里出现快照项按可重试处理。
+3. 未配对的扩展被 `identity_not_allowed` 拒绝；配对写在桌面 `settings.json`，插件只负责把自己的 `chrome.runtime.id` 显示出来让用户去粘贴。
+
+**插件现状：** `background.js` 是 classic service worker，只有 `chrome.action.onClicked → TOGGLE_MANAGER` 和 `ENSURE_AI_HOST`（offscreen）。permissions 为 `offscreen` / `storage` / `scripting` / `activeTab` / `tabs`，**没有** `nativeMessaging`、**没有** `alarms`。`chrome.storage.local` 已占用 `templates` / `activeTemplateId` / `aiConfig`（content.js:3）与 `resumeProUpdateCache` / `resumeProDismissedVersion`（popup.js）——D07 一个都不许碰。侧边栏在 shadow root 里由 `renderSidebar()`（content.js:241）渲染。插件没有任何岗位页信息抽取代码，这部分是新写的。
+
+---
+
+## 三个架构决策（已定，PR1 落地；反对请在 PR1 评论提）
+
+**1. 传输用 `chrome.runtime.sendNativeMessage`，不是 `connectNative`。**
+downstream-decisions.md 的风险 V4 已经预留了这个回落。一次性调用的语义与 D06 的 `serve` 循环、与 `nm_browser_check.py` 实测路径一致，也不需要处理 MV3 SW 在长连接上的存活争议。代价是每条消息拉起一次 host 进程（应用进程本身常驻，不重复拉起）。`link/transport.mjs` 只导出 `sendOnce(envelope)`，换成长连接时改这一个文件。
+
+**2. D05 校验器 vendored 进插件，用测试锁一致性。**
+`desktop/crates/protocol/js/` 在扩展根之外，MV3 加载不到。四个文件复制到 `link/protocol/`，`tests/protocol-vendor.test.js` 断言与源文件逐字节相同——源文件一改，插件测试立刻红。不引打包器，不写第二份校验逻辑。
+
+**3. 所有 `link/*.mjs` 通过注入的 `deps` 接触宿主，不直接引用 `chrome`。**
+`deps = { storage, sendNative, now, uuid, alarms }`。SW 在 `background.js` 里组装真实实现，node 测试传假实现。没有这条，`node --test` 覆盖不到队列与重试，D07 的验收只能靠手点。
+
+**队列上限取 D01 的建议值：意图 100 条、绑定消息 100 条**，写成 `link/limits.mjs` 的常量。满了拒绝新增并提示，不丢旧项，不阻止填表。
+
+**`urlAllowlist` 本轮发空。** data-privacy.md §7.1 要求任何岗位号保留规则必须有该站点的正反例（含同 host 的认证路径反例）才能进。D07 不假造站点名单；规则结构留好，条目为空。
+
+---
+
+## File Structure
+
+| 文件 | 职责 |
+| --- | --- |
+| `link/protocol/{validate,schema-lite,schema-data,time}.mjs` | D05 校验器的 vendored 副本，只读，不手改 |
+| `link/limits.mjs` | 队列上限、退避参数、去重窗口等常量，单一出处 |
+| `link/envelope.mjs` | 按 messageType 组装信封：身份该带不该带、写类型盖 `sourceRestoreEpoch` 与 `payloadSha256` |
+| `link/transport.mjs` | `sendOnce(envelope)`；把 `lastError` 与错误应答分类成 `not_installed` / `not_paired` / `retryable` / `fatal` |
+| `link/session.mjs` | 握手、版本协商、`desktopPairing` 缓存、模式判定（未安装 / 未配对 / 曾配对不可用 / 可用 / 协议不兼容） |
+| `link/store.mjs` | `chrome.storage.local` 的四个新 key 读写与并发安全的读改写 |
+| `link/redact.mjs` | URL 脱敏：`sourceUrl` 与 `dedupeUrl` |
+| `link/normalize.mjs` | 公司 / 岗位 / URL 规范化，产出去重三元组 |
+| `link/intents.mjs` | SaveIntent 生命周期：新增、去重、状态流转、删除、容量 |
+| `link/outbox.mjs` | Bound outbox：铸 `messageId`、盖 epoch、发送、ACK 落库、回填 `applicationId` |
+| `link/drain.mjs` | alarms 驱动的排空与有上限退避 |
+| `link/reconcile.mjs` | epoch 不匹配的暂停、`outbox.reconcile` 批次、五种状态的处置 |
+| `link/messages.mjs` | SW ↔ content 的消息名与形状常量 |
+| `background.js` | 组装 `deps`、注册消息路由与 alarm 监听；保留现有 `onClicked` 与 `ENSURE_AI_HOST` |
+| `content.js` | 侧边栏：保存入口、字段确认、候选选择、待同步面板、确认已投递 |
+| `content.css` | 上述面板样式 |
+| `manifest.json` | 加 `nativeMessaging` / `alarms` 权限，SW 改 `type: module` |
+| `tests/*.test.js` | 每个 PR 自带的 node 测试 |
+
+**`background.js` 的 `chrome.action.onClicked` 不得被覆盖**（README.md:51 明确点名）。改成 module 后现有 `ENSURE_AI_HOST` 行为必须逐字保持。
+
+---
+
+## PR 1 · 协议客户端与 Native Messaging 传输
+
+**只做：** 让插件能对桌面发出一条合法信封并正确解读回复。没有任何 UI。
+
+**文件：** `link/protocol/*`（vendored）、`link/limits.mjs`、`link/envelope.mjs`、`link/transport.mjs`、`link/session.mjs`、`link/store.mjs`、`manifest.json`、`background.js`、`tests/protocol-vendor.test.js`、`tests/link-envelope.test.js`、`tests/link-transport.test.js`、`tests/link-session.test.js`
+
+**关键契约：**
+
+- `manifest.json`：`permissions` 加 `nativeMessaging` 与 `alarms`；`background` 改成 `{"service_worker": "background.js", "type": "module"}`。
+- `desktopClientInstanceId`：首次使用 `crypto.randomUUID()` 生成并持久化，之后不变；清存储后是新 ID（D01 §5.2.2）。
+- `envelope.mjs` 按类型分流：`health` / `handshake` 不带信封身份；其余必带 current；写类型的 payload 先填 `sourceRestoreEpoch`，**再**算 `payloadSha256`（摘要是去掉该字段后、键排序的 compact JSON）。发送前 `utf8JsonLen(envelope) > MAX_ENVELOPE_BYTES` 就地失败为 `payload_too_large`，不发。
+- `transport.mjs` 的分类表——这是整个 D07 降级文案的地基：
+
+  | 观察到 | 分类 | 含义 |
+  | --- | --- | --- |
+  | `lastError` 提到 host not found | `not_installed` | 无 host 注册 |
+  | `ok:false` + `identity_not_allowed` | `not_paired` | 装了但没配对 |
+  | `lastError` 其它（管道断、启动失败） | `retryable` | 曾配对，此刻不可用 |
+  | `ok:false` + `unavailable` | `retryable` | 含冷启动超 10 秒 |
+  | `ok:false` + 其它码 | `fatal`（按码分别处置） | |
+
+  `lastError.message` 的措辞随浏览器版本变，**不能**只靠字符串匹配定生死：匹配不上时按 `retryable` 处理，宁可重试一次也不要谎报「未安装」。
+- `session.handshake()`：成功后写 `desktopPairing = {archiveId, restoreEpoch, appVersion, at}`（仅提示，**不是**提交凭证）；`minProtocolVersion`/`maxProtocolVersion` 与本地区间不交 → `protocol_incompatible`，不落 pairing。
+- 冷启动：`sendOnce` 内部对 `retryable` 只重试 **一次**（间隔 1s）。多次重试归 PR5 的 drain，不在传输层重复实现。
+
+**测试（`node --test tests/*.test.js`）：**
+
+- vendored 四个文件与 `desktop/crates/protocol/js/` 逐字节相同。
+- 用 `desktop/crates/protocol/fixtures/requests/*.json` 反向验证：`envelope.mjs` 造出的 `job.save` / `queryCandidates` / `handshake` / `outbox.reconcile` 都能过 vendored `validateRequest`。
+- `health` / `handshake` 带上身份会被拒；`queryCandidates` 多塞 `payloadSha256` 会被拒（`invalid_payload`）。
+- 超过 65536 字节在本地就失败，不调用 `sendNative`。
+- 五种传输观察各自映射到正确分类；`lastError` 措辞不认识时归 `retryable`。
+- 握手区间不交 → `protocol_incompatible` 且不写 pairing。
+
+**覆盖 #20 的：**「协议不兼容」测试项的一半（另一半是 PR3 的文案）。
+
+**不做：** UI、队列、任何写入的实际发送。
+
+---
+
+## PR 2 · URL 脱敏与去重规范化
+
+**只做：** 两个纯函数模块，无 chrome、无网络。
+
+**文件：** `link/redact.mjs`、`link/normalize.mjs`、`tests/link-redact.test.js`、`tests/link-normalize.test.js`
+
+**关键契约（data-privacy.md §7.1 与 product-requirements.md §7）：**
+
+- 一律去掉 `user:pass@` 用户信息与 fragment。
+- 始终剥离（大小写不敏感，含百分号编码的参数名）：`token`、`access_token`、`refresh_token`、`id_token`、`session`、`sessionid`、`sid`、`auth`、`authorization`、`api_key`、`apikey`、`password`、`pwd`、`secret`、`signature`、`sig`，以及 **默认剥离** 的 `code`、`key`。
+- `sourceUrl` 与 `dedupeUrl` 用同一套剥离策略；`dedupeUrl` 再去 `utm_*` 并把 host 小写。
+- 脱敏必须发生在 **入意图队列之前**，不留原始副本。
+- `urlAllowlist` 结构：`{host, pathPattern, param, valuePattern, version, reviewedAt}`，**本轮为空数组**。命中规则才可保留岗位号；登录 / 回调 / 重置 / 邀请 / 认证路径永不适用。
+- 规范化三元组：公司去首尾空白 + 全半角折叠 + 有限后缀词表（「有限公司」「股份有限公司」「(中国)」等，词表写死在模块里并注释来源）；岗位去首尾空白 + 压缩内部空白；URL 用 `dedupeUrl`。**原始字符串始终保留**，规范化只用于比较。
+
+**测试：**
+
+- data-privacy.md §7.1 的三个合成例逐字对上（`jobs.example.com/apply?code=REQ42&utm_source=mail&access_token=abc` → `sourceUrl = https://jobs.example.com/apply?utm_source=mail`、`dedupeUrl = https://jobs.example.com/apply`）。
+- 认证路径反例：`auth.example.com/callback?code=...`、`portal.example.com/reset?key=...` 一律剥光。
+- 重复参数、大小写变化（`Access_Token`）、编码参数名（`access%5Ftoken`）、超长值、非法岗位号语法。
+- **脱敏输出必须能过 PR1 vendored 的 `checkUrl`**——这条把两个 PR 焊死，防止「插件觉得干净、桌面照样拒」。
+- 规范化：同公司不同后缀折叠成同一 key；不同公司不折叠成同一 key（防过度折叠）。
+
+**覆盖 #20 的：**「URL 删除明确的登录凭据/令牌等秘密参数」。
+
+**不做：** 页面抽取、任何存储。
+
+---
+
+## PR 3 · 保存入口、字段确认与 SaveIntent 队列（离线可用，不发送任何写入）
+
+**只做：** 桌面完全不在也能把用户确认过的字段安全存下来，并且诚实地说「待同步」。
+
+**文件：** `content.js`、`content.css`、`link/intents.mjs`、`link/messages.mjs`、`background.js`、`tests/link-intents.test.js`、`tests/link-extract.test.js`
+
+**关键契约：**
+
+- 侧边栏新增「保存岗位到本地」。点击后弹字段确认面板，展示 **抽取到的** 公司 / 岗位 / 地点 / 来源链接，缺项留空让用户手填。抽取只用确定性来源：`JobPosting` JSON-LD、`og:title` / `og:site_name`、`document.title`、`<h1>`。**抽不到就留空，不猜、不调 AI**（#20：「缺失字段可手动补充，不捏造」）。公司与岗位为空时不允许确认。
+- URL 在 **content.js 交给 SW 之前** 就过 `redact.mjs`（§5.2 时序图明确画在 content 侧）。
+- **只带走用户确认过的那几个字段**：不存整页 HTML、不存浏览历史、不对用户没主动保存的页面留任何记录（#20 隐私条款）。抽取只在用户点「保存岗位到本地」之后跑一次，不在页面加载时后台扫描。
+- 模式判定（复用 PR1 `session.mjs`）决定确认后的行为：
+
+  | 模式 | 行为 | 文案 |
+  | --- | --- | --- |
+  | 未安装 / 从未配对 | **不建意图、不建队列** | 「先安装桌面程序」/「到桌面粘贴扩展 ID：`<chrome.runtime.id>`」+ 一键复制 |
+  | 已安装未配对 | **不建意图** | 只说配对，**不得**说「未安装」 |
+  | 曾配对、桌面不可用 | **持久化 SaveIntent** | 「待同步（尚未绑定申请）」 |
+  | 协议不兼容 | 保留已有意图，不新建绑定 | 提示升级 |
+
+  配对成功后提示「重载扩展或重启浏览器」（downstream-decisions 风险 V3）。
+- SaveIntent 字段严格照 §8.10：`intentId`、`clientInstanceId`、`company`、`title`、`sourceUrl`、`location`、`createdAt`、`lastSeenArchiveId`（仅提示）、`status ∈ {pending_desktop, pending_bind, cancelled}`。**没有** `messageId`、**没有**申请 UUID、**没有** `restoreEpoch`。
+- 10 秒去重：同一页规范化三元组相同且已有 pending 意图 → 提示「已有待同步意图」，不写第二条；用户显式点「再存一次」才铸新 `intentId`。
+- 容量 100：满了拒绝新增 + 提示处理，不丢旧项，**不影响填表**。
+- 待同步面板：列出意图、显示状态、支持删除单条。
+- 存储 key 只用 `desktopSaveIntents` / `desktopOutbox` / `desktopClientInstanceId` / `desktopPairing`。
+
+**测试：**
+
+- 抽取：JSON-LD 齐全 → 三项都填；只有 `<title>` → 公司留空而不是拿站点名充数；脏页面不抛异常。
+- 桌面不可用时确认 → 意图落盘且 UI 文案 **不含**「已保存」（断言字符串）。
+- 未安装 / 从未配对 → `desktopSaveIntents` 保持为空。
+- 10 秒内同三元组重复点击只有一条；显式「再存一次」有两条。
+- 第 101 条被拒且前 100 条完好。
+- 现有 `templates` / `aiConfig` / `resumeProUpdateCache` 在整个流程后逐字节不变。
+
+**覆盖 #20 的：**「新增显式保存入口」「缺失字段手动补充」「离线入队」「队列满」「未安装时现有功能仍可用」，以及验收 1 的前半。
+
+**不做：** queryCandidates、绑定、发送。
+
+---
+
+## PR 4 · 候选查询、绑定与 job.save 成功路径
+
+**只做：** 桌面在线时，从意图走到「桌面已保存」，且重放不重复建档。
+
+**文件：** `link/outbox.mjs`、`content.js`、`content.css`、`background.js`、`tests/link-outbox.test.js`、`tests/link-candidates.test.js`
+
+**关键契约：**
+
+- 握手成功后才 `application.queryCandidates`（读，payload 只带 `company` / `title` / `sourceUrl`）。**不把整库同步给插件**——只用应答里的最小形状。
+- 候选 UI 两层（§7）：`exact` 标「可能是同一岗位的重复投递」，`sameCompany` 标「同公司其他岗位」。**默认新建，永不自动绑定**。第三个选项「稍后再说」= 意图保持 pending，不写绑定项。
+- 用户选定后写 Bound outbox（§8.10 字段），此刻才铸 `messageId`、盖 `sourceRestoreEpoch = 当时 current`、算 `payloadSha256`。**先落盘，再发送**——发送前进程被杀也不会丢身份。
+- 发送 `job.save`，信封身份用 **最新握手的 current**。应答 `ok:true` → 记 `resultId`，「新建」路径把返回的 `applicationId` 回填一次，删除对应意图与队列项，UI 才显示「桌面已保存（stage=saved，不是已投递）」。
+- 应答一律 `validateResponseForRequest(res, req)`。校验不过按 `retryable` 处理，不当成功。
+- 重试沿用同一 `messageId`，绝不新铸——桌面据此返回原 `resultId`。
+
+**测试：**
+
+- 假 host 返回 `queryCandidates` 双层结果 → UI 分层正确、默认选中「新建」。
+- 绑定项落盘在发送之前（在 `sendNative` 里断言 storage 已有该项）。
+- 同一 `messageId` 重发，桌面返回同一 `resultId` → 队列删一次、不产生第二条申请、不重复触发 UI。
+- `ok:false` 的应答带了 `resultId`（越权响应）→ 被 `validateResponseForRequest` 拒绝，不写成功态。
+- 「稍后再说」→ 意图仍 pending，`desktopOutbox` 为空。
+- 「桌面已保存」文案只在 `ok:true` 且已删队列项之后出现。
+
+**覆盖 #20 的：** 验收 2、验收 3 的重放部分、验收 5 的默认阶段、「支持选择新建或绑定现有」「候选查询只取必要字段」。
+
+---
+
+## PR 5 · 重试、退避与用户可控的待同步队列
+
+**只做：** 应答丢了、浏览器重启了、桌面十分钟后才开——最后仍然恰好一条。
+
+**文件：** `link/drain.mjs`、`background.js`、`content.js`、`tests/link-drain.test.js`
+
+**关键契约：**
+
+- `chrome.alarms` 驱动排空（SW 会被回收，`setTimeout` 撑不过）。Chrome 对 alarm 周期有 ≥30 秒的下限，退避阶梯据此设计：1s / 5s / 30s / 2min / 10min / 30min，**有上限**，达上限转「需要手动重试」而不是无限重试。30 秒以内的那几档只在 SW 仍存活时用 `setTimeout` 走，跨越回收一律靠 alarm。
+- 退避不产生新业务事件：**重试沿用原 `messageId` 与原 `sourceRestoreEpoch`**，只有信封身份换成最新 current。
+- 浏览器重启后 SW 冷启动时挂一次排空；意图与绑定项都从 `chrome.storage.local` 读回。
+- 待同步面板显示：待同步条数、每条的失败原因（用 PR1 的分类，不回显协议原文）、下次重试时间、**手动重试**、**用户取消**。
+- 绑定队列容量 100，满了拒绝新增并提示，不丢旧项、不阻止填表。
+- 排空串行：同一时刻只有一条在途，避免多条抢同一个 host 冷启动。
+
+**测试：**
+
+- 假时钟推进，断言退避阶梯与上限；达上限后不再自动发。
+- 「应答丢失」：`sendNative` 超时不回 → 重试用同一 `messageId`；第二次桌面返回原 `resultId` → 只删一次。
+- 冷启动 `unavailable` 连续两次后成功 → 用户全程只看到「待同步」，没有错误弹窗。
+- 模拟浏览器重启（丢弃内存态、只留 storage）→ 队列完整、排空继续。
+- 队列满：第 101 条被拒，填表功能仍可用（跑现有 `tests/form-agent.test.js` 断言无回归）。
+- 用户取消：队列项消失、不再重试、不给桌面发任何东西。
+
+**覆盖 #20 的：** 验收 1 完整、「持久化待发送队列、有上限退避」「显示待同步数、失败原因、手动重试与取消」，测试项里的「浏览器重启」「应答丢失后重发」「连接恢复」「队列满」。
+
+---
+
+## PR 6 · restoreEpoch 不匹配：暂停、对账与用户决定
+
+**只做：** 桌面恢复过备份之后，旧队列不许静默重放。
+
+**文件：** `link/reconcile.mjs`、`content.js`、`background.js`、`tests/link-reconcile.test.js`
+
+**关键契约：**
+
+- 每次握手成功后，逐条比较绑定项的 `sourceRestoreEpoch` 与新 current：不等 → 该项 **立即暂停**，不发任何写入。
+- 暂停项 **只能** 发 `outbox.reconcile`：外层信封用当前握手身份，payload 每项带完整旧身份 `{clientInstanceId, messageId, sourceRestoreEpoch, payloadSha256}`，批次 ≤ 32（`MAX_RECONCILE_ITEMS`）。
+- 五种状态的处置：
+
+  | 状态 | 处置 |
+  | --- | --- |
+  | `applied` | 桌面已执行过；删除队列项，**不新增业务事件**，也不把它当成可重放的许可 |
+  | `purged` | 对象已被永久删除；不重建，告知用户 |
+  | `not_found` | **不代表从未执行**；不自动重写，交用户核对 |
+  | `conflict` | 同身份摘要不符；拒绝自动处理 |
+  | `unverifiable` | 无法核实；不自动重放 |
+
+- 用户对暂停项只有三个出口：**关联**（绑到指定申请）/ **丢弃** / **另存**。「另存」= 铸新 `messageId` + 盖当前 epoch + 记录旧身份关联，**该转换必须先持久化再发送**，重试不得再生成第三个身份。
+- 意图不盖 epoch，桌面恢复后 **重新走 queryCandidates**，不直接复用旧候选。
+- `sourceRestoreEpoch` 一旦写入 **永不修改**（§8.10 明确 immutable）。
+
+**测试：**
+
+- 换 epoch 后握手 → 所有旧绑定项 status 变 paused，且 `sendNative` 再没收到过任何写类型。
+- 五种对账状态各自的处置，逐个断言队列与 UI 结果。
+- 「另存」在发送前已落盘；连续两次重试只有一个新 `messageId`。
+- 33 条待对账 → 分两批，每批 ≤ 32。
+- 旧信封（旧 epoch）在任何路径下都不会被发出（全局断言）。
+- 意图在恢复后重新查候选，不复用旧 `exact` 结果。
+
+**覆盖 #20 的：**「restoreEpoch 不匹配时暂停旧队列，由用户决定关联/丢弃/另存，不自动重放」，测试项里的「重复内容冲突」「恢复档案库后的旧队列」。
+
+---
+
+## PR 7 · 确认已投递、降级文案收口与回归
+
+**只做：** 补上 `submit.confirm`，把九种降级模式的文案一次对齐，出 D07 的验收证据。
+
+**文件：** `content.js`、`content.css`、`link/outbox.mjs`、`README.md`、`docs/desktop-mvp/`（如有契约偏差）、`tests/link-submit-confirm.test.js`、`tests/link-degradation.test.js`
+
+**关键契约：**
+
+- 「确认已投递」按钮 **与 AI 填写成功与否无关**（§5.2 第 5 条），只对已绑定申请可用。payload 只有 `applicationId`（+ `sourceRestoreEpoch` / `payloadSha256`）。走与 `job.save` 同一套 outbox / 退避 / 对账。
+- 一次保存 ≠ 已投递：`job.save` 后阶段是 `saved`，只有用户点「确认已投递」才推进。
+- 把 §9 降级矩阵九行的文案集中到一处并逐行测：「未安装」「已安装未配对」「曾配对不可用」「离线」「AI 不可用」「协议不兼容」「epoch 不匹配」各自说什么、**不**说什么。
+- 全量回归：`node --test tests/*.test.js` 全绿，含 D07 之前就有的 8 个测试文件。
+- 若实现中发现与 D05 / D01 契约的偏差，**先改 [#23](https://github.com/TshyGO/resume-form-assistant-plugin/issues/23) / [#17](https://github.com/TshyGO/resume-form-assistant-plugin/issues/17) 和受影响 issue**，不只改本模块（#20 完成条件第 3 条）。
+- 用 `desktop/scripts/nm_browser_check.py` 的方式跑一次真实浏览器端到端，把证据贴回 #20。**关闭顺序：先让应用退出，再关浏览器。**
+
+**覆盖 #20 的：** 验收 4、验收 5 完整，「当前插件完整回归」，完成条件三条。
+
+---
+
+## 依赖与并行
+
+```text
+PR1 ──> PR2 ──> PR3 ──> PR4 ──> PR5 ──> PR6 ──> PR7
+```
+
+PR1→PR4 严格串行：后一个都要用前一个的模块。PR5 与 PR6 都改待同步面板，建议顺序合并而不是并行开两个分支——谁先合谁不改，后者 rebase。PR2 唯一能提前的是它的纯函数部分，但收尾测试要用 PR1 的 `checkUrl`，所以仍排在 PR1 之后。
+
+## #20 验收清单的覆盖
+
+| #20 验收 | PR |
+| --- | --- |
+| 关闭主程序保存岗位，重启浏览器后队列仍在；恢复后只产生一条 | PR3（持久化）+ PR5（重启与排空） |
+| 「桌面已保存」只在持久化应答后出现 | PR4（正路）+ PR3/PR7（反例文案） |
+| 重复点击 / 消息重放不重复建档；同 URL 可显式新建 | PR3（10 秒去重）+ PR4（同 messageId 重放） |
+| 未安装桌面程序时现有功能仍可用 | PR3（不建队列）+ PR5（队列满不阻塞）+ PR7（回归） |
+| 一次保存不等于已投递，默认阶段 saved | PR4 + PR7 |
+
+| #20 测试项 | PR |
+| --- | --- |
+| 离线入队 | PR3 |
+| 浏览器重启 | PR5 |
+| 应答丢失后重发 | PR5 |
+| 重复内容冲突 | PR6（`conflict`） |
+| 连接恢复 | PR5 + PR6 |
+| 队列满 | PR3（意图）+ PR5（绑定） |
+| 协议不兼容 | PR1（协商）+ PR3（文案） |
+| 恢复档案库后的旧队列 | PR6 |
+| 当前插件完整回归 | PR7 |
+
+## 明确不在 D07 范围
+
+- **快照字节与 IndexedDB 暂存**（D08 #22）。`snapshot.chunk` 在 D06 一律回 `unavailable`，D07 不发它。
+- **`fill.submit` 填写留档**（D08 #22）。D07 只搭出 outbox 机制，不接填写事件。
+- **生产环境的 host 注册与安装包**（D13 #29）。开发期用 `desktop/scripts/nm-dev-register.mjs`。
+- **桌面侧的配对界面**（D06 已做）。插件只显示自己的扩展 ID。
+- **备份恢复本身**（D12 #28）。D07 只处理恢复之后插件这一侧的对账。
+
+## 风险登记（downstream-decisions.md）
+
+| 编号 | 风险 | 本计划的处置 |
+| --- | --- | --- |
+| V2 | host 按需拉起应用 | PR1 的冷启动重试 + PR5 的退避；文案「请先打开一次桌面」 |
+| V3 | 改 host manifest 后能否不重启就连上 | PR3 配对成功后强制提示「重载扩展或重启浏览器」 |
+| V4 | MV3 SW 与 `connectNative` | 架构决策 1：直接用 `sendNativeMessage`，`transport.mjs` 留换实现的缝 |
+| V12 | 扩展源 IndexedDB 在 SW 重启后能否读回 | D07 不碰 IDB；风险留给 D08 |

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -1,0 +1,72 @@
+import { MAX_INTENTS } from './limits.mjs';
+
+// User-facing wording for every outcome of a save, in one table.
+//
+// The distinctions here are contractual, not stylistic. §9 requires that an uninstalled
+// desktop is never described as unpaired and vice versa, and that queued work is never
+// described as saved. Scattering these strings across the sidebar is how one of them
+// eventually says the wrong thing.
+const PAIRING_HINT = '粘贴后请重新加载扩展或重启浏览器，否则新的注册不会生效。';
+
+export function describeSaveResult(result) {
+  const { status, mode, reason, extensionId } = result ?? {};
+
+  if (status === 'queued') {
+    if (mode === 'incompatible') {
+      return {
+        tone: 'pending',
+        text: '已记为待同步（尚未绑定申请）。桌面程序的协议版本和插件对不上，升级之后才能同步。'
+      };
+    }
+    return {
+      tone: 'pending',
+      text: '已记为待同步（尚未绑定申请）。桌面程序可用之后再选择绑定到哪条申请。'
+    };
+  }
+
+  if (status === 'duplicate') {
+    return {
+      tone: 'warn',
+      offerForce: true,
+      text: result.recent
+        ? '刚刚已经存过这个岗位了，没有再存一份。'
+        : '这个岗位已经在待同步列表里了，没有再存一份。',
+      hint: '如果这是又投了一次，可以选择再存一次。'
+    };
+  }
+
+  if (status === 'rejected') {
+    if (reason === 'queue_full') {
+      return {
+        tone: 'warn',
+        text: `待同步队列已满（${MAX_INTENTS} 条），这次没有保存。请先处理已有的几条。填表功能不受影响。`
+      };
+    }
+    return { tone: 'warn', text: '公司和岗位不能为空，请补齐之后再保存。' };
+  }
+
+  if (status === 'not_queued') {
+    if (mode === 'not_installed') {
+      return {
+        tone: 'info',
+        text: '没有找到桌面程序，这次没有保存。装好之后再回来保存岗位；填表、模板和 AI 填写都不受影响。'
+      };
+    }
+    if (mode === 'not_paired') {
+      return {
+        tone: 'info',
+        extensionId,
+        text: '桌面程序在运行，但还没有配对这个插件，这次没有保存。到桌面程序的设置里粘贴下面的扩展 ID。',
+        hint: PAIRING_HINT
+      };
+    }
+    return {
+      tone: 'info',
+      extensionId,
+      text: '还没有和桌面程序配对过，这次没有保存。打开桌面程序，在设置里粘贴下面的扩展 ID。',
+      hint: PAIRING_HINT
+    };
+  }
+
+  return { tone: 'warn', text: '这次没能保存，请稍后再试。填表功能不受影响。' };
+}

--- a/link/errors.mjs
+++ b/link/errors.mjs
@@ -8,8 +8,3 @@ export class LinkError extends Error {
     this.code = code;
   }
 }
-
-// `unavailable` is the only code D05 marks retryable by default. Everything else needs a
-// deliberate decision, which is why the retry policy lives in one place instead of at each
-// call site.
-export const RETRYABLE_CODES = new Set(['unavailable']);

--- a/link/extract.mjs
+++ b/link/extract.mjs
@@ -1,0 +1,81 @@
+import { redactUrl } from './redact.mjs';
+
+/**
+ * Read the few fields a job page states about itself.
+ *
+ * Everything here is deterministic and comes from what the page declares. Nothing is
+ * inferred, guessed or sent to a model: #20 requires missing fields to be filled in by the
+ * user, not invented. A blank field is a correct answer.
+ *
+ * It runs once, when the user asks to save. It does not scan pages in the background, and
+ * it reads only the elements below — never the page body, never history.
+ */
+export function extractJobFields(doc, href) {
+  const posting = findJobPosting(doc);
+  const redacted = redactUrl(href);
+
+  return {
+    company: text(companyFrom(posting)),
+    title: text(posting?.title) || metaContent(doc, 'og:title') || text(doc.querySelector('h1')?.textContent) || text(doc.title),
+    location: text(localityFrom(posting)),
+    sourceUrl: redacted?.sourceUrl ?? '',
+    dedupeUrl: redacted?.dedupeUrl ?? ''
+  };
+}
+
+function findJobPosting(doc) {
+  let nodes;
+  try {
+    nodes = doc.querySelectorAll('script[type="application/ld+json"]');
+  } catch {
+    return null;
+  }
+  for (const node of nodes ?? []) {
+    let parsed;
+    try {
+      parsed = JSON.parse(node.textContent);
+    } catch {
+      // A page with malformed structured data is still a page the user wants to save.
+      continue;
+    }
+    const found = searchForPosting(parsed);
+    if (found) return found;
+  }
+  return null;
+}
+
+function searchForPosting(value, depth = 0) {
+  if (depth > 4 || !value || typeof value !== 'object') return null;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = searchForPosting(entry, depth + 1);
+      if (found) return found;
+    }
+    return null;
+  }
+  const type = value['@type'];
+  const types = Array.isArray(type) ? type : [type];
+  if (types.includes('JobPosting')) return value;
+  // Publishers commonly wrap several entities in @graph.
+  return searchForPosting(value['@graph'], depth + 1);
+}
+
+function companyFrom(posting) {
+  const org = posting?.hiringOrganization;
+  if (typeof org === 'string') return org;
+  return org?.name;
+}
+
+function localityFrom(posting) {
+  const location = Array.isArray(posting?.jobLocation) ? posting.jobLocation[0] : posting?.jobLocation;
+  return location?.address?.addressLocality ?? location?.address?.addressRegion;
+}
+
+function metaContent(doc, property) {
+  const node = doc.querySelector(`meta[property="${property}"]`);
+  return text(node?.getAttribute('content') ?? node?.content);
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/link/intents.mjs
+++ b/link/intents.mjs
@@ -1,0 +1,85 @@
+import { DEDUPE_WINDOW_MS, MAX_INTENTS } from './limits.mjs';
+import { normalizeTriple } from './normalize.mjs';
+
+// Modes in which a long-lived intent may exist at all. §5.2.3 is explicit that a profile
+// which never reached a paired desktop gets no queue: there would be nothing to drain it,
+// and the user would be told their job is "pending" forever.
+const MAY_QUEUE = new Set(['ready', 'unavailable', 'incompatible']);
+
+/**
+ * SaveIntent lifecycle.
+ *
+ * An intent records that the user confirmed these fields. It is deliberately not a message:
+ * no messageId, no application id, no epoch. Those exist only once the user has chosen what
+ * to bind to, against a desktop that answered.
+ */
+export function createIntents({ store, uuid, now }) {
+  async function save({ fields, mode, force = false }) {
+    if (!String(fields?.company ?? '').trim() || !String(fields?.title ?? '').trim()) {
+      // The company and the job title are the two things nothing else can supply. Refusing
+      // here is what keeps "do not fabricate" from turning into "save a blank record".
+      return { status: 'rejected', reason: 'missing_fields' };
+    }
+
+    if (!MAY_QUEUE.has(mode)) {
+      return { status: 'not_queued', reason: mode };
+    }
+
+    const triple = normalizeTriple(fields);
+    // Read outside the transaction only what does not depend on the queue: these two are
+    // stable for the life of the profile, and awaiting inside the callback is not possible.
+    const pairing = await store.getPairing();
+    const clientInstanceId = await store.clientInstanceId();
+
+    const intent = {
+      intentId: uuid(),
+      clientInstanceId,
+      fields: {
+        company: fields.company.trim(),
+        title: fields.title.trim(),
+        location: String(fields.location ?? '').trim(),
+        sourceUrl: String(fields.sourceUrl ?? ''),
+        dedupeUrl: String(fields.dedupeUrl ?? '')
+      },
+      triple,
+      createdAt: now().toISOString(),
+      // A hint for the sidebar only. The epoch is deliberately not copied: an epoch on an
+      // intent reads as a stamp, and an intent has never been stamped.
+      lastSeenArchiveId: pairing?.archiveId ?? null,
+      status: mode === 'ready' ? 'pending_bind' : 'pending_desktop'
+    };
+
+    // Deciding and appending happen in one queued step. As separate steps, two sidebar
+    // clicks handled in the same worker turn both read a queue without their posting in it,
+    // both conclude they are new, and the duplicate guard is defeated by timing alone.
+    let outcome;
+    await store.updateIntents(list => {
+      if (!force) {
+        const duplicate = list.find(item => item.triple === triple && isPending(item));
+        if (duplicate) {
+          const age = now().getTime() - Date.parse(duplicate.createdAt);
+          outcome = { status: 'duplicate', intent: duplicate, recent: age <= DEDUPE_WINDOW_MS };
+          return list;
+        }
+      }
+      if (list.length >= MAX_INTENTS) {
+        outcome = { status: 'rejected', reason: 'queue_full' };
+        return list;
+      }
+      outcome = { status: 'queued', intent };
+      return [...list, intent];
+    });
+
+    return outcome;
+  }
+
+  return {
+    save,
+    list: () => store.getIntents(),
+    remove: intentId => store.updateIntents(list => list.filter(item => item.intentId !== intentId))
+  };
+}
+
+function isPending(intent) {
+  return intent.status === 'pending_desktop' || intent.status === 'pending_bind';
+}

--- a/link/limits.mjs
+++ b/link/limits.mjs
@@ -1,0 +1,22 @@
+// Product limits, in one place so the UI copy and the queue agree on the numbers.
+
+// D01 §5.2.4 suggests 100 of each and requires the number to be stated rather than implied.
+// A full queue refuses new work and says so; it never drops the oldest entry, because the
+// user was already told that entry is pending.
+export const MAX_INTENTS = 100;
+export const MAX_OUTBOX = 100;
+
+// A same-posting save inside this window is a double click rather than a decision, so the
+// wording says "just saved" instead of "already pending". Either way it is refused as a
+// duplicate: a pending intent for the same posting always requires an explicit "save again",
+// no matter how old it is. Letting the guard expire would hand the user two applications for
+// one posting through nothing but delay.
+export const DEDUPE_WINDOW_MS = 10_000;
+
+// Retry backoff for bound messages. Capped: after the last step the entry waits for the user
+// rather than retrying forever.
+export const BACKOFF_STEPS_MS = [1_000, 5_000, 30_000, 120_000, 600_000, 1_800_000];
+
+// chrome.alarms will not fire faster than this, so anything shorter runs in the worker while
+// it is still alive and falls back to an alarm once it is not.
+export const MIN_ALARM_DELAY_MS = 30_000;

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -1,0 +1,10 @@
+// The names the sidebar and the service worker use to talk to each other. Content scripts
+// cannot open a native messaging port, so every desktop operation crosses this boundary.
+export const MSG = {
+  probe: 'DESKTOP_PROBE',
+  saveJob: 'DESKTOP_SAVE_JOB',
+  listQueue: 'DESKTOP_LIST_QUEUE',
+  removeIntent: 'DESKTOP_REMOVE_INTENT'
+};
+
+export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -1,0 +1,48 @@
+import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
+
+/**
+ * Turns sidebar messages into desktop-link operations.
+ *
+ * Returns null for anything it does not own, so the existing service worker listeners keep
+ * working unchanged.
+ *
+ * Replies carry a status and a mode, never finished user-facing text. "Pending sync" and
+ * "saved on the desktop" are different claims, and the difference has to survive the trip to
+ * the sidebar rather than being decided by whoever formats the string.
+ */
+export function createRouter({ session, intents, extensionId }) {
+  async function handle(message) {
+    const type = message?.type;
+    if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
+
+    if (type === MSG.probe) {
+      const probe = await session.probe();
+      return { mode: probe.mode, extensionId };
+    }
+
+    if (type === MSG.saveJob) {
+      // The mode is probed at save time, not cached: the desktop may have been opened or
+      // closed since the sidebar was drawn.
+      const probe = await session.probe();
+      const result = await intents.save({
+        fields: message.fields,
+        mode: probe.mode,
+        force: Boolean(message.force)
+      });
+      return { ...result, mode: probe.mode, extensionId };
+    }
+
+    if (type === MSG.listQueue) {
+      return { intents: await intents.list() };
+    }
+
+    if (type === MSG.removeIntent) {
+      await intents.remove(message.intentId);
+      return { ok: true };
+    }
+
+    return null;
+  }
+
+  return { handle };
+}

--- a/link/session.mjs
+++ b/link/session.mjs
@@ -17,8 +17,6 @@ export const PLUGIN_VERSION = '0.3.0';
  *   never_paired  no successful handshake was ever recorded; no long-lived queue is created
  */
 export function createSession({ store, sendNative, sleep, uuid, now }) {
-  let identity = null;
-
   async function probe() {
     const message = await buildEnvelope({
       messageType: 'handshake',
@@ -42,7 +40,7 @@ export function createSession({ store, sendNative, sleep, uuid, now }) {
         identity = null;
         return { mode: 'incompatible', identity: null };
       }
-      identity = { archiveId: payload.archiveId, restoreEpoch: payload.restoreEpoch };
+      const identity = { archiveId: payload.archiveId, restoreEpoch: payload.restoreEpoch };
       await store.setPairing({
         archiveId: payload.archiveId,
         restoreEpoch: payload.restoreEpoch,
@@ -51,8 +49,6 @@ export function createSession({ store, sendNative, sleep, uuid, now }) {
       });
       return { mode: 'ready', identity, capabilities: payload.capabilities };
     }
-
-    identity = null;
 
     if (result.status === 'not_paired') return { mode: 'not_paired', identity: null };
     if (result.status === 'fatal' && result.code === 'protocol_incompatible') {
@@ -75,12 +71,7 @@ export function createSession({ store, sendNative, sleep, uuid, now }) {
     return { mode: 'never_paired', identity: null, code: result.code };
   }
 
-  return {
-    probe,
-    // The identity of the last successful handshake in this worker lifetime. Null until one
-    // succeeds; a stored pairing record never fills it in.
-    currentIdentity: () => identity
-  };
+  return { probe };
 }
 
 function versionsIntersect(min, max) {

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -1,0 +1,46 @@
+import { nativeSender, sleep, storageAdapter } from './chrome.mjs';
+import { createStore } from './store.mjs';
+import { createSession } from './session.mjs';
+import { createIntents } from './intents.mjs';
+import { createRouter } from './router.mjs';
+import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
+
+/**
+ * Compose the desktop link and hang it off the service worker's message port.
+ *
+ * Registered as its own listener rather than folded into the existing one: the AI host and
+ * the manager toggle are unrelated, and a shared listener that returns the wrong value for
+ * one of them breaks the other.
+ */
+export function installDesktopLink(api) {
+  const store = createStore({
+    storage: storageAdapter(api),
+    uuid: () => crypto.randomUUID()
+  });
+
+  const deps = {
+    store,
+    sendNative: nativeSender(api),
+    sleep,
+    uuid: () => crypto.randomUUID(),
+    now: () => new Date()
+  };
+
+  const router = createRouter({
+    session: createSession(deps),
+    intents: createIntents(deps),
+    extensionId: api.runtime.id
+  });
+
+  api.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (!DESKTOP_MESSAGE_TYPES.has(message?.type)) return false;
+    router.handle(message).then(sendResponse).catch(error => {
+      // The sidebar is waiting on this port. An unhandled rejection here leaves the user
+      // looking at a spinner with no way to find out what happened.
+      sendResponse({ error: true, code: error?.code ?? 'unavailable', message: error?.message });
+    });
+    return true;
+  });
+
+  return router;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,8 @@
   "web_accessible_resources": [
     {
       "resources": [
+        "link/*.mjs",
+        "link/protocol/*.mjs",
         "popup.html",
         "popup.css",
         "popup.js",

--- a/tests/ai-host.test.js
+++ b/tests/ai-host.test.js
@@ -4,6 +4,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 const source = file => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+// background.js is an ES module since the desktop link landed, and vm.runInContext only
+// takes a classic script. The import is replaced with a stub so these tests keep exercising
+// the offscreen AI host, which is what they are about.
+const asClassicScript = text => text.replace(
+  /^import \{ installDesktopLink \} from "\.\/link\/worker\.mjs";$/m,
+  'const installDesktopLink = () => {};'
+);
 
 test('service worker only creates one concurrent offscreen worker host and never fetches AI', async () => {
   let complete, creates = 0;
@@ -12,7 +19,7 @@ test('service worker only creates one concurrent offscreen worker host and never
     runtime: { getURL: name => `chrome-extension://test/${name}`, getContexts: async () => [], onMessage: { addListener() {} } },
     offscreen: { createDocument: options => { creates++; assert.equal(options.reasons[0], 'WORKERS'); return new Promise(resolve => { complete = resolve; }); } }
   } });
-  vm.runInContext(source('background.js'), context);
+  vm.runInContext(asClassicScript(source('background.js')), context);
   const a = context.ensureAiHost(), b = context.ensureAiHost();
   await new Promise(resolve => setImmediate(resolve));
   assert.equal(creates, 1);

--- a/tests/link-copy.test.js
+++ b/tests/link-copy.test.js
@@ -1,0 +1,113 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../link/copy.mjs');
+const ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+test('a queued intent is described as pending, never as saved', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'queued', mode: 'unavailable', intent: { status: 'pending_desktop' } });
+
+  assert.match(copy.text, /待同步/);
+  assert.equal(copy.text.includes('已保存'), false);
+  assert.equal(copy.tone, 'pending');
+});
+
+test('an uninstalled desktop is not described as unpaired', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'not_queued', mode: 'not_installed', extensionId: ID });
+
+  assert.match(copy.text, /桌面程序/);
+  assert.equal(copy.text.includes('配对'), false);
+  assert.equal(copy.text.includes(ID), false, 'there is nowhere to paste an id yet');
+});
+
+test('an unpaired desktop is not described as missing, and shows the id to paste', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'not_queued', mode: 'not_paired', extensionId: ID });
+
+  assert.match(copy.text, /配对/);
+  assert.equal(copy.text.includes('未安装'), false);
+  assert.equal(copy.extensionId, ID);
+});
+
+test('a profile that never paired is told where to paste the id', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'not_queued', mode: 'never_paired', extensionId: ID });
+
+  assert.equal(copy.extensionId, ID);
+  assert.match(copy.text, /扩展 ID/);
+});
+
+test('pairing instructions say the extension has to be reloaded afterwards', async () => {
+  const { describeSaveResult } = await load();
+  // Risk V3: a manifest written after the browser started is not picked up until the
+  // extension is reloaded, and the user is otherwise left pairing over and over.
+  const copy = describeSaveResult({ status: 'not_queued', mode: 'never_paired', extensionId: ID });
+
+  assert.match(copy.hint, /重新加载|重启/);
+});
+
+test('an incompatible desktop keeps the intent and asks for an upgrade', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'queued', mode: 'incompatible', intent: { status: 'pending_desktop' } });
+
+  assert.match(copy.text, /升级/);
+  assert.match(copy.text, /待同步/);
+});
+
+test('a duplicate offers saving again rather than silently doing nothing', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'duplicate', recent: true, mode: 'unavailable' });
+
+  assert.equal(copy.offerForce, true);
+  assert.match(copy.text, /已经/);
+});
+
+test('a full queue says how full and promises filling still works', async () => {
+  const { describeSaveResult } = await load();
+  const { MAX_INTENTS } = await import('../link/limits.mjs');
+
+  const copy = describeSaveResult({ status: 'rejected', reason: 'queue_full', mode: 'unavailable' });
+
+  assert.match(copy.text, new RegExp(String(MAX_INTENTS)));
+  assert.match(copy.text, /填表/);
+});
+
+test('missing fields are named rather than blamed on the desktop', async () => {
+  const { describeSaveResult } = await load();
+
+  const copy = describeSaveResult({ status: 'rejected', reason: 'missing_fields', mode: 'ready' });
+
+  assert.match(copy.text, /公司/);
+  assert.match(copy.text, /岗位/);
+});
+
+test('no copy in the whole table claims a desktop save', async () => {
+  const { describeSaveResult } = await load();
+  const cases = [
+    { status: 'queued', mode: 'unavailable', intent: { status: 'pending_desktop' } },
+    { status: 'queued', mode: 'incompatible', intent: { status: 'pending_desktop' } },
+    { status: 'queued', mode: 'ready', intent: { status: 'pending_bind' } },
+    { status: 'not_queued', mode: 'not_installed' },
+    { status: 'not_queued', mode: 'not_paired' },
+    { status: 'not_queued', mode: 'never_paired' },
+    { status: 'duplicate', mode: 'unavailable' },
+    { status: 'rejected', reason: 'queue_full', mode: 'unavailable' },
+    { status: 'rejected', reason: 'missing_fields', mode: 'ready' },
+    { status: 'error', mode: 'unavailable' }
+  ];
+
+  for (const input of cases) {
+    const copy = describeSaveResult({ ...input, extensionId: ID });
+    assert.equal(typeof copy.text, 'string');
+    assert.notEqual(copy.text, '');
+    assert.equal(copy.text.includes('桌面已保存'), false, JSON.stringify(input));
+  }
+});

--- a/tests/link-extract.test.js
+++ b/tests/link-extract.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../link/extract.mjs');
+
+// A minimal stand-in for the four things extraction reads from a page.
+function fakeDoc({ jsonLd = [], meta = {}, h1 = null, title = '' } = {}) {
+  return {
+    title,
+    querySelectorAll(selector) {
+      if (selector.includes('ld+json')) {
+        return jsonLd.map(entry => ({ textContent: typeof entry === 'string' ? entry : JSON.stringify(entry) }));
+      }
+      return [];
+    },
+    querySelector(selector) {
+      const property = selector.match(/property="([^"]+)"/)?.[1];
+      if (property) return property in meta ? { getAttribute: () => meta[property] } : null;
+      if (selector === 'h1') return h1 === null ? null : { textContent: h1 };
+      return null;
+    }
+  };
+}
+
+test('a JobPosting fills company, title and location', async () => {
+  const { extractJobFields } = await load();
+  const doc = fakeDoc({
+    jsonLd: [{
+      '@type': 'JobPosting',
+      title: '后端开发工程师',
+      hiringOrganization: { '@type': 'Organization', name: '星河科技' },
+      jobLocation: { address: { addressLocality: '上海' } }
+    }]
+  });
+
+  const fields = extractJobFields(doc, 'https://jobs.example.com/apply');
+
+  assert.equal(fields.company, '星河科技');
+  assert.equal(fields.title, '后端开发工程师');
+  assert.equal(fields.location, '上海');
+});
+
+test('a page with only a document title leaves the company blank', async () => {
+  const { extractJobFields } = await load();
+  // og:site_name is the job board, not the employer. Filling the company with it would be
+  // the fabrication #20 forbids — and the user would confirm it without noticing.
+  const doc = fakeDoc({ title: '后端开发工程师 - 招聘', meta: { 'og:site_name': '示例招聘网' } });
+
+  const fields = extractJobFields(doc, 'https://jobs.example.com/apply');
+
+  assert.equal(fields.company, '');
+  assert.equal(fields.title, '后端开发工程师 - 招聘');
+});
+
+test('og:title is preferred over the document title', async () => {
+  const { extractJobFields } = await load();
+  const doc = fakeDoc({ title: '后端开发 - 示例招聘网 - 第 1 页', meta: { 'og:title': '后端开发工程师' } });
+
+  assert.equal(extractJobFields(doc, 'https://jobs.example.com/a').title, '后端开发工程师');
+});
+
+test('a heading is used when there is no structured data at all', async () => {
+  const { extractJobFields } = await load();
+
+  const fields = extractJobFields(fakeDoc({ h1: '  测试开发工程师  ' }), 'https://jobs.example.com/a');
+
+  assert.equal(fields.title, '测试开发工程师');
+});
+
+test('the URL arrives already redacted', async () => {
+  const { extractJobFields } = await load();
+
+  const fields = extractJobFields(fakeDoc({}), 'https://jobs.example.com/apply?access_token=abc&job=42');
+
+  assert.equal(fields.sourceUrl, 'https://jobs.example.com/apply?job=42');
+  assert.equal(fields.dedupeUrl, 'https://jobs.example.com/apply?job=42');
+});
+
+test('an http page contributes no URL and no error', async () => {
+  const { extractJobFields } = await load();
+
+  const fields = extractJobFields(fakeDoc({ title: '后端开发' }), 'http://jobs.example.com/apply');
+
+  assert.equal(fields.sourceUrl, '');
+  assert.equal(fields.title, '后端开发');
+});
+
+test('broken structured data does not break extraction', async () => {
+  const { extractJobFields } = await load();
+  const doc = fakeDoc({ jsonLd: ['{ not json at all'], title: '后端开发' });
+
+  const fields = extractJobFields(doc, 'https://jobs.example.com/a');
+
+  assert.equal(fields.title, '后端开发');
+  assert.equal(fields.company, '');
+});
+
+test('a JobPosting nested in an @graph is still found', async () => {
+  const { extractJobFields } = await load();
+  const doc = fakeDoc({
+    jsonLd: [{ '@graph': [{ '@type': 'WebPage' }, { '@type': 'JobPosting', title: '数据分析', hiringOrganization: { name: '星河科技' } }] }]
+  });
+
+  const fields = extractJobFields(doc, 'https://jobs.example.com/a');
+
+  assert.equal(fields.company, '星河科技');
+  assert.equal(fields.title, '数据分析');
+});
+
+test('a hiring organisation given as a bare string is read', async () => {
+  const { extractJobFields } = await load();
+  const doc = fakeDoc({ jsonLd: [{ '@type': 'JobPosting', title: '后端', hiringOrganization: '星河科技' }] });
+
+  assert.equal(extractJobFields(doc, 'https://jobs.example.com/a').company, '星河科技');
+});
+
+test('extraction reads nothing beyond the four fields it reports', async () => {
+  const { extractJobFields } = await load();
+  const seen = [];
+  const doc = fakeDoc({ title: '后端开发' });
+  const watched = {
+    ...doc,
+    get body() { seen.push('body'); return null; },
+    querySelectorAll(selector) { seen.push(selector); return doc.querySelectorAll(selector); },
+    querySelector(selector) { seen.push(selector); return doc.querySelector(selector); }
+  };
+
+  extractJobFields(watched, 'https://jobs.example.com/a');
+
+  // #20: no page HTML, no browsing history, nothing the user did not ask to save.
+  assert.equal(seen.includes('body'), false);
+  assert.ok(seen.every(selector => /ld\+json|og:|^h1$/.test(selector)), seen.join(', '));
+});

--- a/tests/link-intents.test.js
+++ b/tests/link-intents.test.js
@@ -1,0 +1,231 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+const FIELDS = {
+  company: '星河科技',
+  title: '后端开发',
+  location: '上海',
+  sourceUrl: 'https://jobs.example.com/apply',
+  dedupeUrl: 'https://jobs.example.com/apply'
+};
+
+async function makeIntents({ storage = fakeStorage(), clock = { value: 1000 } } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  let minted = 0;
+  const store = createStore({ storage, uuid: () => 'client-1' });
+  const intents = createIntents({
+    store,
+    uuid: () => `intent-${++minted}`,
+    now: () => new Date(clock.value)
+  });
+  return { intents, store, storage, clock };
+}
+
+test('a save while the desktop is closed is queued as a pending intent', async () => {
+  const { intents, storage } = await makeIntents();
+
+  const result = await intents.save({ fields: FIELDS, mode: 'unavailable' });
+
+  assert.equal(result.status, 'queued');
+  assert.equal(result.intent.status, 'pending_desktop');
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+});
+
+test('a queued intent has no message id, application id or epoch', async () => {
+  const { intents } = await makeIntents();
+
+  const { intent } = await intents.save({ fields: FIELDS, mode: 'unavailable' });
+
+  // §8.10 freezes this: an intent is not a message. Any of these fields would mean the
+  // plugin had already committed to an archive it never spoke to.
+  assert.equal('messageId' in intent, false);
+  assert.equal('applicationId' in intent, false);
+  assert.equal('restoreEpoch' in intent, false);
+  assert.equal('sourceRestoreEpoch' in intent, false);
+});
+
+test('a profile that never paired queues nothing', async () => {
+  const { intents, storage } = await makeIntents();
+
+  const result = await intents.save({ fields: FIELDS, mode: 'never_paired' });
+
+  assert.equal(result.status, 'not_queued');
+  assert.equal(result.reason, 'never_paired');
+  assert.equal('desktopSaveIntents' in storage.data, false);
+});
+
+test('an extension with no host registration queues nothing', async () => {
+  const { intents, storage } = await makeIntents();
+
+  const result = await intents.save({ fields: FIELDS, mode: 'not_installed' });
+
+  assert.equal(result.status, 'not_queued');
+  assert.equal('desktopSaveIntents' in storage.data, false);
+});
+
+test('an installed but unpaired desktop queues nothing and says so', async () => {
+  const { intents, storage } = await makeIntents();
+
+  const result = await intents.save({ fields: FIELDS, mode: 'not_paired' });
+
+  assert.equal(result.status, 'not_queued');
+  assert.equal(result.reason, 'not_paired');
+  assert.equal('desktopSaveIntents' in storage.data, false);
+});
+
+test('an incompatible desktop still keeps the intent', async () => {
+  const { intents } = await makeIntents();
+  // §5.2.3: the intent is kept and the user is asked to upgrade. It is simply never promoted
+  // into a bound message.
+  const result = await intents.save({ fields: FIELDS, mode: 'incompatible' });
+
+  assert.equal(result.status, 'queued');
+  assert.equal(result.intent.status, 'pending_desktop');
+});
+
+test('a reachable desktop queues the intent ready for binding', async () => {
+  const { intents } = await makeIntents();
+
+  const result = await intents.save({ fields: FIELDS, mode: 'ready' });
+
+  assert.equal(result.status, 'queued');
+  assert.equal(result.intent.status, 'pending_bind');
+});
+
+test('a second click on the same posting does not queue a second intent', async () => {
+  const { intents, storage } = await makeIntents();
+
+  await intents.save({ fields: FIELDS, mode: 'unavailable' });
+  const second = await intents.save({ fields: FIELDS, mode: 'unavailable' });
+
+  assert.equal(second.status, 'duplicate');
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+});
+
+test('a differently spelled company is still the same posting', async () => {
+  const { intents, storage } = await makeIntents();
+
+  await intents.save({ fields: FIELDS, mode: 'unavailable' });
+  const second = await intents.save({
+    fields: { ...FIELDS, company: '星河科技有限公司', title: ' 后端开发 ' },
+    mode: 'unavailable'
+  });
+
+  assert.equal(second.status, 'duplicate');
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+});
+
+test('the user can deliberately save the same posting again', async () => {
+  const { intents, storage } = await makeIntents();
+  // Walkthrough 10.4: applying to the same posting a second time is two applications when
+  // the user says so.
+  await intents.save({ fields: FIELDS, mode: 'unavailable' });
+  const again = await intents.save({ fields: FIELDS, mode: 'unavailable', force: true });
+
+  assert.equal(again.status, 'queued');
+  assert.equal(storage.data.desktopSaveIntents.length, 2);
+  assert.notEqual(storage.data.desktopSaveIntents[0].intentId, storage.data.desktopSaveIntents[1].intentId);
+});
+
+test('a different posting at the same company queues separately', async () => {
+  const { intents, storage } = await makeIntents();
+
+  await intents.save({ fields: FIELDS, mode: 'unavailable' });
+  const other = await intents.save({ fields: { ...FIELDS, title: '测试开发' }, mode: 'unavailable' });
+
+  assert.equal(other.status, 'queued');
+  assert.equal(storage.data.desktopSaveIntents.length, 2);
+});
+
+test('a full queue refuses new work instead of dropping old work', async () => {
+  const { intents, storage } = await makeIntents();
+  const { MAX_INTENTS } = await import('../link/limits.mjs');
+
+  for (let i = 0; i < MAX_INTENTS; i += 1) {
+    await intents.save({ fields: { ...FIELDS, title: `岗位 ${i}` }, mode: 'unavailable' });
+  }
+  const overflow = await intents.save({ fields: { ...FIELDS, title: '再来一个' }, mode: 'unavailable' });
+
+  assert.equal(overflow.status, 'rejected');
+  assert.equal(overflow.reason, 'queue_full');
+  assert.equal(storage.data.desktopSaveIntents.length, MAX_INTENTS);
+  assert.equal(storage.data.desktopSaveIntents[0].fields.title, '岗位 0', 'the oldest intent is still there');
+});
+
+test('a save with no company or no title is refused before it reaches the queue', async () => {
+  const { intents } = await makeIntents();
+
+  const noCompany = await intents.save({ fields: { ...FIELDS, company: '  ' }, mode: 'unavailable' });
+  const noTitle = await intents.save({ fields: { ...FIELDS, title: '' }, mode: 'unavailable' });
+
+  assert.equal(noCompany.status, 'rejected');
+  assert.equal(noCompany.reason, 'missing_fields');
+  assert.equal(noTitle.status, 'rejected');
+});
+
+test('deleting an intent removes exactly that one', async () => {
+  const { intents, storage } = await makeIntents();
+  const first = await intents.save({ fields: FIELDS, mode: 'unavailable' });
+  await intents.save({ fields: { ...FIELDS, title: '测试开发' }, mode: 'unavailable' });
+
+  await intents.remove(first.intent.intentId);
+
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+  assert.equal(storage.data.desktopSaveIntents[0].fields.title, '测试开发');
+});
+
+test('the last successful handshake is recorded on the intent as a hint only', async () => {
+  const storage = fakeStorage({ desktopPairing: { archiveId: 'aaaa', restoreEpoch: 'bbbb', at: 1 } });
+  const { intents } = await makeIntents({ storage });
+
+  const { intent } = await intents.save({ fields: FIELDS, mode: 'unavailable' });
+
+  assert.equal(intent.lastSeenArchiveId, 'aaaa');
+  assert.equal('lastSeenRestoreEpoch' in intent, false, 'an epoch on an intent would read as a stamp');
+});
+
+test('two clicks handled at the same time still produce one intent', async () => {
+  const { intents, storage } = await makeIntents();
+  // The service worker handles sidebar messages concurrently. Reading the queue, deciding it
+  // holds no duplicate and appending have to be one step: as three separate steps both saves
+  // read an empty queue, both decide they are new, and #20's "重复点击不重复建档" is broken by
+  // nothing more than timing.
+  const [first, second] = await Promise.all([
+    intents.save({ fields: FIELDS, mode: 'unavailable' }),
+    intents.save({ fields: FIELDS, mode: 'unavailable' })
+  ]);
+
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+  assert.deepEqual([first.status, second.status].sort(), ['duplicate', 'queued']);
+});
+
+test('a race cannot push the queue past its limit', async () => {
+  const { intents, storage } = await makeIntents();
+  const { MAX_INTENTS } = await import('../link/limits.mjs');
+  for (let i = 0; i < MAX_INTENTS - 1; i += 1) {
+    await intents.save({ fields: { ...FIELDS, title: `岗位 ${i}` }, mode: 'unavailable' });
+  }
+
+  const results = await Promise.all([
+    intents.save({ fields: { ...FIELDS, title: 'A' }, mode: 'unavailable' }),
+    intents.save({ fields: { ...FIELDS, title: 'B' }, mode: 'unavailable' }),
+    intents.save({ fields: { ...FIELDS, title: 'C' }, mode: 'unavailable' })
+  ]);
+
+  assert.equal(storage.data.desktopSaveIntents.length, MAX_INTENTS);
+  assert.equal(results.filter(result => result.status === 'rejected').length, 2);
+});

--- a/tests/link-manifest.test.js
+++ b/tests/link-manifest.test.js
@@ -36,6 +36,30 @@ test('the offscreen AI host is still created on demand', async () => {
   assert.match(source, /ai-host\.html/);
 });
 
+test('the service worker installs the desktop link', async () => {
+  const source = background();
+  assert.match(source, /import \{ installDesktopLink \} from ['"]\.\/link\/worker\.mjs['"]/);
+  assert.match(source, /installDesktopLink\(chrome\)/);
+});
+
+test('the sidebar can import the extraction and copy modules', async () => {
+  // A content script reaches them through chrome.runtime.getURL, which only resolves for
+  // web-accessible resources. Without this the save button fails with an opaque import
+  // error at the moment the user clicks it.
+  const resources = manifest().web_accessible_resources[0].resources;
+  assert.ok(resources.includes('link/*.mjs'));
+  assert.ok(resources.includes('link/protocol/*.mjs'));
+});
+
+test('the sidebar offers saving a job and never formats desktop copy itself', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  assert.match(source, /resume-pro-save-job/);
+  assert.match(source, /DESKTOP_SAVE_JOB/);
+  // The wording table lives in link/copy.mjs so the §9 distinctions stay testable.
+  assert.match(source, /describeSaveResult/);
+  assert.equal(source.includes('桌面已保存'), false);
+});
+
 test('the desktop link ships every file it imports', async () => {
   const files = [
     'link/protocol/validate.mjs',

--- a/tests/link-router.test.js
+++ b/tests/link-router.test.js
@@ -1,0 +1,139 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+const FIELDS = {
+  company: '星河科技',
+  title: '后端开发',
+  location: '上海',
+  sourceUrl: 'https://jobs.example.com/apply',
+  dedupeUrl: 'https://jobs.example.com/apply'
+};
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+function handshakeReply(message) {
+  return {
+    response: {
+      protocolVersion: 1,
+      correlationId: message.messageId,
+      ok: true,
+      payload: {
+        appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1,
+        archiveId: ARCHIVE, restoreEpoch: EPOCH, capabilities: ['handshake', 'job.save']
+      }
+    }
+  };
+}
+
+async function makeRouter({ reply = () => ({ lastError: 'Error when communicating with the native messaging host.' }), storage = fakeStorage() } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createRouter } = await import('../link/router.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date('2026-09-09T00:00:00.000Z');
+  const store = createStore({ storage, uuid });
+  const session = createSession({ store, sendNative: async (host, message) => reply(message), sleep: async () => {}, uuid, now });
+  const intents = createIntents({ store, uuid, now });
+  const router = createRouter({ session, intents, extensionId: 'abcdefghijklmnopabcdefghijklmnop' });
+  return { router, storage };
+}
+
+test('an unknown message is left for the other listeners', async () => {
+  const { router } = await makeRouter();
+
+  assert.equal(await router.handle({ type: 'ENSURE_AI_HOST' }), null);
+  assert.equal(await router.handle({}), null);
+  assert.equal(await router.handle(undefined), null);
+});
+
+test('saving while the desktop is closed answers pending, never saved', async () => {
+  const { router } = await makeRouter({
+    storage: fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } })
+  });
+
+  const result = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  assert.equal(result.status, 'queued');
+  assert.equal(result.mode, 'unavailable');
+  // The one thing this reply must never be able to say.
+  assert.equal(JSON.stringify(result).includes('saved'), false);
+});
+
+test('saving with no desktop ever paired reports the pairing instructions with the extension id', async () => {
+  const { router, storage } = await makeRouter();
+
+  const result = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  assert.equal(result.status, 'not_queued');
+  assert.equal(result.mode, 'never_paired');
+  assert.equal(result.extensionId, 'abcdefghijklmnopabcdefghijklmnop');
+  assert.equal('desktopSaveIntents' in storage.data, false);
+});
+
+test('an unpaired but installed desktop is reported as unpaired, with the id to paste', async () => {
+  const { router } = await makeRouter({
+    reply: message => ({
+      response: {
+        protocolVersion: 1, correlationId: message.messageId, ok: false,
+        error: { code: 'identity_not_allowed', retryable: false, message: 'origin is not paired' },
+        payload: {}
+      }
+    })
+  });
+
+  const result = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  assert.equal(result.mode, 'not_paired');
+  assert.equal(result.extensionId, 'abcdefghijklmnopabcdefghijklmnop');
+});
+
+test('the queue can be listed and one entry removed', async () => {
+  const { router } = await makeRouter({
+    storage: fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } })
+  });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  const listed = await router.handle({ type: 'DESKTOP_LIST_QUEUE' });
+  assert.equal(listed.intents.length, 1);
+
+  await router.handle({ type: 'DESKTOP_REMOVE_INTENT', intentId: saved.intent.intentId });
+  assert.equal((await router.handle({ type: 'DESKTOP_LIST_QUEUE' })).intents.length, 0);
+});
+
+test('a duplicate save is reported as such rather than silently ignored', async () => {
+  const { router } = await makeRouter({
+    storage: fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } })
+  });
+
+  await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+  const again = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  assert.equal(again.status, 'duplicate');
+  assert.equal(again.recent, true);
+});
+
+test('a probe reports the mode without saving anything', async () => {
+  const { router, storage } = await makeRouter({ reply: handshakeReply });
+
+  const result = await router.handle({ type: 'DESKTOP_PROBE' });
+
+  assert.equal(result.mode, 'ready');
+  assert.equal('desktopSaveIntents' in storage.data, false);
+});

--- a/tests/link-worker.test.js
+++ b/tests/link-worker.test.js
@@ -1,0 +1,83 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// A fake chrome with the pieces installDesktopLink touches, plus a way to invoke the
+// listener it registered the way the browser would.
+function fakeChrome({ nativeError = 'Specified native messaging host not found.' } = {}) {
+  const listeners = [];
+  return {
+    listeners,
+    runtime: {
+      id: 'abcdefghijklmnopabcdefghijklmnop',
+      lastError: undefined,
+      onMessage: { addListener: fn => listeners.push(fn) },
+      sendNativeMessage(hostName, message, callback) {
+        this.lastError = { message: nativeError };
+        callback(undefined);
+        this.lastError = undefined;
+      }
+    },
+    storage: {
+      local: {
+        _data: {},
+        async get(keys) {
+          const out = {};
+          for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in this._data) out[name] = this._data[name];
+          return out;
+        },
+        async set(values) { Object.assign(this._data, values); }
+      }
+    },
+    // Invoke the registered listener the way the browser does and resolve what it answered.
+    dispatch(message) {
+      return new Promise(resolve => {
+        const kept = listeners.map(fn => fn(message, {}, resolve));
+        if (!kept.some(Boolean)) resolve(undefined);
+      });
+    }
+  };
+}
+
+test('the desktop listener answers a probe', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  installDesktopLink(api);
+
+  const result = await api.dispatch({ type: 'DESKTOP_PROBE' });
+
+  assert.equal(result.mode, 'not_installed');
+  assert.equal(result.extensionId, 'abcdefghijklmnopabcdefghijklmnop');
+});
+
+test('the desktop listener keeps the message channel open for its async answer', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  installDesktopLink(api);
+
+  // Returning anything but true here closes the port before the handshake resolves, and the
+  // sidebar silently receives undefined.
+  assert.equal(api.listeners[0]({ type: 'DESKTOP_PROBE' }, {}, () => {}), true);
+});
+
+test('the desktop listener does not answer messages it does not own', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  installDesktopLink(api);
+
+  // ENSURE_AI_HOST and TOGGLE_MANAGER belong to the existing worker. Claiming them here
+  // would break the offscreen AI host.
+  assert.equal(api.listeners[0]({ type: 'ENSURE_AI_HOST' }, {}, () => {}), false);
+  assert.equal(api.listeners[0]({ type: 'TOGGLE_MANAGER' }, {}, () => {}), false);
+});
+
+test('a failure inside the desktop link answers an error instead of hanging the sidebar', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  api.storage.local.get = async () => { throw new Error('storage is unavailable'); };
+  installDesktopLink(api);
+
+  const result = await api.dispatch({ type: 'DESKTOP_PROBE' });
+
+  assert.equal(result.error, true);
+  assert.equal(typeof result.code, 'string');
+});


### PR DESCRIPTION
D07 第三部分：侧边栏多出「保存岗位到本地」。读页面自己声明的字段 → 给用户确认 → 曾经配对过就落成 SaveIntent。**这一步不发送任何东西**，绑定和 `job.save` 在下一个 PR。

依赖 #45、#46（均已合入）。

## 抽取故意很薄

只有 JSON-LD `JobPosting` 能提供公司名。`og:site_name` 是招聘网站，不是雇主，拿它填公司就是 #20 明令禁止的捏造——而且用户会毫无察觉地点确认。**抽不到就留空，表单会明说「这个页面没有声明公司名，插件不会替你猜」。**

只在用户点保存之后跑一次，不在页面加载时后台扫描；不存整页 HTML、不存浏览历史。

## 模式决定队列存不存在

从未配对过的 profile **不建意图**——没有任何东西能把它排空，用户会永远看到「待同步」。「未安装」和「未配对」两个方向都不许说错（§9）。

## 并发下的去重

**判断和追加在同一个队列步骤里完成。** Service worker 并发处理侧边栏消息，拆成两步的话两次点击都会读到一个还没有自己那条的队列、都认为自己是新的，#20 的「重复点击不重复建档」就被时序本身击穿了。

复现过，然后修的：

```
statuses: queued queued
intents stored: 2 (expected 1)
```

两个回归测试盯着它:`two clicks handled at the same time still produce one intent`、`a race cannot push the queue past its limit`。

## 一个值得指出的读法

去重是**不看年龄**的。§5.2.4 建议对重复点击设 10 秒窗口；但让守卫过期意味着用户拖到第 11 秒再点就能得到同一岗位的两条申请——纯粹靠延迟制造重复。所以只要还有同岗位的 pending 意图，就一律要求显式「再存一次」；10 秒只用来决定文案说「刚刚已存过」还是「已在待同步里」。

如果你认为该严格照文档，改 `link/intents.mjs` 一行即可。

## 顺带清掉三个死导出

`link/session.mjs` 的 `currentIdentity`、`link/errors.mjs` 的 `RETRYABLE_CODES` 是 #45 留下的，加上这里的 `markPendingBind`，全仓库无人调用。前两个尤其不该留着：一个是没有任何新鲜握手确认过的缓存身份，一个是 `transport.mjs` 里已有策略的第二份副本。

## 测试

```bash
node --test tests/*.test.js
```

243 passed / 0 failed。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“保存岗位到本地”功能，可从当前页面提取公司、职位、地点和来源链接。
  - 支持桌面连接状态检测、保存结果提示及扩展 ID 复制。
  - 新增待同步队列，可查看、重试或移除待处理岗位。
  - 支持重复保存识别、离线排队和队列容量限制。

- **界面优化**
  - 新增保存表单、状态提示和待同步列表的视觉样式。

- **测试**
  - 增加岗位信息提取、保存流程、队列管理及不同连接状态的覆盖测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->