### PR TITLE
feat(d07): pause, reconcile and let the user decide after a restore

### DIFF
--- a/content.js
+++ b/content.js
@@ -1899,6 +1899,11 @@
         entry.payload?.sourceUrl,
         describeOutboxState(entry)
       );
+      if (entry.status === "needs_user" || entry.status === "paused") {
+        appendReconcileChoices(row, entry);
+        list.appendChild(row);
+        continue;
+      }
       row.appendChild(rowButton("立即重试", async () => {
         const { copy } = await loadDesktopModules();
         const result = await chrome.runtime.sendMessage({ type: "DESKTOP_RETRY", messageId: entry.messageId });
@@ -1937,9 +1942,41 @@
     return button;
   }
 
+  // After a restore the queued envelope carries an epoch the desktop has replaced. There is
+  // no "retry" here on purpose: the only ways out are the three the user chooses.
+  function appendReconcileChoices(row, entry) {
+    loadDesktopModules().then(({ copy }) => {
+      const explain = copy.describeReconcileStatus(entry.reconcileStatus);
+      const note = document.createElement("em");
+      note.textContent = explain.text;
+      row.appendChild(note);
+    });
+
+    row.appendChild(rowButton("关联到已有申请", async () => {
+      const applicationId = prompt("要关联到哪条申请？请粘贴桌面里的申请 ID：");
+      if (!applicationId) return;
+      await resolvePaused(entry.messageId, "associate", applicationId.trim());
+    }));
+    row.appendChild(rowButton("另存为新的", () => resolvePaused(entry.messageId, "resave")));
+    row.appendChild(rowButton("丢弃", () => resolvePaused(entry.messageId, "discard")));
+  }
+
+  async function resolvePaused(messageId, choice, applicationId) {
+    const { copy } = await loadDesktopModules();
+    const result = await chrome.runtime.sendMessage({
+      type: "DESKTOP_RESOLVE", messageId, choice, applicationId
+    });
+    if (choice !== "discard") {
+      setDesktopStatus(copy.describeBindResult(result ?? { status: "pending" }));
+    }
+    refreshPendingList();
+  }
+
   // The reason is the plugin's own classification, not the protocol text: the wording table
   // in link/copy.mjs is the only place that turns a code into a sentence.
   function describeOutboxState(entry) {
+    if (entry.status === "paused") return "桌面换过档案库，已暂停";
+    if (entry.status === "needs_user") return "桌面换过档案库，等你决定";
     if (entry.status === "failed") return `已停下，需要处理（${describeFailure(entry.lastError)}）`;
     if (entry.status === "stalled") return `重试多次仍未成功，等你决定（${describeFailure(entry.lastError)}）`;
     const next = entry.nextAttemptAt ? `，下次重试 ${formatClock(entry.nextAttemptAt)}` : "";

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -118,6 +118,14 @@ export function describeBindResult(result) {
     if (reason === 'unknown_intent') {
       return { tone: 'warn', text: '这条待同步记录已经不在了，请重新保存一次。' };
     }
+    if (reason === 'awaiting_reconcile' || reason === 'not_paused') {
+      // Not "try later": this entry is waiting on a decision only the user can make, and
+      // telling them to retry sends them round a loop that cannot succeed.
+      return {
+        tone: 'warn',
+        text: '桌面换过档案库，这条不能直接重试，要先对账。请选择关联到已有申请、另存为新的，或者丢弃。'
+      };
+    }
     return { tone: 'warn', text: '这次没能绑定，请稍后再试。填表功能不受影响。' };
   }
 
@@ -126,4 +134,24 @@ export function describeBindResult(result) {
   }
 
   return { tone: 'warn', text: '这次没能保存到桌面，已经留在待同步里。' };
+}
+
+// What the four unresolved reconcile answers mean, and why none of them is a retry button.
+//
+// After a restore the queued envelope carries an epoch the desktop has replaced. Sending it
+// again is refused; sending it under the new epoch would be a different write the user never
+// asked for. So every one of these ends in a choice the user makes.
+const RECONCILE = {
+  purged: '这条在桌面上已经被永久删除了。桌面不会重建它。',
+  not_found: '当前档案库里没有找到这次写入的凭据。这不等于没有执行过——可能只是这份备份不含它。请先到桌面核对。',
+  conflict: '桌面上有一条身份相同但内容不同的记录，没有自动处理。',
+  unverifiable: '桌面无法核实这次写入是否发生过，不会自动重放。'
+};
+
+export function describeReconcileStatus(status) {
+  return {
+    tone: 'warn',
+    text: RECONCILE[status] ?? '桌面换过档案库，这条要你决定怎么处理。',
+    choices: ['associate', 'discard', 'resave']
+  };
 }

--- a/link/drain.mjs
+++ b/link/drain.mjs
@@ -21,7 +21,7 @@ export function nextDelayMs(attempts) {
  * short rungs of the ladder only apply while the worker happens to still be alive; the alarm
  * catches everything else a little later. Later is fine. Never is not.
  */
-export function createDrain({ session, outbox, alarms, now }) {
+export function createDrain({ session, outbox, reconcile = null, alarms, now }) {
   async function run() {
     // Nothing queued means nothing to do, and probing is not free: it spawns a native host,
     // and per D06 the host starts the desktop application on demand. Waking every thirty
@@ -40,15 +40,19 @@ export function createDrain({ session, outbox, alarms, now }) {
       return { mode: probe.mode, saved: [], pending: [], failed: [] };
     }
 
+    // Pausing comes first, in the same pass. A stale entry that reaches drainOnce would be
+    // sent under an epoch the user never chose.
+    if (reconcile) await reconcile.pauseStale(probe.identity);
     const result = await outbox.drainOnce({ identity: probe.identity });
+    const reconciled = reconcile ? await reconcile.run(probe.identity) : null;
     await scheduleNext();
-    return { mode: probe.mode, ...result };
+    return { mode: probe.mode, ...result, reconciled };
   }
 
-  // Work the queue can make progress on by itself. Entries waiting for a person — stalled or
-  // failed — are not work.
+  // Work the queue can make progress on by itself: a pending entry to send, or a paused one
+  // waiting to be reconciled against the archive that exists now.
   async function hasWork() {
-    return (await outbox.list()).some(entry => entry.status === 'pending');
+    return (await outbox.list()).some(entry => entry.status === 'pending' || entry.status === 'paused');
   }
 
   async function retryNow(messageId) {

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -8,7 +8,8 @@ export const MSG = {
   listQueue: 'DESKTOP_LIST_QUEUE',
   removeIntent: 'DESKTOP_REMOVE_INTENT',
   retry: 'DESKTOP_RETRY',
-  cancel: 'DESKTOP_CANCEL'
+  cancel: 'DESKTOP_CANCEL',
+  resolve: 'DESKTOP_RESOLVE'
 };
 
 export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/reconcile.mjs
+++ b/link/reconcile.mjs
@@ -1,0 +1,172 @@
+import { buildEnvelope } from './envelope.mjs';
+import { sendOnce } from './transport.mjs';
+import {
+  MAX_RECONCILE_ITEMS,
+  payloadBodySha256,
+  snapshotChunkIdentitySha256
+} from './protocol/validate.mjs';
+
+/**
+ * What happens to the queue when the desktop's archive has been restored.
+ *
+ * A restore mints a new `restoreEpoch`. Every queued message stamped with the old one is
+ * paused immediately: the desktop would refuse it, and if it did not, the job would land in
+ * an archive the user never chose. Paused messages may only ask a read-only question —
+ * `outbox.reconcile` — and the answer never authorises a replay.
+ */
+export function createReconcile({ store, outbox, uuid, now, sendNative, sleep }) {
+  const wire = { sendNative, sleep };
+
+  /** Freeze everything whose bound epoch is not the current one. */
+  async function pauseStale(identity) {
+    await store.updateOutbox(list => list.map(entry => {
+      if (entry.sourceRestoreEpoch === identity.restoreEpoch) return entry;
+      if (entry.status === 'paused' || entry.status === 'needs_user') return entry;
+      return { ...entry, status: 'paused', nextAttemptAt: null };
+    }));
+  }
+
+  /** Ask the desktop what it knows about each paused message. */
+  async function run(identity) {
+    const paused = (await store.getOutbox()).filter(entry => entry.status === 'paused');
+    const report = { applied: [], needsUser: [], unreachable: [] };
+
+    for (let at = 0; at < paused.length; at += MAX_RECONCILE_ITEMS) {
+      const batch = paused.slice(at, at + MAX_RECONCILE_ITEMS);
+      const items = await Promise.all(batch.map(identityOf));
+
+      const message = await buildEnvelope({
+        messageType: 'outbox.reconcile',
+        messageId: uuid(),
+        clientInstanceId: await store.clientInstanceId(),
+        payload: { items },
+        identity,
+        now
+      });
+
+      const result = await sendOnce(message, wire);
+      if (result.status !== 'ok') {
+        report.unreachable.push(...batch.map(entry => entry.messageId));
+        continue;
+      }
+
+      for (const answer of result.response.payload.items) {
+        const entry = batch.find(item => item.messageId === answer.messageId);
+        if (!entry) continue;
+
+        if (answer.status === 'applied') {
+          // The desktop already executed it. Drop the queue entry and the intent behind it,
+          // and add nothing: `applied` confirms history, it does not license a rewrite.
+          await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+          if (entry.intentId) {
+            await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
+          }
+          report.applied.push({ messageId: entry.messageId, resultId: answer.resultId });
+          continue;
+        }
+
+        // purged, not_found, conflict, unverifiable: all four stop here. In particular
+        // not_found means "this archive holds no receipt", never "this never happened".
+        await patch(entry.messageId, item => ({
+          ...item,
+          status: 'needs_user',
+          reconcileStatus: answer.status,
+          nextAttemptAt: null
+        }));
+        report.needsUser.push({ messageId: entry.messageId, status: answer.status });
+      }
+    }
+
+    return report;
+  }
+
+  /**
+   * The three ways out of a paused message: bind it to an application, discard it, or write
+   * it again under a new identity.
+   *
+   * The replacement is persisted before it is sent. Without that, a failed send would mint a
+   * third identity on the next attempt and the user would have asked once for two writes.
+   */
+  async function resolve(messageId, { choice, applicationId = null, identity = null }) {
+    const entry = (await store.getOutbox()).find(item => item.messageId === messageId);
+    if (!entry) return { status: 'rejected', reason: 'unknown_message' };
+    if (entry.status !== 'paused' && entry.status !== 'needs_user') {
+      // A sidebar rendered before a drain pass can still be showing these buttons for an
+      // entry that is back on the normal ladder. Minting a replacement identity for a
+      // message that may already be in flight is how one decision becomes two applications.
+      return { status: 'rejected', reason: 'not_paused' };
+    }
+
+    if (choice === 'discard') {
+      await store.updateOutbox(list => list.filter(item => item.messageId !== messageId));
+      if (entry.intentId) {
+        await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
+      }
+      return { status: 'discarded' };
+    }
+
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+
+    const payload = { ...entry.payload };
+    delete payload.sourceRestoreEpoch;
+    delete payload.payloadSha256;
+    if (choice === 'associate') {
+      if (!applicationId) return { status: 'rejected', reason: 'no_application' };
+      payload.applicationId = applicationId;
+    }
+
+    const replacement = {
+      ...entry,
+      messageId: uuid(),
+      archiveId: identity.archiveId,
+      sourceRestoreEpoch: identity.restoreEpoch,
+      applicationId: payload.applicationId ?? null,
+      payload,
+      status: 'pending',
+      attempts: 0,
+      nextAttemptAt: now().toISOString(),
+      reconcileStatus: null,
+      lastError: null,
+      // Keeps the trail from the old archive to the new write. The old envelope is never
+      // valid again; this is a record, not a credential.
+      previousIdentity: {
+        clientInstanceId: entry.clientInstanceId,
+        messageId: entry.messageId,
+        sourceRestoreEpoch: entry.sourceRestoreEpoch
+      }
+    };
+
+    await store.updateOutbox(list => [
+      ...list.filter(item => item.messageId !== messageId),
+      replacement
+    ]);
+
+    return outbox.deliverOne(replacement.messageId, identity);
+  }
+
+  // Full prior identity, exactly as §8.11 specifies. The digest is recomputed from the stored
+  // payload the same way it was computed when the message was first built.
+  async function identityOf(entry) {
+    const body = { ...entry.payload, sourceRestoreEpoch: entry.sourceRestoreEpoch };
+    delete body.payloadSha256;
+    // A chunk's receipt digest is its immutable identity (snapshot/index/application/count/
+    // length/hashes), not the payload body — the body carries the bytes, which the receipt
+    // deliberately does not. Using the wrong one makes the desktop answer conflict or
+    // not_found for chunks it is actually holding.
+    const digest = entry.messageType === 'snapshot.chunk'
+      ? await snapshotChunkIdentitySha256(body)
+      : await payloadBodySha256(body);
+    return {
+      clientInstanceId: entry.clientInstanceId,
+      messageId: entry.messageId,
+      sourceRestoreEpoch: entry.sourceRestoreEpoch,
+      payloadSha256: digest
+    };
+  }
+
+  const patch = (messageId, change) => store.updateOutbox(list =>
+    list.map(item => (item.messageId === messageId ? change(item) : item))
+  );
+
+  return { pauseStale, run, resolve };
+}

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -10,7 +10,7 @@ import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
  * "saved on the desktop" are different claims, and the difference has to survive the trip to
  * the sidebar rather than being decided by whoever formats the string.
  */
-export function createRouter({ session, intents, outbox, drain, extensionId }) {
+export function createRouter({ session, intents, outbox, drain, reconcile, extensionId }) {
   async function handle(message) {
     const type = message?.type;
     if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
@@ -68,6 +68,17 @@ export function createRouter({ session, intents, outbox, drain, extensionId }) {
       // application or delete it outright.
       await drain.cancel(message.messageId);
       return { ok: true };
+    }
+
+    if (type === MSG.resolve) {
+      // Associate, discard or save again. Only the user gets to make this call: none of the
+      // four unresolved reconcile answers authorises the plugin to decide on its own.
+      const probe = message.choice === 'discard' ? { identity: null } : await session.probe();
+      return reconcile.resolve(message.messageId, {
+        choice: message.choice,
+        applicationId: message.applicationId ?? null,
+        identity: probe.identity
+      });
     }
 
     if (type === MSG.removeIntent) {

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -3,6 +3,7 @@ import { createStore } from './store.mjs';
 import { createSession } from './session.mjs';
 import { createIntents } from './intents.mjs';
 import { createOutbox } from './outbox.mjs';
+import { createReconcile } from './reconcile.mjs';
 import { createDrain, ALARM_NAME } from './drain.mjs';
 import { createRouter } from './router.mjs';
 import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
@@ -30,13 +31,15 @@ export function installDesktopLink(api) {
 
   const session = createSession(deps);
   const outbox = createOutbox(deps);
-  const drain = createDrain({ session, outbox, alarms: api.alarms, now: deps.now });
+  const reconcile = createReconcile({ ...deps, outbox });
+  const drain = createDrain({ session, outbox, reconcile, alarms: api.alarms, now: deps.now });
 
   const router = createRouter({
     session,
     intents: createIntents(deps),
     outbox,
     drain,
+    reconcile,
     extensionId: api.runtime.id
   });
 

--- a/tests/link-copy.test.js
+++ b/tests/link-copy.test.js
@@ -170,3 +170,39 @@ test('a second bind for the same posting says it is already queued', async () =>
   assert.match(copy.text, /已经|队列/);
   assert.equal(copy.text.includes('没能'), false, 'the first click did work');
 });
+
+// --- reconciliation --------------------------------------------------------
+
+test('every reconcile verdict has its own explanation and none offers a plain retry', async () => {
+  const { describeReconcileStatus } = await load();
+
+  for (const status of ['purged', 'not_found', 'conflict', 'unverifiable']) {
+    const copy = describeReconcileStatus(status);
+    assert.equal(typeof copy.text, 'string');
+    assert.notEqual(copy.text, '');
+    // The only ways out are associate, discard and save-again. A plain "retry" would send an
+    // envelope stamped with an epoch the desktop has already replaced.
+    assert.deepEqual(copy.choices.sort(), ['associate', 'discard', 'resave']);
+  }
+});
+
+test('not_found says a receipt is missing and says that is not proof', async () => {
+  const { describeReconcileStatus } = await load();
+
+  const copy = describeReconcileStatus('not_found');
+
+  // §8.11: "not_found" means this archive holds no receipt, never "this never happened".
+  // The disclaimer has to be in the sentence the user reads, not only in the spec.
+  assert.match(copy.text, /没有找到|无法证明|凭据/);
+  assert.match(copy.text, /不等于|不代表|不能据此/);
+});
+
+test('a retry refused because the archive changed says so', async () => {
+  const { describeBindResult } = await load();
+  // Not "try later": this entry is waiting on a decision the user has to make, and telling
+  // them to retry sends them round a loop that cannot succeed.
+  const copy = describeBindResult({ status: 'rejected', reason: 'awaiting_reconcile' });
+
+  assert.match(copy.text, /档案库|对账/);
+  assert.equal(copy.text.includes('稍后再试'), false);
+});

--- a/tests/link-drain.test.js
+++ b/tests/link-drain.test.js
@@ -293,3 +293,110 @@ test('the scheduled alarm respects the browser minimum', async () => {
   const alarm = bench.alarms.created.at(-1);
   assert.ok(alarm.delayInMinutes * 60_000 >= MIN_ALARM_DELAY_MS, JSON.stringify(alarm));
 });
+
+test('a restored archive is noticed before anything is sent', async () => {
+  const { createReconcile } = await import('../link/reconcile.mjs');
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+
+  const NEW_EPOCH = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+  const storage = fakeStorage();
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const clock = { value: Date.parse('2026-09-09T00:00:00.000Z') };
+  const now = () => new Date(clock.value);
+  const sent = [];
+  let epoch = EPOCH;
+  const sendNative = async (host, message) => {
+    sent.push(message);
+    if (message.messageType === 'handshake') {
+      return {
+        response: {
+          protocolVersion: 1, correlationId: message.messageId, ok: true,
+          payload: {
+            appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1,
+            archiveId: ARCHIVE, restoreEpoch: epoch, capabilities: ['handshake', 'job.save']
+          }
+        }
+      };
+    }
+    if (message.messageType === 'outbox.reconcile') {
+      return {
+        response: {
+          protocolVersion: 1, correlationId: message.messageId, ok: true,
+          payload: { items: message.payload.items.map(item => ({ ...item, status: 'not_found' })) }
+        }
+      };
+    }
+    return unavailable(message);
+  };
+
+  const store = createStore({ storage, uuid });
+  const deps = { store, uuid, now, sleep: async () => {}, sendNative };
+  const outbox = createOutbox(deps);
+  const drain = createDrain({
+    session: createSession(deps),
+    outbox,
+    reconcile: createReconcile({ ...deps, outbox }),
+    alarms: fakeAlarms(),
+    now
+  });
+  const intents = createIntents(deps);
+
+  const { intent } = await intents.save({ fields: FIELDS, mode: 'ready' });
+  await outbox.bindAndSend({ intentId: intent.intentId, identity: IDENTITY });
+
+  epoch = NEW_EPOCH;
+  clock.value += 3_600_000;
+  await drain.run();
+
+  // The pause has to happen inside the same pass, before the drain looks for due entries.
+  assert.equal(storage.data.desktopOutbox[0].status, 'needs_user');
+  assert.equal(storage.data.desktopOutbox[0].reconcileStatus, 'not_found');
+});
+
+test('an empty queue does not wake the worker or start the desktop', async () => {
+  const bench = await harness({ desktop: () => ({ lastError: 'Error when communicating with the native messaging host.' }) });
+  await bench.store.setPairing({ archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 });
+
+  await bench.drain.run();
+  await bench.drain.run();
+
+  // Probing spawns a native host, and per D06 the host starts the application on demand.
+  // Doing that on a timer with nothing queued restarts a desktop the user deliberately
+  // closed, over and over, for no work at all.
+  assert.equal(bench.sent.length, 0, 'nothing to send, so nothing should have been sent');
+  assert.equal(bench.alarms.created.length, 0, 'nothing to do later, so nothing to wake for');
+});
+
+test('a queued write still schedules a look even when the desktop is closed', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  await bindOne(bench);
+  bench.alarms.created.length = 0;
+
+  await bench.drain.run();
+
+  assert.ok(bench.alarms.created.length > 0, 'work is queued, so something has to come back for it');
+});
+
+test('entries that are only waiting for the user do not keep the worker awake', async () => {
+  const bench = await harness({ desktop: message => (message.messageType === 'handshake' ? handshakeReply(message) : unavailable(message)) });
+  const { BACKOFF_STEPS_MS } = await import('../link/limits.mjs');
+  await bindOne(bench);
+  for (const step of BACKOFF_STEPS_MS) {
+    bench.clock.value += step;
+    await bench.drain.run();
+  }
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'stalled');
+
+  bench.alarms.created.length = 0;
+  bench.sent.length = 0;
+  bench.clock.value += 86_400_000;
+  await bench.drain.run();
+
+  assert.equal(bench.sent.length, 0);
+  assert.equal(bench.alarms.created.length, 0);
+});

--- a/tests/link-reconcile.test.js
+++ b/tests/link-reconcile.test.js
@@ -1,0 +1,407 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OLD_EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const NEW_EPOCH = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+
+const FIELDS = {
+  company: '星河科技',
+  title: '后端开发',
+  location: '上海',
+  sourceUrl: 'https://jobs.example.com/apply',
+  dedupeUrl: 'https://jobs.example.com/apply'
+};
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+async function harness({ desktop, storage = fakeStorage(), clock = { value: Date.parse('2026-09-09T00:00:00.000Z') } } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createReconcile } = await import('../link/reconcile.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date(clock.value);
+  const sent = [];
+  const deps = {
+    store: createStore({ storage, uuid }),
+    uuid,
+    now,
+    sleep: async () => {},
+    sendNative: async (host, message) => {
+      sent.push(message);
+      return desktop(message);
+    }
+  };
+  const outbox = createOutbox(deps);
+  const reconcile = createReconcile({ ...deps, outbox });
+  const intents = createIntents(deps);
+  return { reconcile, outbox, intents, store: deps.store, storage, sent, clock };
+}
+
+const unavailable = message => ({
+  response: {
+    protocolVersion: 1, correlationId: message.messageId, ok: false,
+    error: { code: 'unavailable', retryable: true, message: 'starting' }, payload: {}
+  }
+});
+
+// A reconcile answer must echo each requested identity exactly; D05 refuses anything else.
+// `writes` is shared with staleEntry: the original send has to fail, or there would be no
+// queued message left to reconcile.
+const reconcileReply = (statusFor, writes = { ok: true }) => message => {
+  if (message.messageType !== 'outbox.reconcile') {
+    return writes.ok
+      ? { response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId: APPLICATION, payload: {} } }
+      : unavailable(message);
+  }
+  return {
+    response: {
+      protocolVersion: 1,
+      correlationId: message.messageId,
+      ok: true,
+      payload: {
+        items: message.payload.items.map(item => {
+          const status = statusFor(item);
+          const answered = { ...item, status };
+          if (status === 'applied') answered.resultId = APPLICATION;
+          return answered;
+        })
+      }
+    }
+  };
+};
+
+/** Queue one bound message stamped with the old epoch, left unsent. */
+async function staleEntry(bench, writes) {
+  const wasOk = writes.ok;
+  writes.ok = false;
+  const { intent } = await bench.intents.save({ fields: FIELDS, mode: 'ready' });
+  await bench.outbox.bindAndSend({
+    intentId: intent.intentId,
+    identity: { archiveId: ARCHIVE, restoreEpoch: OLD_EPOCH }
+  });
+  writes.ok = wasOk;
+  return bench.storage.data.desktopOutbox.at(-1);
+}
+
+const current = { archiveId: ARCHIVE, restoreEpoch: NEW_EPOCH };
+
+test('a restored archive pauses every message stamped with the old epoch', async () => {
+  const bench = await harness({ desktop: unavailable });
+  await staleEntry(bench, { ok: false });
+
+  await bench.reconcile.pauseStale(current);
+
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'paused');
+});
+
+test('a paused message is never sent as a write again', async () => {
+  const bench = await harness({ desktop: unavailable });
+  await staleEntry(bench, { ok: false });
+  await bench.reconcile.pauseStale(current);
+  bench.clock.value += 86_400_000;
+  const before = bench.sent.filter(message => message.messageType === 'job.save').length;
+
+  await bench.outbox.drainOnce({ identity: current });
+
+  // The old envelope must never go out again: the desktop would refuse it, and if it did
+  // not, the job would land in an archive the user never chose.
+  const after = bench.sent.filter(message => message.messageType === 'job.save').length;
+  assert.equal(after, before, 'nothing was sent after the pause');
+});
+
+test('a message stamped with the current epoch keeps going', async () => {
+  const bench = await harness({ desktop: unavailable });
+  const { intent } = await bench.intents.save({ fields: FIELDS, mode: 'ready' });
+  await bench.outbox.bindAndSend({ intentId: intent.intentId, identity: current });
+
+  await bench.reconcile.pauseStale(current);
+
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'pending');
+});
+
+test('applied means the desktop already did it: no new event, no replay licence', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'applied', writeState) });
+  await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+
+  const before = bench.sent.filter(message => message.messageType === 'job.save').length;
+  const report = await bench.reconcile.run(current);
+
+  assert.equal(report.applied.length, 1);
+  assert.deepEqual(bench.storage.data.desktopOutbox, []);
+  const after = bench.sent.filter(message => message.messageType === 'job.save').length;
+  assert.equal(after, before, 'reconcile must not re-send the write it just confirmed');
+});
+
+test('purged is not rebuilt', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'purged', writeState) });
+  await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+
+  await bench.reconcile.run(current);
+
+  assert.equal(bench.storage.data.desktopOutbox[0].reconcileStatus, 'purged');
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'needs_user');
+});
+
+test('not_found does not authorise a rewrite', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+  const before = bench.sent.filter(message => message.messageType === 'job.save').length;
+
+  await bench.reconcile.run(current);
+
+  // "This backup holds no receipt" is not "this never happened". Rewriting on that basis is
+  // how a restore turns into a duplicate.
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'needs_user');
+  assert.equal(bench.storage.data.desktopOutbox[0].reconcileStatus, 'not_found');
+  const after = bench.sent.filter(message => message.messageType === 'job.save').length;
+  assert.equal(after, before, 'not_found must not trigger a rewrite');
+});
+
+test('conflict and unverifiable both stop for the user', async () => {
+  for (const status of ['conflict', 'unverifiable']) {
+    const writeState = { ok: true };
+    const bench = await harness({ desktop: reconcileReply(() => status, writeState) });
+    await staleEntry(bench, writeState);
+    await bench.reconcile.pauseStale(current);
+
+    await bench.reconcile.run(current);
+
+    assert.equal(bench.storage.data.desktopOutbox[0].status, 'needs_user', status);
+    assert.equal(bench.storage.data.desktopOutbox[0].reconcileStatus, status);
+  }
+});
+
+test('reconcile batches stay within the protocol limit', async () => {
+  const { MAX_RECONCILE_ITEMS } = await import('../link/protocol/validate.mjs');
+  const writeState = { ok: false };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  for (let i = 0; i < MAX_RECONCILE_ITEMS + 1; i += 1) {
+    const { intent } = await bench.intents.save({ fields: { ...FIELDS, title: `岗位 ${i}` }, mode: 'ready' });
+    await bench.outbox.bindAndSend({
+      intentId: intent.intentId,
+      identity: { archiveId: ARCHIVE, restoreEpoch: OLD_EPOCH }
+    });
+  }
+  await bench.reconcile.pauseStale(current);
+
+  await bench.reconcile.run(current);
+
+  const batches = bench.sent.filter(message => message.messageType === 'outbox.reconcile');
+  assert.equal(batches.length, 2);
+  assert.ok(batches.every(batch => batch.payload.items.length <= MAX_RECONCILE_ITEMS));
+});
+
+test('the reconcile envelope uses the current identity and the items keep the old one', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+
+  await bench.reconcile.run(current);
+
+  const batch = bench.sent.find(message => message.messageType === 'outbox.reconcile');
+  assert.equal(batch.restoreEpoch, NEW_EPOCH);
+  assert.equal(batch.payload.items[0].sourceRestoreEpoch, OLD_EPOCH);
+  assert.equal(batch.payload.items[0].messageId, entry.messageId);
+});
+
+test('discarding a paused message drops it and the fields behind it', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+  await bench.reconcile.run(current);
+
+  await bench.reconcile.resolve(entry.messageId, { choice: 'discard' });
+
+  assert.deepEqual(bench.storage.data.desktopOutbox, []);
+  assert.deepEqual(bench.storage.data.desktopSaveIntents, []);
+});
+
+test('saving again mints one new identity and records the old one', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+  await bench.reconcile.run(current);
+
+  const result = await bench.reconcile.resolve(entry.messageId, { choice: 'resave', identity: current });
+
+  assert.equal(result.status, 'saved');
+  const write = bench.sent.filter(message => message.messageType === 'job.save').at(-1);
+  assert.notEqual(write.messageId, entry.messageId);
+  assert.equal(write.payload.sourceRestoreEpoch, NEW_EPOCH);
+});
+
+test('a retry after saving again does not mint a third identity', async () => {
+  let allowWrite = false;
+  const bench = await harness({
+    desktop: message => {
+      if (message.messageType === 'outbox.reconcile') return reconcileReply(() => 'not_found')(message);
+      if (!allowWrite) return unavailable(message);
+      return { response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId: APPLICATION, payload: {} } };
+    }
+  });
+  const entry = await staleEntry(bench, { ok: false });
+  await bench.reconcile.pauseStale(current);
+  await bench.reconcile.run(current);
+
+  // The conversion is persisted before it is sent, so a failed send retries the new identity
+  // rather than creating yet another one.
+  await bench.reconcile.resolve(entry.messageId, { choice: 'resave', identity: current });
+  const minted = bench.storage.data.desktopOutbox[0].messageId;
+  allowWrite = true;
+  bench.clock.value += 60_000;
+  await bench.outbox.drainOnce({ identity: current });
+
+  const writes = bench.sent.filter(message => message.messageType === 'job.save');
+  const identities = new Set(writes.map(message => message.messageId));
+  assert.deepEqual([...identities].sort(), [entry.messageId, minted].sort());
+});
+
+test('the resaved message remembers what it came from', async () => {
+  const writeState = { ok: false };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+  await bench.reconcile.run(current);
+
+  await bench.reconcile.resolve(entry.messageId, { choice: 'resave', identity: current });
+
+  const replacement = bench.storage.data.desktopOutbox[0];
+  assert.equal(replacement.previousIdentity.messageId, entry.messageId);
+  assert.equal(replacement.previousIdentity.sourceRestoreEpoch, OLD_EPOCH);
+});
+
+test('associating binds the paused fields to an application the user names', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+  await bench.reconcile.run(current);
+
+  await bench.reconcile.resolve(entry.messageId, {
+    choice: 'associate',
+    applicationId: '99999999-9999-4999-8999-999999999999',
+    identity: current
+  });
+
+  const write = bench.sent.filter(message => message.messageType === 'job.save').at(-1);
+  assert.equal(write.payload.applicationId, '99999999-9999-4999-8999-999999999999');
+});
+
+test('reconciliation leaves intents alone so they get fresh candidates', async () => {
+  const writeState = { ok: true };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+
+  await bench.reconcile.run(current);
+
+  // An intent carries no epoch, so there is nothing to reconcile. It goes back through
+  // candidate selection against the archive that exists now.
+  assert.equal(bench.storage.data.desktopSaveIntents.length, 1);
+  assert.equal(bench.sent.some(message => message.messageType === 'application.queryCandidates'), false);
+});
+
+test('a manual retry cannot revive a paused message', async () => {
+  const { createSession } = await import('../link/session.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+  const writeState = { ok: false };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  await bench.reconcile.pauseStale(current);
+
+  const drain = createDrain({
+    session: createSession({
+      store: bench.store,
+      sendNative: async () => ({ lastError: 'unreachable' }),
+      sleep: async () => {},
+      uuid: () => '00000000-0000-4000-8000-00000000ffff',
+      now: () => new Date(bench.clock.value)
+    }),
+    outbox: bench.outbox,
+    alarms: { created: [], async create() {}, async clear() { return true; } },
+    now: () => new Date(bench.clock.value)
+  });
+  const before = bench.sent.filter(message => message.messageType === 'job.save').length;
+
+  // The sidebar hides retry for a paused row, but the message path takes any messageId. A
+  // revived paused entry goes out under an epoch the desktop has already replaced.
+  const result = await drain.retryNow(entry.messageId);
+
+  assert.equal(bench.storage.data.desktopOutbox[0].status, 'paused');
+  assert.equal(bench.sent.filter(message => message.messageType === 'job.save').length, before);
+  assert.equal(result.status, 'rejected');
+});
+
+test('saving again is refused for a message that is not paused', async () => {
+  const writeState = { ok: false };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const entry = await staleEntry(bench, writeState);
+  // Never paused: this entry is still on the normal retry ladder.
+
+  const result = await bench.reconcile.resolve(entry.messageId, { choice: 'resave', identity: current });
+
+  assert.equal(result.status, 'rejected');
+  assert.equal(bench.storage.data.desktopOutbox.length, 1);
+  assert.equal(bench.storage.data.desktopOutbox[0].messageId, entry.messageId);
+});
+
+test('a snapshot chunk reconciles on its chunk identity, not its payload body', async () => {
+  const { snapshotChunkIdentitySha256 } = await import('../link/protocol/validate.mjs');
+  const writeState = { ok: false };
+  const bench = await harness({ desktop: reconcileReply(() => 'not_found', writeState) });
+  const chunkPayload = {
+    snapshotId: '44444444-4444-4444-8444-444444444444',
+    applicationId: APPLICATION,
+    chunkIndex: 0,
+    chunkCount: 1,
+    chunkSha256: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    snapshotSha256: '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    byteSize: 5,
+    bytesBase64: 'aGVsbG8='
+  };
+  await bench.store.updateOutbox(() => [{
+    messageId: '55555555-5555-4555-8555-555555555555',
+    intentId: null,
+    clientInstanceId: '00000000-0000-4000-8000-000000000001',
+    messageType: 'snapshot.chunk',
+    archiveId: ARCHIVE,
+    sourceRestoreEpoch: OLD_EPOCH,
+    payload: chunkPayload,
+    status: 'paused',
+    attempts: 0,
+    nextAttemptAt: null
+  }]);
+
+  await bench.reconcile.run(current);
+
+  // D05 stores a chunk's receipt digest as the immutable chunk identity. Sending the payload
+  // body digest instead makes the desktop answer conflict or not_found for chunks it holds.
+  const batch = bench.sent.find(message => message.messageType === 'outbox.reconcile');
+  const expected = await snapshotChunkIdentitySha256({ ...chunkPayload, sourceRestoreEpoch: OLD_EPOCH });
+  assert.equal(batch.payload.items[0].payloadSha256, expected);
+});


### PR DESCRIPTION
D07 第六部分：桌面恢复过备份之后，旧队列不许静默重放。

依赖 #49（已合入）。

## 暂停发生在发送之前，同一趟里

恢复会新铸 `restoreEpoch`。每条盖着旧 epoch 的队列项在 `drainOnce` 去找到期条目**之前**就被暂停——走到线上的旧信封，会被写进一个用户从没选过的档案库。

## 暂停项只能问一个只读问题

`outbox.reconcile`：信封用当前握手，每项带完整旧身份，批次不超过协议的 32。

快照分片按**不可变块身份**对账，不是载荷正文摘要。正文带着字节，而回执刻意不带——用错的那个，桌面会对自己明明持有的分片回 `conflict` 或 `not_found`。（D07 不发快照，但 D08 会撞上。）

## 四种未解决答复，没有一种授权插件自己动手

| 状态 | 含义 |
| --- | --- |
| `purged` | 已永久删除，不重建 |
| `not_found` | **这个档案库里没有凭据——不等于没有执行过** |
| `conflict` | 同身份不同摘要，要人来看 |
| `unverifiable` | 无法证明，两个方向都不行 |

所以暂停项上**没有重试按钮**，只有关联 / 丢弃 / 另存。两条通往「重试」的后门也都堵上了：

- 手动重试拒绝任何归对账管的条目
- 另存拒绝一条并未暂停的消息——侧边栏可能还停留在一次排空之前的渲染上，而给一条可能仍在途中的消息铸一个替代身份，正是「一个决定变成两条申请」的做法

## `not_found` 的文案

免责声明写在用户真正会读到的那句话里，不是只写在规格书里。测试断言的是「必须含有免责说明」，而不是「不许出现某些词」——后者会因为一句正确的否定句而误报。

## 另存

只铸**一个**新身份，并且**先落盘再发送**。否则一次发送失败就会在下次尝试时铸出第三个身份,用户问了一次却写了两次。替代消息记住自己从哪来——这是一条记录，不是凭证：旧信封永远不会再生效。

## 意图不受影响

意图不盖 epoch，没有东西可对账。它们会对着**现在存在的**那个档案库重新走候选选择。

## 测试

311 passed / 0 failed。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)