### PR TITLE
feat(d07): capped backoff, alarms and a queue the user controls

### DIFF
--- a/content.js
+++ b/content.js
@@ -1899,6 +1899,16 @@
         entry.payload?.sourceUrl,
         describeOutboxState(entry)
       );
+      row.appendChild(rowButton("立即重试", async () => {
+        const { copy } = await loadDesktopModules();
+        const result = await chrome.runtime.sendMessage({ type: "DESKTOP_RETRY", messageId: entry.messageId });
+        setDesktopStatus(copy.describeBindResult(result ?? { status: "pending" }));
+        refreshPendingList();
+      }));
+      row.appendChild(rowButton("取消", async () => {
+        await chrome.runtime.sendMessage({ type: "DESKTOP_CANCEL", messageId: entry.messageId });
+        refreshPendingList();
+      }));
       list.appendChild(row);
     }
   }
@@ -1927,9 +1937,29 @@
     return button;
   }
 
+  // The reason is the plugin's own classification, not the protocol text: the wording table
+  // in link/copy.mjs is the only place that turns a code into a sentence.
   function describeOutboxState(entry) {
-    if (entry.status === "failed") return "已停下，需要处理";
-    return `待同步（已尝试 ${entry.attempts || 0} 次）`;
+    if (entry.status === "failed") return `已停下，需要处理（${describeFailure(entry.lastError)}）`;
+    if (entry.status === "stalled") return `重试多次仍未成功，等你决定（${describeFailure(entry.lastError)}）`;
+    const next = entry.nextAttemptAt ? `，下次重试 ${formatClock(entry.nextAttemptAt)}` : "";
+    return `待同步（已尝试 ${entry.attempts || 0} 次${next}）`;
+  }
+
+  function describeFailure(code) {
+    if (code === "unavailable") return "桌面暂时不可用";
+    if (code === "invalid_payload") return "桌面看不懂这条内容";
+    if (code === "restore_epoch_mismatch") return "桌面换过档案库";
+    if (code === "previously_purged") return "已在桌面永久删除";
+    if (code === "conflict") return "与桌面已有记录冲突";
+    return "原因未知";
+  }
+
+  function formatClock(iso) {
+    const at = new Date(iso);
+    return Number.isNaN(at.getTime())
+      ? "稍后"
+      : at.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   }
 
   chrome.runtime.onMessage.addListener((message) => {

--- a/link/drain.mjs
+++ b/link/drain.mjs
@@ -1,0 +1,87 @@
+import { BACKOFF_STEPS_MS, MIN_ALARM_DELAY_MS } from './limits.mjs';
+
+export const ALARM_NAME = 'resume-pro-desktop-drain';
+
+/**
+ * How long to wait before attempt number `attempts + 1`.
+ *
+ * Returns null once the ladder is exhausted: the entry then waits for a person. Retrying
+ * forever would hide a problem only the user can fix, and would keep waking the worker to
+ * do it.
+ */
+export function nextDelayMs(attempts) {
+  return BACKOFF_STEPS_MS[attempts - 1] ?? null;
+}
+
+/**
+ * Drives the outbox on a schedule the service worker can survive.
+ *
+ * MV3 evicts the worker while entries are still queued, so the wake-up is a chrome alarm
+ * rather than a timer. Chrome will not fire an alarm sooner than MIN_ALARM_DELAY_MS, so the
+ * short rungs of the ladder only apply while the worker happens to still be alive; the alarm
+ * catches everything else a little later. Later is fine. Never is not.
+ */
+export function createDrain({ session, outbox, alarms, now }) {
+  async function run() {
+    // Nothing queued means nothing to do, and probing is not free: it spawns a native host,
+    // and per D06 the host starts the desktop application on demand. Waking every thirty
+    // seconds to do that for an empty queue would restart a desktop the user deliberately
+    // closed, indefinitely. Entries that are only waiting for a person — stalled, failed,
+    // already reconciled — are not work either.
+    if (!(await hasWork())) {
+      return { mode: 'idle', saved: [], pending: [], failed: [] };
+    }
+
+    const probe = await session.probe();
+    if (probe.mode !== 'ready') {
+      // Not an error: a closed desktop is the normal case for a queue that exists precisely
+      // because the desktop was closed. Just make sure something wakes us again.
+      await schedule(MIN_ALARM_DELAY_MS);
+      return { mode: probe.mode, saved: [], pending: [], failed: [] };
+    }
+
+    const result = await outbox.drainOnce({ identity: probe.identity });
+    await scheduleNext();
+    return { mode: probe.mode, ...result };
+  }
+
+  // Work the queue can make progress on by itself. Entries waiting for a person — stalled or
+  // failed — are not work.
+  async function hasWork() {
+    return (await outbox.list()).some(entry => entry.status === 'pending');
+  }
+
+  async function retryNow(messageId) {
+    const due = await outbox.markDue(messageId, now());
+    if (due.status !== 'ok') return due;
+    const probe = await session.probe();
+    if (probe.mode !== 'ready') return { status: 'pending', mode: probe.mode };
+    const result = await outbox.deliverOne(messageId, probe.identity);
+    await scheduleNext();
+    return result;
+  }
+
+  async function cancel(messageId) {
+    await outbox.remove(messageId);
+    await scheduleNext();
+  }
+
+  // The next alarm is set for the earliest entry that still has a rung left. A stalled entry
+  // is deliberately not counted: nothing about waiting longer will change it.
+  async function scheduleNext() {
+    const due = (await outbox.list())
+      .filter(entry => entry.status === 'pending' && entry.nextAttemptAt)
+      .map(entry => Date.parse(entry.nextAttemptAt))
+      .filter(Number.isFinite);
+
+    if (!due.length) return;
+    await schedule(Math.min(...due) - now().getTime());
+  }
+
+  async function schedule(delayMs) {
+    const delay = Math.max(delayMs, MIN_ALARM_DELAY_MS);
+    await alarms.create(ALARM_NAME, { delayInMinutes: delay / 60_000 });
+  }
+
+  return { run, retryNow, cancel, scheduleNext, alarmName: ALARM_NAME };
+}

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -6,7 +6,9 @@ export const MSG = {
   candidates: 'DESKTOP_CANDIDATES',
   bind: 'DESKTOP_BIND',
   listQueue: 'DESKTOP_LIST_QUEUE',
-  removeIntent: 'DESKTOP_REMOVE_INTENT'
+  removeIntent: 'DESKTOP_REMOVE_INTENT',
+  retry: 'DESKTOP_RETRY',
+  cancel: 'DESKTOP_CANCEL'
 };
 
 export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -1,6 +1,7 @@
 import { buildEnvelope } from './envelope.mjs';
 import { sendOnce } from './transport.mjs';
 import { MAX_OUTBOX } from './limits.mjs';
+import { nextDelayMs } from './drain.mjs';
 
 /**
  * Bound messages: the queue that exists once the user has chosen what to bind to.
@@ -70,6 +71,8 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
       bytes: new TextEncoder().encode(JSON.stringify(payload)).length,
       status: 'pending',
       attempts: 0,
+      // Due immediately. Every later attempt gets a time from the backoff ladder.
+      nextAttemptAt: now().toISOString(),
       lastError: null
     };
 
@@ -109,6 +112,7 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
 
     for (const entry of await store.getOutbox()) {
       if (entry.status !== 'pending') continue;
+      if (!isDue(entry)) continue;
       const result = await deliver(entry, identity);
       if (result.status === 'saved') saved.push(result);
       else if (result.status === 'failed') failed.push(result);
@@ -158,12 +162,54 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
       return { status: 'failed', messageId: entry.messageId, code: result.code };
     }
 
+    const attempts = entry.attempts + 1;
+    const delay = nextDelayMs(attempts);
     await patch(entry.messageId, item => ({
       ...item,
-      attempts: item.attempts + 1,
+      attempts,
+      // No rung left: stop retrying and say so. The entry is not lost and not failed — it is
+      // waiting for the user to retry it or give up on it.
+      status: delay === null ? 'stalled' : 'pending',
+      nextAttemptAt: delay === null ? null : new Date(now().getTime() + delay).toISOString(),
       lastError: result.code ?? result.status
     }));
-    return { status: 'pending', messageId: entry.messageId, code: result.code ?? result.status };
+    return {
+      status: delay === null ? 'stalled' : 'pending',
+      messageId: entry.messageId,
+      code: result.code ?? result.status
+    };
+  }
+
+  function isDue(entry) {
+    if (!entry.nextAttemptAt) return false;
+    return Date.parse(entry.nextAttemptAt) <= now().getTime();
+  }
+
+  // A message that is only waiting for the retry ladder. A paused or needs_user entry is
+  // waiting for something else entirely: its stamped epoch no longer exists on the desktop,
+  // so sending it again is not a retry, it is a write the desktop has to refuse.
+  const RETRYABLE_STATES = new Set(['pending', 'stalled', 'failed']);
+
+  /**
+   * Used by a manual retry: clear the wait and un-stall the entry.
+   *
+   * The identity, the messageId and the stamped epoch are untouched — this is the same
+   * message, sent again. Refuses anything the reconcile flow owns.
+   */
+  async function markDue(messageId, at) {
+    const entry = (await store.getOutbox()).find(item => item.messageId === messageId);
+    if (!entry) return { status: 'rejected', reason: 'unknown_message' };
+    if (!RETRYABLE_STATES.has(entry.status)) {
+      return { status: 'rejected', reason: 'awaiting_reconcile' };
+    }
+    await patch(messageId, item => ({ ...item, status: 'pending', nextAttemptAt: at.toISOString() }));
+    return { status: 'ok' };
+  }
+
+  async function deliverOne(messageId, identity) {
+    const entry = (await store.getOutbox()).find(item => item.messageId === messageId);
+    if (!entry) return { status: 'rejected', reason: 'unknown_message' };
+    return deliver(entry, identity);
   }
 
   const patch = (messageId, change) => store.updateOutbox(list =>
@@ -174,6 +220,8 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     queryCandidates,
     bindAndSend,
     drainOnce,
+    deliverOne,
+    markDue,
     list: () => store.getOutbox(),
     remove: messageId => store.updateOutbox(list => list.filter(item => item.messageId !== messageId))
   };

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -10,7 +10,7 @@ import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
  * "saved on the desktop" are different claims, and the difference has to survive the trip to
  * the sidebar rather than being decided by whoever formats the string.
  */
-export function createRouter({ session, intents, outbox, extensionId }) {
+export function createRouter({ session, intents, outbox, drain, extensionId }) {
   async function handle(message) {
     const type = message?.type;
     if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
@@ -55,6 +55,19 @@ export function createRouter({ session, intents, outbox, extensionId }) {
 
     if (type === MSG.listQueue) {
       return { intents: await intents.list(), outbox: await outbox.list() };
+    }
+
+    if (type === MSG.retry) {
+      // The user asking again is not a new decision: the same messageId and the same stamped
+      // epoch go back out, so the desktop can still recognise it as a replay.
+      return drain.retryNow(message.messageId);
+    }
+
+    if (type === MSG.cancel) {
+      // Giving up on the bound message. The intent stays, so the user can pick a different
+      // application or delete it outright.
+      await drain.cancel(message.messageId);
+      return { ok: true };
     }
 
     if (type === MSG.removeIntent) {

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -3,6 +3,7 @@ import { createStore } from './store.mjs';
 import { createSession } from './session.mjs';
 import { createIntents } from './intents.mjs';
 import { createOutbox } from './outbox.mjs';
+import { createDrain, ALARM_NAME } from './drain.mjs';
 import { createRouter } from './router.mjs';
 import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
 
@@ -27,10 +28,15 @@ export function installDesktopLink(api) {
     now: () => new Date()
   };
 
+  const session = createSession(deps);
+  const outbox = createOutbox(deps);
+  const drain = createDrain({ session, outbox, alarms: api.alarms, now: deps.now });
+
   const router = createRouter({
-    session: createSession(deps),
+    session,
     intents: createIntents(deps),
-    outbox: createOutbox(deps),
+    outbox,
+    drain,
     extensionId: api.runtime.id
   });
 
@@ -43,6 +49,15 @@ export function installDesktopLink(api) {
     });
     return true;
   });
+
+  api.alarms.onAlarm.addListener(alarm => {
+    if (alarm?.name !== ALARM_NAME) return;
+    drain.run().catch(() => {});
+  });
+
+  // A cold worker has no timers left from its previous life. Without this pass the queue
+  // waits for an alarm that nothing rescheduled, which for an offline queue means forever.
+  drain.run().catch(() => {});
 
   return router;
 }

--- a/tests/link-drain.test.js
+++ b/tests/link-drain.test.js
@@ -1,0 +1,295 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+const IDENTITY = { archiveId: ARCHIVE, restoreEpoch: EPOCH };
+
+const FIELDS = {
+  company: '星河科技',
+  title: '后端开发',
+  location: '上海',
+  sourceUrl: 'https://jobs.example.com/apply',
+  dedupeUrl: 'https://jobs.example.com/apply'
+};
+
+// One shared storage object survives across "browser restarts": the test throws away every
+// in-memory object and builds new ones over the same data, which is what a fresh service
+// worker sees.
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+function fakeAlarms() {
+  const created = [];
+  return {
+    created,
+    async create(name, options) { created.push({ name, ...options }); },
+    async clear() { return true; },
+    onAlarm: { addListener() {} }
+  };
+}
+
+async function harness({ desktop, storage = fakeStorage(), clock = { value: Date.parse('2026-09-09T00:00:00.000Z') } } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date(clock.value);
+  const sent = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const sendNative = async (host, message) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await Promise.resolve();
+    sent.push(message);
+    const reply = desktop(message);
+    inFlight -= 1;
+    return reply;
+  };
+
+  const store = createStore({ storage, uuid });
+  const deps = { store, uuid, now, sleep: async () => {}, sendNative };
+  const session = createSession(deps);
+  const intents = createIntents(deps);
+  const outbox = createOutbox(deps);
+  const alarms = fakeAlarms();
+  const drain = createDrain({ session, outbox, alarms, now });
+
+  return { drain, outbox, intents, store, storage, sent, alarms, clock, stats: () => ({ maxInFlight }) };
+}
+
+const handshakeReply = message => ({
+  response: {
+    protocolVersion: 1, correlationId: message.messageId, ok: true,
+    payload: {
+      appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1,
+      archiveId: ARCHIVE, restoreEpoch: EPOCH, capabilities: ['handshake', 'job.save']
+    }
+  }
+});
+
+const unavailable = message => ({
+  response: {
+    protocolVersion: 1, correlationId: message.messageId, ok: false,
+    error: { code: 'unavailable', retryable: true, message: 'starting' }, payload: {}
+  }
+});
+
+const saved = message => ({
+  response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId: APPLICATION, payload: {} }
+});
+
+async function bindOne(harnessed, { title = FIELDS.title } = {}) {
+  const { intent } = await harnessed.intents.save({ fields: { ...FIELDS, title }, mode: 'ready' });
+  return harnessed.outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+}
+
+test('the backoff ladder is the documented one and it ends', async () => {
+  const { nextDelayMs } = await import('../link/drain.mjs');
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+
+  BACKOFF_STEPS_MS.forEach((step, index) => {
+    assert.equal(nextDelayMs(index + 1), step);
+  });
+  // Past the last step the entry waits for a person. Retrying forever hides a problem the
+  // user is the only one who can fix.
+  assert.equal(nextDelayMs(BACKOFF_STEPS_MS.length + 1), null);
+});
+
+test('a failed attempt schedules the next one instead of spinning', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+
+  await bindOne(bench);
+  const entry = bench.storage.data.desktopOutbox[0];
+
+  assert.equal(entry.attempts, 1);
+  assert.equal(Date.parse(entry.nextAttemptAt), bench.clock.value + BACKOFF_STEPS_MS[0]);
+});
+
+test('an entry that is not due yet is left alone', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  await bindOne(bench);
+  const before = bench.sent.length;
+
+  await bench.drain.run();
+
+  assert.equal(bench.sent.length, before + 1, 'only the handshake went out');
+});
+
+test('the entry is retried once its delay has passed', async () => {
+  let phase = 'down';
+  const bench = await harness({
+    desktop: message => {
+      if (message.messageType === 'handshake') return handshakeReply(message);
+      return phase === 'down' ? unavailable(message) : saved(message);
+    }
+  });
+  await bindOne(bench);
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+
+  phase = 'up';
+  bench.clock.value += BACKOFF_STEPS_MS[0];
+  const result = await bench.drain.run();
+
+  assert.equal(result.saved.length, 1);
+  assert.deepEqual(bench.storage.data.desktopOutbox, []);
+});
+
+test('a retry keeps the original message id across the whole ladder', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+  await bindOne(bench);
+  const original = bench.sent.at(-1).messageId;
+
+  for (const step of BACKOFF_STEPS_MS) {
+    bench.clock.value += step;
+    await bench.drain.run();
+  }
+
+  const writes = bench.sent.filter(message => message.messageType === 'job.save');
+  assert.ok(writes.length > 1);
+  assert.ok(writes.every(message => message.messageId === original), 'a new id would be a new application');
+});
+
+test('an exhausted ladder stops and asks for a person', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+  await bindOne(bench);
+
+  for (const step of BACKOFF_STEPS_MS) {
+    bench.clock.value += step;
+    await bench.drain.run();
+  }
+  const writesSoFar = bench.sent.filter(message => message.messageType === 'job.save').length;
+  bench.clock.value += 86_400_000;
+  await bench.drain.run();
+
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'stalled');
+  assert.equal(
+    bench.sent.filter(message => message.messageType === 'job.save').length,
+    writesSoFar,
+    'a stalled entry waits for the user, it is not retried'
+  );
+});
+
+test('a manual retry sends a stalled entry again without a new identity', async () => {
+  let phase = 'down';
+  const bench = await harness({
+    desktop: message => {
+      if (message.messageType === 'handshake') return handshakeReply(message);
+      return phase === 'down' ? unavailable(message) : saved(message);
+    }
+  });
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+  await bindOne(bench);
+  const original = bench.sent.at(-1).messageId;
+  for (const step of BACKOFF_STEPS_MS) {
+    bench.clock.value += step;
+    await bench.drain.run();
+  }
+
+  phase = 'up';
+  const result = await bench.drain.retryNow(bench.storage.data.desktopOutbox[0].messageId);
+
+  assert.equal(result.status, 'saved');
+  assert.equal(bench.sent.at(-1).messageId, original);
+});
+
+test('cancelling a queued write stops it reaching the desktop', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  await bindOne(bench);
+  const { messageId } = bench.storage.data.desktopOutbox[0];
+
+  await bench.drain.cancel(messageId);
+  bench.clock.value += 86_400_000;
+  const before = bench.sent.filter(message => message.messageType === 'job.save').length;
+  await bench.drain.run();
+
+  assert.deepEqual(bench.storage.data.desktopOutbox, []);
+  assert.equal(bench.sent.filter(message => message.messageType === 'job.save').length, before);
+});
+
+test('the queue survives a browser restart and keeps draining', async () => {
+  const storage = fakeStorage();
+  const first = await harness({
+    desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)),
+    storage
+  });
+  await bindOne(first);
+  const original = storage.data.desktopOutbox[0].messageId;
+
+  // Everything in memory is gone; only chrome.storage.local survives.
+  const restarted = await harness({
+    desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : saved(message)),
+    storage,
+    clock: { value: Date.parse('2026-09-09T01:00:00.000Z') }
+  });
+  const result = await restarted.drain.run();
+
+  assert.equal(result.saved.length, 1);
+  assert.equal(restarted.sent.at(-1).messageId, original);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.deepEqual(storage.data.desktopSaveIntents, []);
+});
+
+test('two queued writes go out one at a time', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : saved(message)) });
+  await bindOne(bench, { title: '后端开发' });
+  await bindOne(bench, { title: '测试开发' });
+
+  await bench.drain.run();
+
+  // Parallel sends race for the same cold start and the host answers all but one of them
+  // with `unavailable` for no reason at all.
+  assert.equal(bench.stats().maxInFlight, 1);
+});
+
+test('a closed desktop schedules another look instead of failing the queue', async () => {
+  let reachable = true;
+  const bench = await harness({
+    desktop: message => {
+      if (!reachable) return { lastError: 'Error when communicating with the native messaging host.' };
+      return message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message);
+    }
+  });
+  await bindOne(bench);
+  await bench.store.setPairing({ archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 });
+  bench.alarms.created.length = 0;
+
+  // The desktop goes away with work still queued.
+  reachable = false;
+  bench.clock.value += 60_000;
+  const result = await bench.drain.run();
+
+  assert.equal(result.mode, 'unavailable');
+  assert.ok(bench.alarms.created.length > 0, 'nothing would ever wake the worker again');
+});
+
+test('the scheduled alarm respects the browser minimum', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  const { MIN_ALARM_DELAY_MS } = await import('../link/limits.mjs');
+  await bindOne(bench);
+  await bench.store.setPairing({ archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 });
+
+  await bench.drain.run();
+
+  const alarm = bench.alarms.created.at(-1);
+  assert.ok(alarm.delayInMinutes * 60_000 >= MIN_ALARM_DELAY_MS, JSON.stringify(alarm));
+});

--- a/tests/link-outbox.test.js
+++ b/tests/link-outbox.test.js
@@ -28,14 +28,14 @@ function fakeStorage(initial = {}) {
   };
 }
 
-async function harness({ desktop, storage = fakeStorage() } = {}) {
+async function harness({ desktop, storage = fakeStorage(), clock = { value: Date.parse('2026-09-09T00:00:00.000Z') } } = {}) {
   const { createStore } = await import('../link/store.mjs');
   const { createIntents } = await import('../link/intents.mjs');
   const { createOutbox } = await import('../link/outbox.mjs');
 
   let minted = 0;
   const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
-  const now = () => new Date('2026-09-09T00:00:00.000Z');
+  const now = () => new Date(clock.value);
   const store = createStore({ storage, uuid });
   const sent = [];
   const outbox = createOutbox({
@@ -49,7 +49,7 @@ async function harness({ desktop, storage = fakeStorage() } = {}) {
     }
   });
   const intents = createIntents({ store, uuid, now });
-  return { outbox, intents, store, storage, sent };
+  return { outbox, intents, store, storage, sent, clock };
 }
 
 const savedReply = (message, resultId = APPLICATION) => ({
@@ -155,7 +155,7 @@ test('binding to an existing application sends that id and keeps it', async () =
 });
 
 test('the source epoch is stamped at bind time and never refreshed', async () => {
-  const { outbox, intents, storage, sent } = await harness({
+  const { outbox, intents, storage, sent, clock } = await harness({
     desktop: message => errorReply(message, 'unavailable', true)
   });
   const intent = await queuedIntent(intents);
@@ -163,6 +163,7 @@ test('the source epoch is stamped at bind time and never refreshed', async () =>
 
   // The desktop was restored between attempts. The envelope must follow the new identity,
   // the payload must not: rewriting it would replay this job into a different archive.
+  clock.value += 60_000;
   await outbox.drainOnce({ identity: { archiveId: ARCHIVE, restoreEpoch: LATER_EPOCH } });
 
   assert.equal(storage.data.desktopOutbox[0].sourceRestoreEpoch, EPOCH);
@@ -185,7 +186,7 @@ test('an unanswered send leaves the job pending, not saved', async () => {
 
 test('a retry reuses the message id and the replay resolves to one application', async () => {
   let calls = 0;
-  const { outbox, intents, storage, sent } = await harness({
+  const { outbox, intents, storage, sent, clock } = await harness({
     desktop: message => {
       calls += 1;
       // First attempt: the reply is lost. Second: the desktop recognises the identity and
@@ -197,6 +198,7 @@ test('a retry reuses the message id and the replay resolves to one application',
 
   await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
   const first = sent[0].message.messageId;
+  clock.value += 60_000;
   const result = await outbox.drainOnce({ identity: IDENTITY });
 
   assert.equal(sent.at(-1).message.messageId, first, 'a new id would create a second application');

--- a/tests/link-router.test.js
+++ b/tests/link-router.test.js
@@ -44,6 +44,7 @@ async function makeRouter({ reply = () => ({ lastError: 'Error when communicatin
   const { createSession } = await import('../link/session.mjs');
   const { createIntents } = await import('../link/intents.mjs');
   const { createOutbox } = await import('../link/outbox.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
   const { createRouter } = await import('../link/router.mjs');
 
   let minted = 0;
@@ -58,7 +59,9 @@ async function makeRouter({ reply = () => ({ lastError: 'Error when communicatin
   const session = createSession({ store, sendNative, sleep: async () => {}, uuid, now });
   const intents = createIntents({ store, uuid, now });
   const outbox = createOutbox({ store, sendNative, sleep: async () => {}, uuid, now });
-  const router = createRouter({ session, intents, outbox, extensionId: 'abcdefghijklmnopabcdefghijklmnop' });
+  const alarms = { created: [], async create(name, options) { this.created.push({ name, ...options }); }, async clear() { return true; } };
+  const drain = createDrain({ session, outbox, alarms, now });
+  const router = createRouter({ session, intents, outbox, drain, extensionId: 'abcdefghijklmnopabcdefghijklmnop' });
   return { router, storage, sent };
 }
 
@@ -226,4 +229,26 @@ test('the queue listing includes bound messages, not only intents', async () => 
 
   assert.equal(listed.outbox.length, 1);
   assert.equal(listed.outbox[0].messageType, 'job.save');
+});
+
+test('a stalled write can be retried and cancelled from the sidebar', async () => {
+  const { router, storage } = await makeRouter({
+    reply: message => message.messageType === 'handshake'
+      ? handshakeReply(message)
+      : {
+          response: {
+            protocolVersion: 1, correlationId: message.messageId, ok: false,
+            error: { code: 'unavailable', retryable: true, message: 'starting' }, payload: {}
+          }
+        }
+  });
+  const saved = await router.handle({ type: 'DESKTOP_SAVE_JOB', fields: FIELDS });
+  await router.handle({ type: 'DESKTOP_BIND', intentId: saved.intent.intentId });
+  const { messageId } = storage.data.desktopOutbox[0];
+
+  const retried = await router.handle({ type: 'DESKTOP_RETRY', messageId });
+  assert.equal(retried.status, 'pending');
+
+  await router.handle({ type: 'DESKTOP_CANCEL', messageId });
+  assert.deepEqual(storage.data.desktopOutbox, []);
 });

--- a/tests/link-worker.test.js
+++ b/tests/link-worker.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 // listener it registered the way the browser would.
 function fakeChrome({ nativeError = 'Specified native messaging host not found.' } = {}) {
   const listeners = [];
+  listeners.alarm = null;
   return {
     listeners,
     runtime: {
@@ -16,6 +17,13 @@ function fakeChrome({ nativeError = 'Specified native messaging host not found.'
         callback(undefined);
         this.lastError = undefined;
       }
+    },
+    alarms: {
+      created: [],
+      fired: [],
+      async create(name, options) { this.created.push({ name, ...options }); },
+      async clear() { return true; },
+      onAlarm: { addListener(fn) { listeners.alarm = fn; } }
     },
     storage: {
       local: {
@@ -37,6 +45,23 @@ function fakeChrome({ nativeError = 'Specified native messaging host not found.'
     }
   };
 }
+
+const PAIRED = { archiveId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', restoreEpoch: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', at: 1 };
+// A write still waiting to go out. Without queued work the drain deliberately does nothing:
+// probing spawns a native host, and per D06 the host starts the desktop application.
+const QUEUED_WRITE = [{
+  messageId: '55555555-5555-4555-8555-555555555555',
+  intentId: null,
+  clientInstanceId: '11111111-1111-4111-8111-111111111111',
+  messageType: 'job.save',
+  archiveId: PAIRED.archiveId,
+  sourceRestoreEpoch: PAIRED.restoreEpoch,
+  payload: { company: '合成公司', title: '后端实习' },
+  status: 'pending',
+  attempts: 0,
+  nextAttemptAt: '2020-01-01T00:00:00.000Z',
+  lastError: null
+}];
 
 test('the desktop listener answers a probe', async () => {
   const { installDesktopLink } = await import('../link/worker.mjs');
@@ -80,4 +105,59 @@ test('a failure inside the desktop link answers an error instead of hanging the 
 
   assert.equal(result.error, true);
   assert.equal(typeof result.code, 'string');
+});
+
+test('the worker wakes the queue when its alarm fires', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const { ALARM_NAME } = await import('../link/drain.mjs');
+  const api = fakeChrome();
+  api.storage.local._data.desktopPairing = PAIRED;
+  api.storage.local._data.desktopOutbox = QUEUED_WRITE;
+  installDesktopLink(api);
+
+  // Without this the queue only moves when the user happens to open a page again, which is
+  // exactly the case the offline queue exists for.
+  assert.equal(typeof api.listeners.alarm, 'function');
+  api.listeners.alarm({ name: ALARM_NAME });
+  // onAlarm is fire-and-forget in the browser too, so the test waits the same way the
+  // browser does: it lets the work finish on its own.
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.ok(api.alarms.created.length > 0);
+});
+
+test('an alarm that belongs to someone else is ignored', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  installDesktopLink(api);
+  await new Promise(resolve => setTimeout(resolve, 0));
+  const before = api.alarms.created.length;
+
+  api.listeners.alarm({ name: 'someone-elses-alarm' });
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.equal(api.alarms.created.length, before);
+});
+
+test('a queued write is retried when the worker starts', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  api.storage.local._data.desktopPairing = PAIRED;
+  api.storage.local._data.desktopOutbox = QUEUED_WRITE;
+  installDesktopLink(api);
+
+  // A cold worker has no timers left over from its previous life; the queue has to be picked
+  // up on startup or it waits for an alarm that was never rescheduled.
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.ok(api.alarms.created.length > 0);
+});
+
+test('a worker with nothing queued neither probes nor sets an alarm', async () => {
+  const { installDesktopLink } = await import('../link/worker.mjs');
+  const api = fakeChrome();
+  api.storage.local._data.desktopPairing = PAIRED;
+  installDesktopLink(api);
+
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.equal(api.alarms.created.length, 0, 'nothing to do, so nothing to wake for');
 });


### PR DESCRIPTION
D07 第五部分：排队的写入现在能熬过 worker 被回收和浏览器重启，而且会**自己停下来**，不是无限重试。

依赖 #48（已合入）。

## 用 alarm，不用 timer

MV3 会在还有队列项的时候回收 worker，timer 跟着一起死——对一个离线队列来说，那意味着工作要等到用户碰巧再打开一个页面。Chrome 的 alarm 最短 30 秒，所以退避阶梯前几档只在 worker 恰好还活着时生效，其余由 alarm 兜住，晚一点。**晚一点可以，永远不发生不行。**

## 空队列的一趟排空什么都不做

不探测、不排 alarm。探测不是免费的：它会拉起一个 native host，而按 D06 的设计 **host 会按需启动桌面应用**。为一个空队列每 30 秒做一次这个，等于把用户主动关掉的桌面程序反复重新拉起来。

修之前实测：

```
outbox 为空、桌面已关、用户只是在浏览网页
drain.run() x5  ->  host 进程拉起尝试: 10
alarms scheduled: 5   delays(min): 0.5,0.5,0.5,0.5,0.5
```

无限循环。现在：没有 pending 项就直接返回，一次探测都不做。

## 阶梯是有尽头的

走完最后一档，条目变成 `stalled`，等人。无限重试是把一个只有用户能解决的问题藏起来，还要为了藏它反复唤醒 worker。手动重试沿用同一个 `messageId` 和同一个盖好的 epoch——**用户再问一次不是一个新决定**。

手动重试也会拒绝任何归对账流程管的条目（下一个 PR 引入的 paused / needs_user）。

## 排空是串行的

并发发送会抢同一次冷启动，host 会毫无理由地对除一个之外的全部回 `unavailable`。

## 取消

取消删掉绑定消息、保留意图，用户可以改绑到别的申请，而不是丢掉自己确认过的字段。

## 测试

286 passed / 0 failed。有两个既有的 outbox 测试改成推进时钟——条目有了到期时间之后，紧接着的二次排空被正确跳过了。那是新行为在生效，不是在迁就测试。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)