### PR TITLE
feat(d07): confirm a submission, lock the degradation wording, and the browser acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,10 +456,28 @@ ai-client.js           请求进程准备及客户端取消顺序控制
 ai-helpers.js          字段匹配、数据清洗和辅助规则
 form-agent.js          受限新增计划、分组识别和执行检查
 resume-utils.js        PDF 文本、版本比较和错误提示辅助逻辑
+link/                  桌面程序连接：保存岗位、待同步队列、Native Messaging
+link/protocol/         D05 协议校验器的 vendored 副本（改动请改源文件后重新复制）
 vendor/pdfjs/          随扩展打包的 PDF.js 运行文件和许可证
 tests/                 单元测试
 icons/                 插件图标
 ```
+
+### 桌面程序连接（D07）
+
+装了 Resume Pro 桌面程序之后，侧边栏多出「保存岗位到本地」和「确认已投递」。**没装桌面程序时这两个按钮之外的一切照旧**：模板、AI 填写、手动取消都不依赖它。
+
+几条不能含糊的规则，改这块代码前先看一眼：
+
+- **「待同步」不等于「桌面已保存」。** 只有桌面持久化并回了 `resultId`，界面才允许说已保存。全部文案集中在 [`link/copy.mjs`](link/copy.mjs)，`tests/link-degradation.test.js` 按 §9 降级矩阵逐行核对。
+- **「未安装」和「未配对」是两件事。** 装了但没配对时要说去桌面粘贴扩展 ID，不能说没装。
+- **队列有两层。** 用户确认了字段但桌面不在 → `SaveIntent`（没有 messageId、没有申请 UUID、没有 epoch）；选好绑定谁之后 → Bound outbox（铸 `messageId`、盖当时的 `sourceRestoreEpoch`）。两者都存在 `chrome.storage.local`，只用 `desktopSaveIntents` / `desktopOutbox` / `desktopClientInstanceId` / `desktopPairing` 四个 key。
+- **`sourceRestoreEpoch` 盖上就不改。** 重试时信封换成最新握手身份，载荷不换。桌面恢复过备份之后，旧 epoch 的消息一律暂停，只能走 `outbox.reconcile`，由用户决定关联 / 丢弃 / 另存。
+- **重试沿用原 `messageId`。** 换 ID 就是第二条申请。
+
+协议校验器不是这里写的，是 `desktop/crates/protocol/js/` 的副本，`tests/protocol-vendor.test.js` 锁死两边一致。改协议请改源文件再复制过来。
+
+开发期把桌面程序注册成 Native Messaging host 的办法见 [`desktop/DEV-NATIVE-MESSAGING.md`](desktop/DEV-NATIVE-MESSAGING.md)。配对之后要重新加载扩展或重启浏览器，否则新写的注册不生效。
 
 ### 本地开发安装
 

--- a/content.js
+++ b/content.js
@@ -137,6 +137,7 @@
         <div class="resume-pro__divider"></div>
         <div class="resume-pro__desktop">
           <button class="resume-pro__manager-button" id="resume-pro-save-job" type="button">保存岗位到本地</button>
+          <button class="resume-pro__manager-button" id="resume-pro-confirm-submit" type="button">确认已投递</button>
           <form class="resume-pro__save-form" id="resume-pro-save-form" hidden>
             <label class="resume-pro__field">
               <span>公司<em>*</em></span>
@@ -1677,6 +1678,7 @@
 
   function bindDesktopEvents(sidebar) {
     sidebar.querySelector("#resume-pro-save-job")?.addEventListener("click", handleSaveJobClick);
+    sidebar.querySelector("#resume-pro-confirm-submit")?.addEventListener("click", handleConfirmSubmitClick);
     sidebar.querySelector("#resume-pro-save-cancel")?.addEventListener("click", closeSaveForm);
     sidebar.querySelector("#resume-pro-save-form")?.addEventListener("submit", (event) => {
       event.preventDefault();
@@ -1708,6 +1710,58 @@
     } catch (error) {
       setDesktopStatus({ tone: "warn", text: "读取页面信息失败，请手动填写后再保存。" });
     }
+  }
+
+  // Confirming a submission is its own act: it has nothing to do with whether the AI fill
+  // worked, and nothing to do with having saved the posting a moment ago. The application is
+  // chosen from the desktop's own candidates rather than remembered here, so the plugin never
+  // holds a stale application id across a restore.
+  async function handleConfirmSubmitClick() {
+    const { extract, copy } = await loadDesktopModules();
+    const fields = extract.extractJobFields(document, location.href);
+    if (!fields.company) {
+      setDesktopStatus({ tone: 'warn', text: '这个页面看不出是哪家公司，请先在桌面里确认投递。' });
+      return;
+    }
+
+    let candidates;
+    try {
+      candidates = await chrome.runtime.sendMessage({ type: "DESKTOP_CANDIDATES_FOR", fields });
+    } catch {
+      candidates = null;
+    }
+    if (candidates?.status !== "ok") {
+      setDesktopStatus(copy.describeConfirmResult({ status: "pending" }));
+      return;
+    }
+
+    const options = [...candidates.exact, ...candidates.sameCompany];
+    if (!options.length) {
+      setDesktopStatus({ tone: 'warn', text: '桌面里还没有这家公司的申请，请先保存岗位。' });
+      return;
+    }
+
+    const box = shadowRoot?.querySelector("#resume-pro-candidates");
+    const list = shadowRoot?.querySelector("#resume-pro-candidate-list");
+    shadowRoot.querySelector("#resume-pro-candidates-note").textContent = "这次投递的是哪一条申请？";
+    list.textContent = "";
+    for (const candidate of options) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "resume-pro__candidate";
+      row.textContent = `${candidate.company} · ${candidate.title}`;
+      row.addEventListener("click", async () => {
+        box.hidden = true;
+        const result = await chrome.runtime.sendMessage({
+          type: "DESKTOP_CONFIRM_SUBMIT", applicationId: candidate.applicationId
+        });
+        setDesktopStatus(copy.describeConfirmResult(result ?? { status: "pending" }));
+        refreshPendingList();
+      });
+      list.appendChild(row);
+    }
+    shadowRoot.querySelector("#resume-pro-bind-new").hidden = true;
+    box.hidden = false;
   }
 
   function closeSaveForm() {
@@ -1775,7 +1829,9 @@
     appendCandidateGroup(list, "同公司的其他岗位（仅供参考）", result.sameCompany, intentId);
 
     box.hidden = false;
-    shadowRoot.querySelector("#resume-pro-bind-new").onclick = () => bindIntent(intentId, null);
+    const bindNew = shadowRoot.querySelector("#resume-pro-bind-new");
+    bindNew.hidden = false;
+    bindNew.onclick = () => bindIntent(intentId, null);
     shadowRoot.querySelector("#resume-pro-bind-later").onclick = () => {
       // §5.2.4: cancelling the picker keeps the intent pending. Nothing is bound and nothing
       // is discarded.

--- a/desktop/scripts/d07_browser_check.py
+++ b/desktop/scripts/d07_browser_check.py
@@ -1,0 +1,376 @@
+"""Drive the real Resume Pro extension against a real desktop, in a real browser.
+
+This is the D07 acceptance that unit tests cannot give: the actual plugin, loaded unpacked,
+talking to the actual host over Native Messaging, with the archive on disk afterwards
+holding exactly one application.
+
+It loads the shipped extension rather than a probe, and it drives it through the same
+messages the sidebar sends, so what is exercised is the plugin's own envelope building,
+transport, queues and idempotency — not a second implementation written for the test.
+
+Run it by hand, not in CI. It needs a headed browser, it writes a real Native Messaging
+registration, and it starts the desktop process.
+
+    python scripts/d07_browser_check.py [--binary <path>] [--keep]
+
+Everything it creates is isolated: a temporary RESUMEPRO_DATA_DIR the browser passes down
+to the host, a temporary browser profile, a temporary copy of the extension, and a
+registration removed again through the same receipt-based unregister the dev scripts use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+DESKTOP = Path(__file__).resolve().parent.parent
+PLUGIN = DESKTOP.parent
+HOST_NAME = "com.resumepro.desktop"
+
+# Everything the extension does not ship. The desktop tree in particular is large and would
+# only slow the unpacked load down.
+EXCLUDE = {
+    ".git", ".github", ".playwright-cli", ".secrets", ".edge-icon-profile",
+    "desktop", "docs", "archive", "output", "tests", "node_modules",
+}
+
+JOB = {
+    "company": "合成科技有限公司",
+    "title": "后端开发工程师",
+    "location": "上海",
+    "sourceUrl": "https://jobs.example.test/d07/apply",
+    "dedupeUrl": "https://jobs.example.test/d07/apply",
+}
+
+
+def copy_extension(destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    for entry in PLUGIN.iterdir():
+        if entry.name in EXCLUDE or entry.name.startswith("."):
+            continue
+        target = destination / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, target)
+        else:
+            shutil.copy2(entry, target)
+
+
+def default_binary() -> Path:
+    name = "resume-pro-desktop.exe" if sys.platform == "win32" else "resume-pro-desktop"
+    for profile in ("debug", "release"):
+        candidate = DESKTOP / "src-tauri" / "target" / profile / name
+        if candidate.exists():
+            return candidate
+    raise SystemExit(
+        "no desktop binary found; run: cargo build --manifest-path src-tauri/Cargo.toml"
+    )
+
+
+def pair(data_root: Path, extension_id: str) -> None:
+    """The same settings.json the desktop's own settings window writes."""
+    (data_root / "settings.json").write_text(
+        json.dumps(
+            {
+                "chromeExtensionId": extension_id,
+                "edgeExtensionId": "",
+                "nativeMessagingRegistered": False,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+def stop_application(binary: Path, env: dict) -> None:
+    """Ask the application to exit before the browser closes.
+
+    The host is a child of the browser and the application a child of the host. Closing the
+    browser first waits on pipes a surviving grandchild still holds.
+    """
+    if not binary.exists():
+        return
+    subprocess.run(
+        [str(binary), "--quit"],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        timeout=60,
+    )
+
+
+def node(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", str(DESKTOP / "scripts" / "nm-dev-register.mjs"), *args],
+        cwd=DESKTOP,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def ask(page, message: dict, tries: int = 1) -> dict:
+    """Send one message to the service worker from an extension page.
+
+    This is the sidebar's own path: a content script cannot open a native port, so every
+    desktop operation is a runtime message. Retrying is what the plugin itself does on a
+    cold start, and D06 measured starts that exceed the host's ten second budget.
+    """
+    last = None
+    for attempt in range(tries):
+        last = page.evaluate(
+            "message => new Promise(resolve => chrome.runtime.sendMessage(message, resolve))",
+            message,
+        )
+        if last and last.get("mode") != "unavailable" and not last.get("error"):
+            return last
+        if attempt + 1 < tries:
+            time.sleep(3)
+    return last or {}
+
+
+def storage(worker) -> dict:
+    return worker.evaluate("() => chrome.storage.local.get(null)")
+
+
+def launch(playwright, workspace: Path, extension: Path, env: dict):
+    return playwright.chromium.launch_persistent_context(
+        user_data_dir=str(workspace / "profile"),
+        headless=False,
+        env=env,
+        args=[
+            f"--disable-extensions-except={extension}",
+            f"--load-extension={extension}",
+        ],
+    )
+
+
+def worker_of(context):
+    return context.service_workers[0] if context.service_workers else context.wait_for_event(
+        "serviceworker", timeout=30_000
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, default=None)
+    parser.add_argument("--keep", action="store_true")
+    args = parser.parse_args()
+    source_binary = (args.binary or default_binary()).resolve()
+    if not source_binary.exists():
+        raise SystemExit(f"no such binary: {source_binary}")
+
+    workspace = Path(tempfile.mkdtemp(prefix="resumepro-d07-"))
+    data_dir = workspace / "data"
+    data_dir.mkdir()
+    extension = workspace / "extension"
+    copy_extension(extension)
+
+    # Registered against a copy so the last phase can take the application away without
+    # touching the build tree.
+    binary = workspace / source_binary.name
+    shutil.copy2(source_binary, binary)
+
+    env = {**os.environ, "RESUMEPRO_DATA_DIR": str(data_dir)}
+    failures: list[str] = []
+    registered = False
+    results: dict = {}
+
+    try:
+        with sync_playwright() as playwright:
+            # Phase 1: registered, not paired. Also the only way to learn the id Chrome
+            # assigns to this unpacked directory.
+            context = launch(playwright, workspace, extension, env)
+            try:
+                extension_id = worker_of(context).url.split("/")[2]
+                print(f"extension id: {extension_id}")
+
+                outcome = node(
+                    "register", "--extension-id", extension_id,
+                    "--browser", "chrome", "--binary", str(binary),
+                )
+                print(outcome.stdout.strip() or outcome.stderr.strip())
+                if outcome.returncode != 0 or "skipped" in outcome.stdout:
+                    failures.append("registration did not happen; remove any existing one first")
+                    return report(failures, results)
+                registered = True
+
+                page = context.new_page()
+                page.goto(f"chrome-extension://{extension_id}/popup.html")
+                results["unpaired_save"] = ask(page, {"type": "DESKTOP_SAVE_JOB", "fields": JOB}, tries=3)
+                results["unpaired_storage"] = storage(worker_of(context))
+            finally:
+                stop_application(binary, env)
+                context.close()
+
+            # Pairing is only picked up by a browser that starts afterwards, which is the
+            # reload the plugin's own copy tells the user about.
+            pair(data_dir, extension_id)
+
+            context = launch(playwright, workspace, extension, env)
+            try:
+                page = context.new_page()
+                page.goto(f"chrome-extension://{extension_id}/popup.html")
+
+                results["probe"] = ask(page, {"type": "DESKTOP_PROBE"}, tries=6)
+                first = ask(page, {"type": "DESKTOP_SAVE_JOB", "fields": JOB}, tries=3)
+                results["save"] = first
+                intent_id = (first.get("intent") or {}).get("intentId")
+                results["candidates_before"] = ask(page, {"type": "DESKTOP_CANDIDATES", "intentId": intent_id}, tries=3)
+                results["bind"] = ask(page, {"type": "DESKTOP_BIND", "intentId": intent_id}, tries=3)
+                application_id = results["bind"].get("applicationId")
+
+                # The same posting again, bound to the application that now exists. Two
+                # saves, one application.
+                second = ask(page, {"type": "DESKTOP_SAVE_JOB", "fields": JOB}, tries=3)
+                results["save_again"] = second
+                second_intent = (second.get("intent") or {}).get("intentId")
+                results["candidates_after"] = ask(page, {"type": "DESKTOP_CANDIDATES", "intentId": second_intent}, tries=3)
+                results["bind_existing"] = ask(
+                    page,
+                    {"type": "DESKTOP_BIND", "intentId": second_intent, "applicationId": application_id},
+                    tries=3,
+                )
+                results["applications"] = ask(page, {"type": "DESKTOP_CANDIDATES_FOR", "fields": JOB}, tries=3)
+                results["confirm"] = ask(
+                    page, {"type": "DESKTOP_CONFIRM_SUBMIT", "applicationId": application_id}, tries=3
+                )
+                results["storage_after"] = storage(worker_of(context))
+            finally:
+                stop_application(binary, env)
+                context.close()
+
+            # Phase 3: the desktop is gone. A profile that has paired before must keep the
+            # fields as an intent and must not claim anything was saved.
+            deadline = time.monotonic() + 20
+            while binary.exists():
+                try:
+                    binary.unlink()
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        failures.append("could not take the application away for the offline phase")
+                        break
+                    time.sleep(1)
+
+            context = launch(playwright, workspace, extension, env)
+            try:
+                page = context.new_page()
+                page.goto(f"chrome-extension://{extension_id}/popup.html")
+                results["offline_save"] = ask(
+                    page, {"type": "DESKTOP_SAVE_JOB", "fields": {**JOB, "title": "测试开发工程师"}}
+                )
+                results["offline_storage"] = storage(worker_of(context))
+            finally:
+                context.close()
+    finally:
+        if registered:
+            print(node("unregister").stdout.strip())
+        stop_application(binary, env)
+        if args.keep:
+            print(f"left in place: {workspace}")
+        else:
+            deadline = time.monotonic() + 20
+            while True:
+                try:
+                    shutil.rmtree(workspace)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        print(f"WARNING: {workspace} still held open", file=sys.stderr)
+                        break
+                    time.sleep(1)
+
+    check(results, failures)
+    return report(failures, results)
+
+
+def check(results: dict, failures: list[str]) -> None:
+    unpaired = results.get("unpaired_save") or {}
+    if unpaired.get("mode") != "not_paired":
+        failures.append(f"an unpaired extension was not told to pair: {unpaired}")
+    if not unpaired.get("extensionId"):
+        failures.append("the pairing message did not carry the id the user has to paste")
+    if (results.get("unpaired_storage") or {}).get("desktopSaveIntents"):
+        failures.append("an unpaired profile queued an intent nothing could ever drain")
+
+    probe = results.get("probe") or {}
+    if probe.get("mode") != "ready":
+        failures.append(f"the paired extension did not reach the desktop: {probe}")
+        return
+
+    save = results.get("save") or {}
+    if save.get("status") != "queued":
+        failures.append(f"the first save was not queued: {save}")
+        return
+
+    bind = results.get("bind") or {}
+    if bind.get("status") != "saved":
+        failures.append(f"binding did not reach the archive: {bind}")
+        return
+    application_id = bind.get("applicationId")
+    if not application_id:
+        failures.append("the desktop did not name the application it wrote")
+
+    before = results.get("candidates_before") or {}
+    if before.get("exact"):
+        failures.append(f"a brand new archive already had an exact candidate: {before}")
+
+    after = results.get("candidates_after") or {}
+    exact = after.get("exact") or []
+    if len(exact) != 1 or exact[0].get("applicationId") != application_id:
+        failures.append(f"the saved job was not offered as the exact candidate: {after}")
+
+    if (results.get("bind_existing") or {}).get("status") != "saved":
+        failures.append(f"binding to the existing application failed: {results.get('bind_existing')}")
+
+    applications = results.get("applications") or {}
+    total = len(applications.get("exact") or []) + len(applications.get("sameCompany") or [])
+    if total != 1:
+        failures.append(f"two saves of one posting produced {total} applications, expected 1")
+
+    if (results.get("confirm") or {}).get("status") != "saved":
+        failures.append(f"confirming the submission failed: {results.get('confirm')}")
+
+    settled = results.get("storage_after") or {}
+    if settled.get("desktopOutbox"):
+        failures.append(f"the outbox did not empty: {settled.get('desktopOutbox')}")
+    if settled.get("desktopSaveIntents"):
+        failures.append(f"an intent survived a persisted write: {settled.get('desktopSaveIntents')}")
+    if not settled.get("desktopPairing", {}).get("archiveId"):
+        failures.append("a successful handshake was not remembered")
+
+    offline = results.get("offline_save") or {}
+    if offline.get("status") != "queued" or offline.get("mode") != "unavailable":
+        failures.append(f"a save with the desktop gone was not queued as an intent: {offline}")
+    intents = (results.get("offline_storage") or {}).get("desktopSaveIntents") or []
+    if len(intents) != 1 or intents[0].get("status") != "pending_desktop":
+        failures.append(f"the offline intent was not persisted as pending: {intents}")
+    if any("restoreEpoch" in intent for intent in intents):
+        failures.append("an intent was stamped with an epoch it never had")
+
+    for key in ("templates", "activeTemplateId", "aiConfig"):
+        if key in settled and key not in (results.get("unpaired_storage") or {}):
+            failures.append(f"the desktop link wrote {key}, which belongs to the rest of the plugin")
+
+
+def report(failures: list[str], results: dict) -> int:
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+    print("OK: the real extension saved, bound, confirmed and queued offline through the host")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -155,3 +155,15 @@ export function describeReconcileStatus(status) {
     choices: ['associate', 'discard', 'resave']
   };
 }
+
+export function describeConfirmResult(result) {
+  if (result?.status === 'saved') {
+    return { tone: 'success', text: '已投递：桌面上的阶段已经更新。' };
+  }
+  if (result?.status === 'rejected' && result.reason === 'no_application') {
+    return { tone: 'warn', text: '请先选择这次投递对应的申请。' };
+  }
+  // Everything else is still in the queue. Saying anything about the stage here would be a
+  // claim about the desktop's records that nothing has confirmed.
+  return { tone: 'pending', text: '已排进待同步队列，桌面可用之后会更新阶段。' };
+}

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -9,7 +9,9 @@ export const MSG = {
   removeIntent: 'DESKTOP_REMOVE_INTENT',
   retry: 'DESKTOP_RETRY',
   cancel: 'DESKTOP_CANCEL',
-  resolve: 'DESKTOP_RESOLVE'
+  resolve: 'DESKTOP_RESOLVE',
+  confirmSubmit: 'DESKTOP_CONFIRM_SUBMIT',
+  candidatesFor: 'DESKTOP_CANDIDATES_FOR'
 };
 
 export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -58,11 +58,39 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     if (intent.fields.location) payload.location = intent.fields.location;
     if (applicationId) payload.applicationId = applicationId;
 
+    return enqueue({ messageType: 'job.save', payload, applicationId, intentId, identity });
+  }
+
+  /**
+   * The user says they actually applied.
+   *
+   * §5.2 rule 5: this is unrelated to saving the posting and unrelated to whether the AI
+   * fill worked. It is its own write, and it goes through the same queue, backoff and
+   * reconciliation as everything else.
+   */
+  async function confirmSubmit({ applicationId, identity }) {
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+    if (!applicationId) return { status: 'rejected', reason: 'no_application' };
+    if ((await store.getOutbox()).length >= MAX_OUTBOX) {
+      return { status: 'rejected', reason: 'queue_full' };
+    }
+    return enqueue({
+      messageType: 'submit.confirm',
+      payload: { applicationId },
+      applicationId,
+      intentId: null,
+      identity
+    });
+  }
+
+  // Persist, then send. Never the other way round: an entry that exists only in flight cannot
+  // be retried with the same identity after the worker dies.
+  async function enqueue({ messageType, payload, applicationId, intentId, identity }) {
     const entry = {
       messageId: uuid(),
       intentId,
       clientInstanceId: await store.clientInstanceId(),
-      messageType: 'job.save',
+      messageType,
       archiveId: identity.archiveId,
       sourceRestoreEpoch: identity.restoreEpoch,
       applicationId,
@@ -219,6 +247,7 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
   return {
     queryCandidates,
     bindAndSend,
+    confirmSubmit,
     drainOnce,
     deliverOne,
     markDue,

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -71,9 +71,6 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
   async function confirmSubmit({ applicationId, identity }) {
     if (!identity) return { status: 'rejected', reason: 'no_identity' };
     if (!applicationId) return { status: 'rejected', reason: 'no_application' };
-    if ((await store.getOutbox()).length >= MAX_OUTBOX) {
-      return { status: 'rejected', reason: 'queue_full' };
-    }
     return enqueue({
       messageType: 'submit.confirm',
       payload: { applicationId },

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -70,6 +70,18 @@ export function createRouter({ session, intents, outbox, drain, reconcile, exten
       return { ok: true };
     }
 
+    if (type === MSG.candidatesFor) {
+      const probe = await session.probe();
+      if (probe.mode !== 'ready') return { status: probe.mode };
+      return outbox.queryCandidates({ identity: probe.identity, fields: message.fields });
+    }
+
+    if (type === MSG.confirmSubmit) {
+      const probe = await session.probe();
+      if (probe.mode !== 'ready') return { status: 'pending', mode: probe.mode };
+      return outbox.confirmSubmit({ applicationId: message.applicationId, identity: probe.identity });
+    }
+
     if (type === MSG.resolve) {
       // Associate, discard or save again. Only the user gets to make this call: none of the
       // four unresolved reconcile answers authorises the plugin to decide on its own.

--- a/tests/link-degradation.test.js
+++ b/tests/link-degradation.test.js
@@ -1,0 +1,111 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const load = () => import('../link/copy.mjs');
+const ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+// The §9 degradation matrix, as a table. Each row states what the user must be told and what
+// they must not be told. The rows are contractual: several of them exist because the wrong
+// message sends someone off to reinstall software they already have, or leaves them
+// believing a job was filed when it is sitting in a queue.
+const MATRIX = [
+  {
+    row: '未安装 / 从未配对',
+    result: { status: 'not_queued', mode: 'not_installed', extensionId: ID },
+    mustSay: [/桌面程序/, /填表/],
+    mustNotSay: [/配对/, /已保存/]
+  },
+  {
+    row: '从未配对（装了但没配过）',
+    result: { status: 'not_queued', mode: 'never_paired', extensionId: ID },
+    mustSay: [/扩展 ID/, /没有保存/],
+    mustNotSay: [/未安装/, /已保存到桌面/]
+  },
+  {
+    row: '已安装但未配对',
+    result: { status: 'not_queued', mode: 'not_paired', extensionId: ID },
+    mustSay: [/配对/, /扩展 ID/],
+    mustNotSay: [/未安装/, /没有找到桌面程序/]
+  },
+  {
+    row: '曾经配对，桌面暂不可用',
+    result: { status: 'queued', mode: 'unavailable', intent: { status: 'pending_desktop' } },
+    mustSay: [/待同步/, /尚未绑定申请/],
+    mustNotSay: [/已保存/, /未安装/]
+  },
+  {
+    row: '离线（无互联网）：与桌面不可用同路',
+    result: { status: 'queued', mode: 'unavailable', intent: { status: 'pending_desktop' } },
+    mustSay: [/待同步/],
+    mustNotSay: [/已保存/]
+  },
+  {
+    row: '协议不兼容',
+    result: { status: 'queued', mode: 'incompatible', intent: { status: 'pending_desktop' } },
+    mustSay: [/升级/, /待同步/],
+    mustNotSay: [/已保存/, /未安装/]
+  },
+  {
+    row: '队列已满',
+    result: { status: 'rejected', reason: 'queue_full', mode: 'unavailable' },
+    mustSay: [/已满/, /填表/],
+    mustNotSay: [/已保存/]
+  }
+];
+
+for (const entry of MATRIX) {
+  test(`§9 ${entry.row}`, async () => {
+    const { describeSaveResult } = await load();
+
+    const copy = describeSaveResult(entry.result);
+    const text = `${copy.text} ${copy.hint ?? ''}`;
+
+    for (const pattern of entry.mustSay) assert.match(text, pattern, entry.row);
+    for (const pattern of entry.mustNotSay) assert.doesNotMatch(text, pattern, entry.row);
+  });
+}
+
+test('every mode has copy, including one nobody thought of', async () => {
+  const { describeSaveResult } = await load();
+
+  for (const mode of ['ready', 'unavailable', 'incompatible', 'not_installed', 'not_paired', 'never_paired', 'something_new']) {
+    const copy = describeSaveResult({ status: 'not_queued', mode, extensionId: ID });
+    assert.equal(typeof copy.text, 'string');
+    assert.notEqual(copy.text.trim(), '');
+  }
+});
+
+test('only a persisted write is ever described as saved on the desktop', async () => {
+  const { describeSaveResult, describeBindResult, describeReconcileStatus } = await load();
+  const claims = [];
+
+  for (const entry of MATRIX) claims.push(describeSaveResult(entry.result).text);
+  for (const status of ['pending', 'failed', 'rejected']) claims.push(describeBindResult({ status }).text);
+  for (const status of ['purged', 'not_found', 'conflict', 'unverifiable']) {
+    claims.push(describeReconcileStatus(status).text);
+  }
+
+  for (const claim of claims) assert.equal(claim.includes('桌面已保存'), false, claim);
+  assert.match(describeBindResult({ status: 'saved' }).text, /桌面已保存/);
+});
+
+test('a desktop save is never described as a submission', async () => {
+  const { describeBindResult } = await load();
+  // Walkthrough rule 5: saving a posting leaves the stage at `saved`. Only the user pressing
+  // "confirm submitted" moves it on.
+  const copy = describeBindResult({ status: 'saved' });
+
+  assert.equal(copy.text.includes('已投递（'), false);
+  assert.match(copy.text, /不是已投递/);
+});
+
+test('a confirmed submission says so and nothing more', async () => {
+  const { describeConfirmResult } = await load();
+
+  const saved = describeConfirmResult({ status: 'saved' });
+  const pending = describeConfirmResult({ status: 'pending' });
+
+  assert.match(saved.text, /已投递/);
+  assert.match(pending.text, /待同步/);
+  assert.equal(pending.text.includes('已投递'), false);
+});

--- a/tests/link-manifest.test.js
+++ b/tests/link-manifest.test.js
@@ -60,6 +60,19 @@ test('the sidebar offers saving a job and never formats desktop copy itself', as
   assert.equal(source.includes('桌面已保存'), false);
 });
 
+test('the sidebar offers confirming a submission separately from saving', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  // §5.2 rule 5: this is its own button, unrelated to whether the AI fill worked.
+  assert.match(source, /resume-pro-confirm-submit/);
+  assert.match(source, /DESKTOP_CONFIRM_SUBMIT/);
+});
+
+test('the desktop link is documented where a maintainer will look', async () => {
+  const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+  assert.match(readme, /link\/ +桌面程序连接/);
+  assert.match(readme, /sourceRestoreEpoch/);
+});
+
 test('the desktop link ships every file it imports', async () => {
   const files = [
     'link/protocol/validate.mjs',
@@ -70,7 +83,20 @@ test('the desktop link ships every file it imports', async () => {
     'link/envelope.mjs',
     'link/transport.mjs',
     'link/store.mjs',
-    'link/session.mjs'
+    'link/session.mjs',
+    'link/intents.mjs',
+    'link/outbox.mjs',
+    'link/drain.mjs',
+    'link/reconcile.mjs',
+    'link/router.mjs',
+    'link/worker.mjs',
+    'link/messages.mjs',
+    'link/limits.mjs',
+    'link/copy.mjs',
+    'link/redact.mjs',
+    'link/normalize.mjs',
+    'link/extract.mjs',
+    'link/chrome.mjs'
   ];
   for (const file of files) {
     assert.ok(fs.existsSync(path.join(root, file)), `${file} is missing from the extension root`);

--- a/tests/link-outbox.test.js
+++ b/tests/link-outbox.test.js
@@ -313,3 +313,50 @@ test('an intent that is already queued is not bound a second time later', async 
   assert.equal(again.status, 'duplicate');
   assert.equal(storage.data.desktopOutbox.length, 1);
 });
+
+// --- submit.confirm --------------------------------------------------------
+
+test('confirming a submission is a queued write like any other', async () => {
+  const { outbox, storage, sent } = await harness({ desktop: savedReply });
+
+  const result = await outbox.confirmSubmit({ applicationId: APPLICATION, identity: IDENTITY });
+
+  assert.equal(result.status, 'saved');
+  assert.equal(sent[0].message.messageType, 'submit.confirm');
+  assert.equal(sent[0].message.payload.applicationId, APPLICATION);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+test('a submit confirmation carries nothing but the application it names', async () => {
+  const { outbox, sent } = await harness({ desktop: savedReply });
+
+  await outbox.confirmSubmit({ applicationId: APPLICATION, identity: IDENTITY });
+
+  // D05 freezes this payload at three fields. `via` and `note` are D03's internal columns and
+  // must not appear on the wire.
+  assert.deepEqual(
+    Object.keys(sent[0].message.payload).sort(),
+    ['applicationId', 'payloadSha256', 'sourceRestoreEpoch']
+  );
+});
+
+test('a confirmation that cannot be delivered waits in the queue', async () => {
+  const { outbox, storage } = await harness({ desktop: message => errorReply(message, 'unavailable', true) });
+
+  const result = await outbox.confirmSubmit({ applicationId: APPLICATION, identity: IDENTITY });
+
+  assert.equal(result.status, 'pending');
+  assert.equal(storage.data.desktopOutbox[0].messageType, 'submit.confirm');
+  assert.equal(storage.data.desktopOutbox[0].sourceRestoreEpoch, EPOCH);
+});
+
+test('confirming a submission does not touch any intent', async () => {
+  const { outbox, intents, storage } = await harness({ desktop: savedReply });
+  await queuedIntent(intents);
+
+  await outbox.confirmSubmit({ applicationId: APPLICATION, identity: IDENTITY });
+
+  // Confirming a submission is unrelated to saving a posting, and unrelated to whether the
+  // AI fill worked. It must not consume a pending intent.
+  assert.equal(storage.data.desktopSaveIntents.length, 1);
+});

--- a/tests/link-router.test.js
+++ b/tests/link-router.test.js
@@ -252,3 +252,30 @@ test('a stalled write can be retried and cancelled from the sidebar', async () =
   await router.handle({ type: 'DESKTOP_CANCEL', messageId });
   assert.deepEqual(storage.data.desktopOutbox, []);
 });
+
+test('confirming a submission needs an application and a live desktop', async () => {
+  const { router } = await makeRouter({ reply: desktopThatAnswers });
+
+  const result = await router.handle({ type: 'DESKTOP_CONFIRM_SUBMIT', applicationId: APPLICATION });
+
+  assert.equal(result.status, 'saved');
+});
+
+test('confirming a submission with no desktop does not claim it happened', async () => {
+  const { router } = await makeRouter();
+
+  const result = await router.handle({ type: 'DESKTOP_CONFIRM_SUBMIT', applicationId: APPLICATION });
+
+  assert.notEqual(result.status, 'saved');
+});
+
+test('candidates can be looked up for the page without an intent', async () => {
+  const { router } = await makeRouter({ reply: desktopThatAnswers });
+
+  // Confirming a submission has no intent behind it: the user is pointing at an application
+  // that already exists.
+  const result = await router.handle({ type: 'DESKTOP_CANDIDATES_FOR', fields: FIELDS });
+
+  assert.equal(result.status, 'ok');
+  assert.equal(result.exact[0].applicationId, APPLICATION);
+});


### PR DESCRIPTION
D07 最后一部分：补上「确认已投递」，把 §9 降级矩阵的文案钉死，并加上驱动**真实插件**的浏览器验收。

依赖 #50（已合入）。合入后 D07 的代码工作全部完成。

## `submit.confirm` 是自己的一件事

§5.2 规则 5 明确：它和有没有保存过岗位无关，和 AI 填写成功与否**也无关**。测试守着这条线——确认投递不会消费任何 pending 意图，载荷只有 D05 冻结的三个字段（`via` / `note` 是 D03 的内部列，不上线）。

申请是从桌面自己的候选里选的，不是插件记住的，所以不会有一个陈旧的 applicationId 熬过一次恢复、指向已经不存在的东西。

## 降级文案变成一张表

`tests/link-degradation.test.js` 按 §9 逐行走：每一行声明「必须说什么」和「绝不能说什么」。这些行是有来历的——说错话会让一个已经装了桌面程序的人再去装一遍，或者让人以为工作已经归档而其实它还在队列里。

有一个测试把整个模块能产出的字符串全收集起来，断言其中**恰好只有一句**——落在持久化应答后面的那句——敢声称桌面已保存。

## 真实浏览器验收

`desktop/scripts/d07_browser_check.py`。驱动的是**发布的插件本身**，不是探针：插件自己的信封构造、传输、队列和幂等，解压加载进真实浏览器，对着真实 host 和真实档案库跑。

三个阶段:

1. **已注册未配对** —— 保存被拒，同时给出要粘贴的扩展 ID
2. **已配对** —— 保存 → 候选 → 绑定 → 同一岗位再存一次并绑到刚建的那条申请 → 确认投递，最后档案库里**恰好一条**申请
3. **应用被移走** —— 字段作为 pending 意图留存，没有任何东西声称保存成功

手工运行，不进 CI：要有头浏览器，会真写一次 Native Messaging 注册，会启动桌面进程。

**第三阶段抓到了 #45 里修掉的那个分类 bug**（曾经配对过的 profile 被告知「未安装」，确认过的字段被丢弃）。

## 测试

331 passed / 0 failed（D07 开工前是 115）。真实浏览器验收在本机通过。

## 还没做的，说清楚

- **macOS 真实浏览器验收没跑**（脚本支持 darwin 路径，但没在 Mac 上执行过）——这是 D06 就挂着的一项。
- **content.js 的 UI 代码没有自动化测试**：仓库没有 DOM 测试框架，所有判断逻辑都抽进了可测模块，content.js 只剩装配，另有源码级断言守着按钮存在、不自己拼文案、不出现「桌面已保存」字样。

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)