### PR TITLE
feat(d07): candidate selection, binding and job.save

### DIFF
--- a/content.css
+++ b/content.css
@@ -498,3 +498,34 @@
   font-size: 11px;
   color: #b45309;
 }
+
+.resume-pro__candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.resume-pro__candidate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.resume-pro__candidate {
+  text-align: left;
+  padding: 6px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 8px;
+  background: #fff;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.resume-pro__candidate:hover {
+  border-color: rgba(37, 99, 235, 0.6);
+  background: rgba(37, 99, 235, 0.06);
+}

--- a/content.js
+++ b/content.js
@@ -160,6 +160,14 @@
               <button class="resume-pro__manager-button" type="button" id="resume-pro-save-cancel">取消</button>
             </div>
           </form>
+          <div class="resume-pro__candidates" id="resume-pro-candidates" hidden>
+            <p class="resume-pro__save-note" id="resume-pro-candidates-note"></p>
+            <div class="resume-pro__candidate-list" id="resume-pro-candidate-list"></div>
+            <div class="resume-pro__save-actions">
+              <button class="resume-pro__ai-button" type="button" id="resume-pro-bind-new">新建一条申请</button>
+              <button class="resume-pro__manager-button" type="button" id="resume-pro-bind-later">稍后再说</button>
+            </div>
+          </div>
           <div class="resume-pro__desktop-status" id="resume-pro-desktop-status" aria-live="polite"></div>
           <details class="resume-pro__pending" id="resume-pro-pending" hidden>
             <summary>待同步 <span id="resume-pro-pending-count">0</span> 条</summary>
@@ -1733,7 +1741,77 @@
     setDesktopStatus(copy.describeSaveResult(result ?? { status: "error" }));
     if (result?.status === "queued") {
       closeSaveForm();
+      if (result.mode === "ready") {
+        await offerCandidates(result.intent.intentId);
+      }
     }
+    refreshPendingList();
+  }
+
+  // Two layers, per §7. The exact layer is "this may be the same posting again"; the
+  // same-company layer is a hint and nothing more. Neither ever binds on its own — the
+  // default is always a new application.
+  async function offerCandidates(intentId) {
+    const box = shadowRoot?.querySelector("#resume-pro-candidates");
+    const list = shadowRoot?.querySelector("#resume-pro-candidate-list");
+    if (!box || !list) return;
+
+    let result;
+    try {
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_CANDIDATES", intentId });
+    } catch {
+      return;
+    }
+    if (result?.status !== "ok") return;
+
+    list.textContent = "";
+    const note = shadowRoot.querySelector("#resume-pro-candidates-note");
+    const total = result.exact.length + result.sameCompany.length;
+    note.textContent = total
+      ? "桌面里有相关的申请。要绑定到已有的哪一条，还是新建？默认新建。"
+      : "桌面里没有相关的申请，确认后会新建一条。";
+
+    appendCandidateGroup(list, "可能是同一岗位的重复投递", result.exact, intentId);
+    appendCandidateGroup(list, "同公司的其他岗位（仅供参考）", result.sameCompany, intentId);
+
+    box.hidden = false;
+    shadowRoot.querySelector("#resume-pro-bind-new").onclick = () => bindIntent(intentId, null);
+    shadowRoot.querySelector("#resume-pro-bind-later").onclick = () => {
+      // §5.2.4: cancelling the picker keeps the intent pending. Nothing is bound and nothing
+      // is discarded.
+      box.hidden = true;
+    };
+  }
+
+  function appendCandidateGroup(list, heading, candidates, intentId) {
+    if (!candidates.length) return;
+    const title = document.createElement("p");
+    title.className = "resume-pro__save-note";
+    title.textContent = heading;
+    list.appendChild(title);
+
+    for (const candidate of candidates) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "resume-pro__candidate";
+      row.textContent = `${candidate.company} · ${candidate.title}${candidate.stage ? `（${candidate.stage}）` : ""}`;
+      row.addEventListener("click", () => bindIntent(intentId, candidate.applicationId));
+      list.appendChild(row);
+    }
+  }
+
+  async function bindIntent(intentId, applicationId) {
+    const { copy } = await loadDesktopModules();
+    let result;
+    try {
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_BIND", intentId, applicationId });
+    } catch {
+      result = { status: "pending" };
+    }
+
+    const box = shadowRoot?.querySelector("#resume-pro-candidates");
+    if (box) box.hidden = true;
+    setDesktopStatus(copy.describeBindResult(result ?? { status: "pending" }));
     refreshPendingList();
   }
 
@@ -1785,42 +1863,73 @@
     if (!details || !list) return;
 
     let intents = [];
+    let outbox = [];
     try {
       const reply = await chrome.runtime.sendMessage({ type: "DESKTOP_LIST_QUEUE" });
       intents = reply?.intents || [];
+      outbox = reply?.outbox || [];
     } catch {
       return;
     }
 
-    details.hidden = intents.length === 0;
-    shadowRoot.querySelector("#resume-pro-pending-count").textContent = String(intents.length);
+    const total = intents.length + outbox.length;
+    details.hidden = total === 0;
+    shadowRoot.querySelector("#resume-pro-pending-count").textContent = String(total);
     list.textContent = "";
 
     for (const intent of intents) {
-      const row = document.createElement("div");
-      row.className = "resume-pro__pending-row";
-
-      const label = document.createElement("span");
-      label.textContent = `${intent.fields.company} · ${intent.fields.title}`;
-      label.title = intent.fields.sourceUrl || "";
-      row.appendChild(label);
-
-      const state = document.createElement("em");
-      state.textContent = intent.status === "pending_bind" ? "待绑定申请" : "待同步（尚未绑定申请）";
-      row.appendChild(state);
-
-      const remove = document.createElement("button");
-      remove.type = "button";
-      remove.className = "resume-pro__manager-button";
-      remove.textContent = "删除";
-      remove.addEventListener("click", async () => {
+      const row = pendingRow(
+        `${intent.fields.company} · ${intent.fields.title}`,
+        intent.fields.sourceUrl,
+        intent.status === "pending_bind" ? "待绑定申请" : "待同步（尚未绑定申请）"
+      );
+      if (intent.status === "pending_bind") {
+        row.appendChild(rowButton("选择绑定", () => offerCandidates(intent.intentId)));
+      }
+      row.appendChild(rowButton("删除", async () => {
         await chrome.runtime.sendMessage({ type: "DESKTOP_REMOVE_INTENT", intentId: intent.intentId });
         refreshPendingList();
-      });
-      row.appendChild(remove);
-
+      }));
       list.appendChild(row);
     }
+
+    for (const entry of outbox) {
+      const row = pendingRow(
+        `${entry.payload?.company || ""} · ${entry.payload?.title || ""}`,
+        entry.payload?.sourceUrl,
+        describeOutboxState(entry)
+      );
+      list.appendChild(row);
+    }
+  }
+
+  function pendingRow(label, title, state) {
+    const row = document.createElement("div");
+    row.className = "resume-pro__pending-row";
+
+    const name = document.createElement("span");
+    name.textContent = label;
+    name.title = title || "";
+    row.appendChild(name);
+
+    const status = document.createElement("em");
+    status.textContent = state;
+    row.appendChild(status);
+    return row;
+  }
+
+  function rowButton(text, onClick) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "resume-pro__manager-button";
+    button.textContent = text;
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  function describeOutboxState(entry) {
+    if (entry.status === "failed") return "已停下，需要处理";
+    return `待同步（已尝试 ${entry.attempts || 0} 次）`;
   }
 
   chrome.runtime.onMessage.addListener((message) => {

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -1,4 +1,4 @@
-import { MAX_INTENTS } from './limits.mjs';
+import { MAX_INTENTS, MAX_OUTBOX } from './limits.mjs';
 
 // User-facing wording for every outcome of a save, in one table.
 //
@@ -69,4 +69,61 @@ export function describeSaveResult(result) {
   }
 
   return { tone: 'warn', text: '这次没能保存，请稍后再试。填表功能不受影响。' };
+}
+
+// Why a write was refused, in words that mean something to the person who clicked. The
+// protocol code is kept out of the sentence: it is not the user's vocabulary, and several
+// of these codes mean "someone has to look at this", not "try again".
+const REFUSALS = {
+  previously_purged: '这条申请在桌面上已经被永久删除了，不会重建。如果还需要，请在桌面新建一条。',
+  conflict: '桌面上有一条同样身份但内容不同的记录，没有自动处理。请到桌面核对之后再决定。',
+  restore_epoch_mismatch: '桌面的档案库换过了，这条要先对账才能继续，已经暂停。',
+  invalid_payload: '桌面看不懂这次的内容，没有保存。请检查公司和岗位是否填对。',
+  identity_not_allowed: '桌面还没有配对这个插件，这次没有保存。',
+  protocol_incompatible: '桌面程序的版本和插件对不上，升级之后再试。'
+};
+
+export function describeBindResult(result) {
+  const { status, code, reason } = result ?? {};
+
+  if (status === 'saved') {
+    // The only sentence in the whole plugin that may claim the desktop has it, and it only
+    // runs after a persisted reply. Saving a posting is not applying to it.
+    return {
+      tone: 'success',
+      text: '桌面已保存（已收藏，不是已投递）。确认投递之后再点「确认已投递」。'
+    };
+  }
+
+  if (status === 'pending') {
+    return {
+      tone: 'pending',
+      text: '已经排进待同步队列，桌面可用之后会自动重试。现在还没有保存到桌面。'
+    };
+  }
+
+  if (status === 'duplicate') {
+    // The first click did the work. Saying "failed" here would send the user looking for a
+    // problem that does not exist.
+    return { tone: 'pending', text: '这条已经在待同步队列里了，没有重复排一份。' };
+  }
+
+  if (status === 'rejected') {
+    if (reason === 'queue_full') {
+      return {
+        tone: 'warn',
+        text: `待同步的消息已满（${MAX_OUTBOX} 条），这次没有绑定。请先处理已有的几条。填表功能不受影响。`
+      };
+    }
+    if (reason === 'unknown_intent') {
+      return { tone: 'warn', text: '这条待同步记录已经不在了，请重新保存一次。' };
+    }
+    return { tone: 'warn', text: '这次没能绑定，请稍后再试。填表功能不受影响。' };
+  }
+
+  if (status === 'failed') {
+    return { tone: 'warn', text: REFUSALS[code] ?? '桌面拒绝了这次写入，请到桌面核对。' };
+  }
+
+  return { tone: 'warn', text: '这次没能保存到桌面，已经留在待同步里。' };
 }

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -3,6 +3,8 @@
 export const MSG = {
   probe: 'DESKTOP_PROBE',
   saveJob: 'DESKTOP_SAVE_JOB',
+  candidates: 'DESKTOP_CANDIDATES',
+  bind: 'DESKTOP_BIND',
   listQueue: 'DESKTOP_LIST_QUEUE',
   removeIntent: 'DESKTOP_REMOVE_INTENT'
 };

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -1,0 +1,180 @@
+import { buildEnvelope } from './envelope.mjs';
+import { sendOnce } from './transport.mjs';
+import { MAX_OUTBOX } from './limits.mjs';
+
+/**
+ * Bound messages: the queue that exists once the user has chosen what to bind to.
+ *
+ * Two rules shape everything here:
+ *
+ *  - The entry is persisted before it is sent. If the worker dies between the send and the
+ *    reply, the same messageId has to be there to retry with; minting a new one on the way
+ *    back is how one job becomes two applications.
+ *  - `sourceRestoreEpoch` is stamped at bind time and never rewritten. The envelope follows
+ *    the current handshake, the payload remembers what the user actually chose. Refreshing
+ *    the payload would silently replay the job into an archive the user never saw.
+ */
+export function createOutbox({ store, uuid, now, sendNative, sleep }) {
+  const wire = { sendNative, sleep };
+
+  async function queryCandidates({ identity, fields }) {
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+
+    const payload = { company: fields.company, title: fields.title };
+    if (fields.sourceUrl) payload.sourceUrl = fields.sourceUrl;
+
+    const message = await buildEnvelope({
+      messageType: 'application.queryCandidates',
+      messageId: uuid(),
+      clientInstanceId: await store.clientInstanceId(),
+      payload,
+      identity,
+      now
+    });
+
+    const result = await sendOnce(message, wire);
+    if (result.status !== 'ok') {
+      // An empty list would read as "nothing matches", which pushes the user into creating a
+      // duplicate. An unreachable desktop has to say so.
+      return { status: result.status, code: result.code };
+    }
+    return {
+      status: 'ok',
+      exact: result.response.payload.exact ?? [],
+      sameCompany: result.response.payload.sameCompany ?? []
+    };
+  }
+
+  async function bindAndSend({ intentId, applicationId = null, identity }) {
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+
+    const intents = await store.getIntents();
+    const intent = intents.find(item => item.intentId === intentId);
+    if (!intent) return { status: 'rejected', reason: 'unknown_intent' };
+
+    const payload = { company: intent.fields.company, title: intent.fields.title };
+    if (intent.fields.sourceUrl) payload.sourceUrl = intent.fields.sourceUrl;
+    if (intent.fields.location) payload.location = intent.fields.location;
+    if (applicationId) payload.applicationId = applicationId;
+
+    const entry = {
+      messageId: uuid(),
+      intentId,
+      clientInstanceId: await store.clientInstanceId(),
+      messageType: 'job.save',
+      archiveId: identity.archiveId,
+      sourceRestoreEpoch: identity.restoreEpoch,
+      applicationId,
+      payload,
+      createdAt: now().toISOString(),
+      bytes: new TextEncoder().encode(JSON.stringify(payload)).length,
+      status: 'pending',
+      attempts: 0,
+      lastError: null
+    };
+
+    // Both guards live in the same queued step as the append.
+    //
+    // The intent guard is what makes a double-clicked bind button harmless: two entries for
+    // one intent carry two messageIds, and two messageIds are two applications, because the
+    // desktop can only recognise a replay by identity. Checked outside the callback, both
+    // clicks see a queue without the other's entry in it.
+    let outcome = null;
+    await store.updateOutbox(list => {
+      if (intentId && list.some(item => item.intentId === intentId)) {
+        outcome = { status: 'duplicate', reason: 'already_queued' };
+        return list;
+      }
+      if (list.length >= MAX_OUTBOX) {
+        outcome = { status: 'rejected', reason: 'queue_full' };
+        return list;
+      }
+      return [...list, entry];
+    });
+    if (outcome) return outcome;
+
+    return deliver(entry, identity);
+  }
+
+  /**
+   * One pass over the pending entries.
+   *
+   * Serial on purpose: parallel sends race for the same cold start, and the host answers all
+   * but one of them with `unavailable` for no reason.
+   */
+  async function drainOnce({ identity }) {
+    const saved = [];
+    const pending = [];
+    const failed = [];
+
+    for (const entry of await store.getOutbox()) {
+      if (entry.status !== 'pending') continue;
+      const result = await deliver(entry, identity);
+      if (result.status === 'saved') saved.push(result);
+      else if (result.status === 'failed') failed.push(result);
+      else pending.push(result);
+    }
+
+    return { saved, pending, failed };
+  }
+
+  async function deliver(entry, identity) {
+    if (!identity) return { status: 'pending', entry };
+
+    const message = await buildEnvelope({
+      messageType: entry.messageType,
+      messageId: entry.messageId,
+      clientInstanceId: entry.clientInstanceId,
+      payload: entry.payload,
+      identity,
+      sourceRestoreEpoch: entry.sourceRestoreEpoch,
+      now
+    });
+
+    const result = await sendOnce(message, wire);
+
+    if (result.status === 'ok') {
+      // The desktop has committed. Only now may the intent and the queue entry go, and only
+      // now may the sidebar say the desktop has it.
+      await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+      if (entry.intentId) {
+        await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
+      }
+      return {
+        status: 'saved',
+        messageId: entry.messageId,
+        resultId: result.resultId,
+        applicationId: entry.applicationId ?? result.resultId
+      };
+    }
+
+    if (result.status === 'fatal') {
+      await patch(entry.messageId, item => ({
+        ...item,
+        status: 'failed',
+        attempts: item.attempts + 1,
+        lastError: result.code
+      }));
+      return { status: 'failed', messageId: entry.messageId, code: result.code };
+    }
+
+    await patch(entry.messageId, item => ({
+      ...item,
+      attempts: item.attempts + 1,
+      lastError: result.code ?? result.status
+    }));
+    return { status: 'pending', messageId: entry.messageId, code: result.code ?? result.status };
+  }
+
+  const patch = (messageId, change) => store.updateOutbox(list =>
+    list.map(item => (item.messageId === messageId ? change(item) : item))
+  );
+
+  return {
+    queryCandidates,
+    bindAndSend,
+    drainOnce,
+    list: () => store.getOutbox(),
+    remove: messageId => store.updateOutbox(list => list.filter(item => item.messageId !== messageId))
+  };
+}

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -10,7 +10,7 @@ import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
  * "saved on the desktop" are different claims, and the difference has to survive the trip to
  * the sidebar rather than being decided by whoever formats the string.
  */
-export function createRouter({ session, intents, extensionId }) {
+export function createRouter({ session, intents, outbox, extensionId }) {
   async function handle(message) {
     const type = message?.type;
     if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
@@ -32,8 +32,29 @@ export function createRouter({ session, intents, extensionId }) {
       return { ...result, mode: probe.mode, extensionId };
     }
 
+    if (type === MSG.candidates) {
+      const probe = await session.probe();
+      if (probe.mode !== 'ready') return { status: probe.mode };
+      const intent = (await intents.list()).find(item => item.intentId === message.intentId);
+      if (!intent) return { status: 'unknown_intent' };
+      return outbox.queryCandidates({ identity: probe.identity, fields: intent.fields });
+    }
+
+    if (type === MSG.bind) {
+      // The identity is taken from a handshake made now, not from whatever was current when
+      // the candidate list was drawn. The desktop may have been restored in between, and the
+      // epoch that gets stamped has to be the one the write will actually be judged against.
+      const probe = await session.probe();
+      if (probe.mode !== 'ready') return { status: 'pending', mode: probe.mode };
+      return outbox.bindAndSend({
+        intentId: message.intentId,
+        applicationId: message.applicationId ?? null,
+        identity: probe.identity
+      });
+    }
+
     if (type === MSG.listQueue) {
-      return { intents: await intents.list() };
+      return { intents: await intents.list(), outbox: await outbox.list() };
     }
 
     if (type === MSG.removeIntent) {

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -2,6 +2,7 @@ import { nativeSender, sleep, storageAdapter } from './chrome.mjs';
 import { createStore } from './store.mjs';
 import { createSession } from './session.mjs';
 import { createIntents } from './intents.mjs';
+import { createOutbox } from './outbox.mjs';
 import { createRouter } from './router.mjs';
 import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
 
@@ -29,6 +30,7 @@ export function installDesktopLink(api) {
   const router = createRouter({
     session: createSession(deps),
     intents: createIntents(deps),
+    outbox: createOutbox(deps),
     extensionId: api.runtime.id
   });
 

--- a/tests/link-copy.test.js
+++ b/tests/link-copy.test.js
@@ -111,3 +111,62 @@ test('no copy in the whole table claims a desktop save', async () => {
     assert.equal(copy.text.includes('桌面已保存'), false, JSON.stringify(input));
   }
 });
+
+// --- binding ---------------------------------------------------------------
+
+test('a persisted write is the only thing allowed to say the desktop has it', async () => {
+  const { describeBindResult } = await load();
+
+  const copy = describeBindResult({ status: 'saved', applicationId: '77777777-7777-4777-8777-777777777777' });
+
+  assert.match(copy.text, /桌面已保存/);
+  assert.equal(copy.tone, 'success');
+});
+
+test('a desktop save says it is saved, not submitted', async () => {
+  const { describeBindResult } = await load();
+  // §5.2 rule 5 and walkthrough note: saving a posting is not applying to it. The stage is
+  // `saved` until the user says otherwise.
+  const copy = describeBindResult({ status: 'saved', applicationId: '77777777-7777-4777-8777-777777777777' });
+
+  assert.match(copy.text, /已收藏|不是已投递/);
+});
+
+test('a bind that could not reach the desktop is pending, not saved', async () => {
+  const { describeBindResult } = await load();
+
+  const copy = describeBindResult({ status: 'pending', mode: 'unavailable' });
+
+  assert.match(copy.text, /待同步/);
+  assert.equal(copy.text.includes('桌面已保存'), false);
+});
+
+test('a refused write names the reason without echoing the protocol', async () => {
+  const { describeBindResult } = await load();
+
+  const purged = describeBindResult({ status: 'failed', code: 'previously_purged' });
+  const conflict = describeBindResult({ status: 'failed', code: 'conflict' });
+
+  assert.equal(purged.tone, 'warn');
+  assert.notEqual(purged.text, conflict.text, 'different refusals need different explanations');
+  assert.equal(purged.text.includes('previously_purged'), false);
+});
+
+test('a full bound queue explains itself and promises filling still works', async () => {
+  const { describeBindResult } = await load();
+  const { MAX_OUTBOX } = await import('../link/limits.mjs');
+
+  const copy = describeBindResult({ status: 'rejected', reason: 'queue_full' });
+
+  assert.match(copy.text, new RegExp(String(MAX_OUTBOX)));
+  assert.match(copy.text, /填表/);
+});
+
+test('a second bind for the same posting says it is already queued', async () => {
+  const { describeBindResult } = await load();
+
+  const copy = describeBindResult({ status: 'duplicate', reason: 'already_queued' });
+
+  assert.match(copy.text, /已经|队列/);
+  assert.equal(copy.text.includes('没能'), false, 'the first click did work');
+});

--- a/tests/link-outbox.test.js
+++ b/tests/link-outbox.test.js
@@ -1,0 +1,313 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const LATER_EPOCH = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+const IDENTITY = { archiveId: ARCHIVE, restoreEpoch: EPOCH };
+
+const FIELDS = {
+  company: '星河科技',
+  title: '后端开发',
+  location: '上海',
+  sourceUrl: 'https://jobs.example.com/apply',
+  dedupeUrl: 'https://jobs.example.com/apply'
+};
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+async function harness({ desktop, storage = fakeStorage() } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date('2026-09-09T00:00:00.000Z');
+  const store = createStore({ storage, uuid });
+  const sent = [];
+  const outbox = createOutbox({
+    store,
+    uuid,
+    now,
+    sleep: async () => {},
+    sendNative: async (host, message) => {
+      sent.push({ message, storageAtSendTime: JSON.parse(JSON.stringify(storage.data)) });
+      return desktop(message);
+    }
+  });
+  const intents = createIntents({ store, uuid, now });
+  return { outbox, intents, store, storage, sent };
+}
+
+const savedReply = (message, resultId = APPLICATION) => ({
+  response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId, payload: {} }
+});
+
+const errorReply = (message, code, retryable = false) => ({
+  response: {
+    protocolVersion: 1, correlationId: message.messageId, ok: false,
+    error: { code, retryable, message: 'synthetic' }, payload: {}
+  }
+});
+
+async function queuedIntent(intents) {
+  const { intent } = await intents.save({ fields: FIELDS, mode: 'ready' });
+  return intent;
+}
+
+test('candidates come back in two layers', async () => {
+  const { outbox } = await harness({
+    desktop: message => ({
+      response: {
+        protocolVersion: 1, correlationId: message.messageId, ok: true,
+        payload: {
+          exact: [{ applicationId: APPLICATION, company: '星河科技', title: '后端开发', stage: 'saved' }],
+          sameCompany: [{ applicationId: '88888888-8888-4888-8888-888888888888', company: '星河科技', title: '测试开发' }]
+        }
+      }
+    })
+  });
+
+  const result = await outbox.queryCandidates({ identity: IDENTITY, fields: FIELDS });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.exact.length, 1);
+  assert.equal(result.sameCompany.length, 1);
+});
+
+test('a candidate query asks for nothing but the three hint fields', async () => {
+  const { outbox, sent } = await harness({
+    desktop: message => ({
+      response: { protocolVersion: 1, correlationId: message.messageId, ok: true, payload: { exact: [], sameCompany: [] } }
+    })
+  });
+
+  await outbox.queryCandidates({ identity: IDENTITY, fields: FIELDS });
+
+  // Reading is not writing: a query carries no source epoch and no digest, and D05 refuses
+  // the message if it does. It also must not turn into a way to pull the archive down.
+  assert.deepEqual(Object.keys(sent[0].message.payload).sort(), ['company', 'sourceUrl', 'title']);
+});
+
+test('a closed desktop makes candidates unavailable rather than empty', async () => {
+  const { outbox } = await harness({ desktop: message => errorReply(message, 'unavailable', true) });
+
+  const result = await outbox.queryCandidates({ identity: IDENTITY, fields: FIELDS });
+
+  // An empty candidate list means "no existing application matches", which would push the
+  // user into creating a duplicate.
+  assert.notEqual(result.status, 'ok');
+  assert.equal(result.status, 'retryable');
+});
+
+test('the outbox entry is on disk before anything is sent', async () => {
+  const { outbox, intents, sent } = await harness({ desktop: savedReply });
+  const intent = await queuedIntent(intents);
+
+  await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  // If the worker dies between the send and the reply, the entry has to be there to retry
+  // with the same messageId. Sending first is how a job gets written twice.
+  const queued = sent[0].storageAtSendTime.desktopOutbox;
+  assert.equal(queued.length, 1);
+  assert.equal(queued[0].messageId, sent[0].message.messageId);
+});
+
+test('a persisted save clears the intent and reports the application it created', async () => {
+  const { outbox, intents, storage } = await harness({ desktop: savedReply });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  assert.equal(result.status, 'saved');
+  // For job.save the desktop's resultId is the application it wrote; D06's own tests feed it
+  // straight back as the applicationId of a later fill.submit.
+  assert.equal(result.applicationId, APPLICATION);
+  assert.deepEqual(storage.data.desktopSaveIntents, []);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+test('binding to an existing application sends that id and keeps it', async () => {
+  const { outbox, intents, sent } = await harness({ desktop: savedReply });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({
+    intentId: intent.intentId,
+    applicationId: '99999999-9999-4999-8999-999999999999',
+    identity: IDENTITY
+  });
+
+  assert.equal(sent[0].message.payload.applicationId, '99999999-9999-4999-8999-999999999999');
+  assert.equal(result.applicationId, '99999999-9999-4999-8999-999999999999');
+});
+
+test('the source epoch is stamped at bind time and never refreshed', async () => {
+  const { outbox, intents, storage, sent } = await harness({
+    desktop: message => errorReply(message, 'unavailable', true)
+  });
+  const intent = await queuedIntent(intents);
+  await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  // The desktop was restored between attempts. The envelope must follow the new identity,
+  // the payload must not: rewriting it would replay this job into a different archive.
+  await outbox.drainOnce({ identity: { archiveId: ARCHIVE, restoreEpoch: LATER_EPOCH } });
+
+  assert.equal(storage.data.desktopOutbox[0].sourceRestoreEpoch, EPOCH);
+  assert.equal(sent.at(-1).message.payload.sourceRestoreEpoch, EPOCH);
+});
+
+test('an unanswered send leaves the job pending, not saved', async () => {
+  const { outbox, intents, storage } = await harness({
+    desktop: message => errorReply(message, 'unavailable', true)
+  });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  assert.equal(result.status, 'pending');
+  assert.equal(storage.data.desktopOutbox.length, 1);
+  assert.equal(storage.data.desktopOutbox[0].status, 'pending');
+  assert.equal(storage.data.desktopSaveIntents.length, 1, 'the intent stays until the write is persisted');
+});
+
+test('a retry reuses the message id and the replay resolves to one application', async () => {
+  let calls = 0;
+  const { outbox, intents, storage, sent } = await harness({
+    desktop: message => {
+      calls += 1;
+      // First attempt: the reply is lost. Second: the desktop recognises the identity and
+      // returns the original resultId without writing anything new.
+      return calls <= 2 ? errorReply(message, 'unavailable', true) : savedReply(message);
+    }
+  });
+  const intent = await queuedIntent(intents);
+
+  await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+  const first = sent[0].message.messageId;
+  const result = await outbox.drainOnce({ identity: IDENTITY });
+
+  assert.equal(sent.at(-1).message.messageId, first, 'a new id would create a second application');
+  assert.equal(result.saved.length, 1);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.deepEqual(storage.data.desktopSaveIntents, []);
+});
+
+test('a protocol refusal marks the entry failed instead of retrying it forever', async () => {
+  const { outbox, intents, storage } = await harness({
+    desktop: message => errorReply(message, 'previously_purged')
+  });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.code, 'previously_purged');
+  assert.equal(storage.data.desktopOutbox[0].status, 'failed');
+  assert.equal(storage.data.desktopOutbox[0].lastError, 'previously_purged');
+});
+
+test('a full outbox refuses a new binding and keeps the intent', async () => {
+  const { MAX_OUTBOX } = await import('../link/limits.mjs');
+  const full = Array.from({ length: MAX_OUTBOX }, (unused, index) => ({
+    messageId: `m-${index}`, status: 'pending', messageType: 'job.save'
+  }));
+  const { outbox, intents, storage } = await harness({
+    desktop: savedReply,
+    storage: fakeStorage({ desktopOutbox: full })
+  });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  assert.equal(result.status, 'rejected');
+  assert.equal(result.reason, 'queue_full');
+  assert.equal(storage.data.desktopOutbox.length, MAX_OUTBOX);
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+});
+
+test('binding an intent that is already gone does not invent one', async () => {
+  const { outbox } = await harness({ desktop: savedReply });
+
+  const result = await outbox.bindAndSend({ intentId: 'no-such-intent', identity: IDENTITY });
+
+  assert.equal(result.status, 'rejected');
+  assert.equal(result.reason, 'unknown_intent');
+});
+
+test('a write is never sent without a fresh handshake identity', async () => {
+  const { outbox, intents, sent } = await harness({ desktop: savedReply });
+  const intent = await queuedIntent(intents);
+
+  const result = await outbox.bindAndSend({ intentId: intent.intentId, identity: null });
+
+  assert.equal(result.status, 'rejected');
+  assert.equal(sent.length, 0);
+});
+
+test('a race cannot push the bound queue past its limit', async () => {
+  const { MAX_OUTBOX } = await import('../link/limits.mjs');
+  const nearlyFull = Array.from({ length: MAX_OUTBOX - 1 }, (unused, index) => ({
+    messageId: `m-${index}`, status: 'pending', messageType: 'job.save'
+  }));
+  const { outbox, intents, storage } = await harness({
+    desktop: message => errorReply(message, 'unavailable', true),
+    storage: fakeStorage({ desktopOutbox: nearlyFull })
+  });
+  const first = await intents.save({ fields: FIELDS, mode: 'ready' });
+  const second = await intents.save({ fields: { ...FIELDS, title: '测试开发' }, mode: 'ready' });
+
+  // Checking the size and appending have to be one step, or two binds in the same worker
+  // turn both see room for one.
+  const results = await Promise.all([
+    outbox.bindAndSend({ intentId: first.intent.intentId, identity: IDENTITY }),
+    outbox.bindAndSend({ intentId: second.intent.intentId, identity: IDENTITY })
+  ]);
+
+  assert.equal(storage.data.desktopOutbox.length, MAX_OUTBOX);
+  assert.equal(results.filter(result => result.status === 'rejected').length, 1);
+});
+
+test('double-clicking bind produces one application, not two', async () => {
+  const { outbox, intents, sent, storage } = await harness({ desktop: savedReply });
+  const intent = await queuedIntent(intents);
+
+  // Two DESKTOP_BIND messages from one double-click, handled in the same worker turn. Two
+  // entries would mean two messageIds, and two messageIds mean the desktop cannot see the
+  // second as a replay — it writes a second application for one posting.
+  const results = await Promise.all([
+    outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY }),
+    outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY })
+  ]);
+
+  const writes = sent.filter(item => item.message.messageType === 'job.save');
+  assert.equal(new Set(writes.map(item => item.message.messageId)).size, 1);
+  assert.equal(results.filter(result => result.status === 'saved').length, 1);
+  assert.equal(results.filter(result => result.status === 'duplicate').length, 1);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+test('an intent that is already queued is not bound a second time later', async () => {
+  const { outbox, intents, storage } = await harness({
+    desktop: message => errorReply(message, 'unavailable', true)
+  });
+  const intent = await queuedIntent(intents);
+  await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  const again = await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  assert.equal(again.status, 'duplicate');
+  assert.equal(storage.data.desktopOutbox.length, 1);
+});

--- a/tests/link-router.test.js
+++ b/tests/link-router.test.js
@@ -43,16 +43,23 @@ async function makeRouter({ reply = () => ({ lastError: 'Error when communicatin
   const { createStore } = await import('../link/store.mjs');
   const { createSession } = await import('../link/session.mjs');
   const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
   const { createRouter } = await import('../link/router.mjs');
 
   let minted = 0;
   const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
   const now = () => new Date('2026-09-09T00:00:00.000Z');
   const store = createStore({ storage, uuid });
-  const session = createSession({ store, sendNative: async (host, message) => reply(message), sleep: async () => {}, uuid, now });
+  const sent = [];
+  const sendNative = async (host, message) => {
+    sent.push(message);
+    return reply(message);
+  };
+  const session = createSession({ store, sendNative, sleep: async () => {}, uuid, now });
   const intents = createIntents({ store, uuid, now });
-  const router = createRouter({ session, intents, extensionId: 'abcdefghijklmnopabcdefghijklmnop' });
-  return { router, storage };
+  const outbox = createOutbox({ store, sendNative, sleep: async () => {}, uuid, now });
+  const router = createRouter({ session, intents, outbox, extensionId: 'abcdefghijklmnopabcdefghijklmnop' });
+  return { router, storage, sent };
 }
 
 test('an unknown message is left for the other listeners', async () => {
@@ -136,4 +143,87 @@ test('a probe reports the mode without saving anything', async () => {
 
   assert.equal(result.mode, 'ready');
   assert.equal('desktopSaveIntents' in storage.data, false);
+});
+
+// --- binding ---------------------------------------------------------------
+
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+
+function desktopThatAnswers(message) {
+  if (message.messageType === 'handshake') return handshakeReply(message);
+  if (message.messageType === 'application.queryCandidates') {
+    return {
+      response: {
+        protocolVersion: 1, correlationId: message.messageId, ok: true,
+        payload: {
+          exact: [{ applicationId: APPLICATION, company: '星河科技', title: '后端开发', stage: 'saved' }],
+          sameCompany: []
+        }
+      }
+    };
+  }
+  return {
+    response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId: APPLICATION, payload: {} }
+  };
+}
+
+test('candidates are fetched for a queued intent', async () => {
+  const { router } = await makeRouter({ reply: desktopThatAnswers });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  const result = await router.handle({ type: 'DESKTOP_CANDIDATES', intentId: saved.intent.intentId });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.exact[0].applicationId, APPLICATION);
+});
+
+test('binding to a new application reports the desktop save', async () => {
+  const { router, storage } = await makeRouter({ reply: desktopThatAnswers });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  const result = await router.handle({ type: 'DESKTOP_BIND', intentId: saved.intent.intentId });
+
+  assert.equal(result.status, 'saved');
+  assert.equal(result.applicationId, APPLICATION);
+  assert.deepEqual(storage.data.desktopSaveIntents, []);
+});
+
+test('a bind while the desktop went away stays pending', async () => {
+  const { router, storage } = await makeRouter({
+    reply: message => message.messageType === 'handshake'
+      ? handshakeReply(message)
+      : {
+          response: {
+            protocolVersion: 1, correlationId: message.messageId, ok: false,
+            error: { code: 'unavailable', retryable: true, message: 'starting' }, payload: {}
+          }
+        }
+  });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+
+  const result = await router.handle({ type: 'DESKTOP_BIND', intentId: saved.intent.intentId });
+
+  assert.equal(result.status, 'pending');
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+  assert.equal(storage.data.desktopOutbox.length, 1);
+});
+
+test('the queue listing includes bound messages, not only intents', async () => {
+  const { router } = await makeRouter({
+    reply: message => message.messageType === 'handshake'
+      ? handshakeReply(message)
+      : {
+          response: {
+            protocolVersion: 1, correlationId: message.messageId, ok: false,
+            error: { code: 'unavailable', retryable: true, message: 'starting' }, payload: {}
+          }
+        }
+  });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+  await router.handle({ type: 'DESKTOP_BIND', intentId: saved.intent.intentId });
+
+  const listed = await router.handle({ type: 'DESKTOP_LIST_QUEUE' });
+
+  assert.equal(listed.outbox.length, 1);
+  assert.equal(listed.outbox[0].messageType, 'job.save');
 });


### PR DESCRIPTION
D07 第四部分：意图变成申请。查两层候选 → 用户选「使用已有」或「新建」→ 发 `job.save`。**只有桌面持久化应答之后侧边栏才会变绿。**

依赖 #47（已合入）。

## 先落盘，再发送

如果 worker 在「已发出、未收到回复」之间被回收，重试必须能拿到同一个 `messageId`。回来的路上现铸一个，就是一份工作写成两条申请。

## 追加那一步里有两个守卫

容量检查是显而易见的那个。另一个是**意图守卫**,它让双击绑定按钮变得无害：

一个意图两条队列项 = 两个 `messageId` = 两条申请,因为桌面**只能靠身份**认出重放。放在回调外面检查,两次点击都会看到一个还没有对方那条的队列。

修之前复现过：

```
job.save messages sent: 2
distinct messageIds  : 2   ← 两条申请
```

回归测试：`double-clicking bind produces one application, not two`。

## `sourceRestoreEpoch` 盖上不改

信封跟最新握手走，载荷记住用户当时选的是哪个档案库。有测试直接驱动这条：两次尝试之间把档案库换掉，断言信封换了新 epoch、载荷没换。

## 桌面不可达时候选是 `retryable`，不是空列表

空列表读起来是「没有匹配的申请」，而那恰恰会把用户推去新建一条重复的——正是这个查询存在的意义所在。

## 一条值得记下来的集成事实

`job.save` 的 `resultId` **就是**申请 ID。D06 自己的测试把它直接当作后续 `fill.submit` 的 `applicationId`，所以「新建」路径不需要单独回填。

## 测试

269 passed / 0 failed。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)