### PR TITLE
fix(d07): remove a TDZ assignment in probe()'s incompatible-version branch

### DIFF
--- a/link/session.mjs
+++ b/link/session.mjs
@@ -16,7 +16,7 @@ export const PLUGIN_VERSION = '0.4.0';
  *                 this is the only failure that may persist a SaveIntent
  *   never_paired  no successful handshake was ever recorded; no long-lived queue is created
  */
-export function createSession({ store, sendNative, sleep, uuid, now }) {
+export function createSession({ store, sendNative, sleep, uuid, now, send = sendOnce }) {
   async function probe() {
     const message = await buildEnvelope({
       messageType: 'handshake',
@@ -30,14 +30,13 @@ export function createSession({ store, sendNative, sleep, uuid, now }) {
       now
     });
 
-    const result = await sendOnce(message, { sendNative, sleep });
+    const result = await send(message, { sendNative, sleep });
 
     if (result.status === 'ok') {
       const payload = result.response.payload;
       if (!versionsIntersect(payload.minProtocolVersion, payload.maxProtocolVersion)) {
         // Deliberately not recorded as pairing: an incompatible desktop must not make the
         // queue believe writes are possible.
-        identity = null;
         return { mode: 'incompatible', identity: null };
       }
       const identity = { archiveId: payload.archiveId, restoreEpoch: payload.restoreEpoch };

--- a/tests/link-session.test.js
+++ b/tests/link-session.test.js
@@ -88,6 +88,28 @@ test('a desktop speaking only a future protocol is incompatible and is not remem
   assert.equal('desktopPairing' in storage.data, false);
 });
 
+test('a handshake that gets past transport validation with no shared version is still incompatible', async () => {
+  // The D05 validator rejects a non-overlapping range before probe() sees it, so this branch
+  // is only reachable if the validator and session.mjs ever disagree. It must still answer
+  // `incompatible` rather than throw.
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const storage = fakeStorage();
+  const session = createSession({
+    store: createStore({ storage, uuid: () => '11111111-1111-4111-8111-111111111111' }),
+    send: async message => ({
+      status: 'ok',
+      response: handshakeReply({ minProtocolVersion: 2, maxProtocolVersion: 3 })(message).response,
+      resultId: null
+    }),
+    uuid: () => '33333333-3333-4333-8333-333333333333',
+    now: () => new Date('2026-09-09T00:00:00.000Z')
+  });
+
+  assert.deepEqual(await session.probe(), { mode: 'incompatible', identity: null });
+  assert.equal('desktopPairing' in storage.data, false);
+});
+
 test('a desktop that rejects the handshake outright is incompatible', async () => {
   const { session } = await makeSession({
     reply: message => ({


### PR DESCRIPTION
D07 follow-up to #45.

## What

`link/session.mjs` `probe()` had, in the `result.status === 'ok'` block, a branch for a handshake whose protocol range does not intersect ours that did `identity = null;` before `const identity = {...}` is declared later in the same block. That assignment is in the temporal dead zone: reaching it throws `ReferenceError: Cannot access 'identity' before initialization` instead of answering `incompatible`.

The line is removed; the existing early `return { mode: 'incompatible', identity: null }` stays.

## Why it never showed up

The vendored D05 validator (`validateResponseForRequest`) rejects a non-overlapping handshake response before `probe()` sees it, so today the probe returns `incompatible` through the `fatal` / `protocol_incompatible` path. That is why the existing "a desktop speaking only a future protocol is incompatible…" test passes. The branch only becomes reachable if the validator and `session.mjs` ever disagree about the supported range.

## Test

`createSession()` now takes an optional `send` (defaults to `sendOnce`), alongside the `sendNative` / `sleep` / `uuid` / `now` it already takes. The new test in `tests/link-session.test.js` hands `probe()` a structurally valid handshake advertising 2–3 and asserts it returns `{ mode: 'incompatible', identity: null }` without recording a pairing.

- Before the fix, the new test fails with the `ReferenceError` above.
- After: `node --test tests/*.test.js` → 377 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
