### PR TITLE
feat(d08): archive a finished fill as fill.submit (#22, PR 3/7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ icons/                 插件图标
 
 - **「待同步」不等于「桌面已保存」。** 只有桌面持久化并回了 `resultId`，界面才允许说已保存。全部文案集中在 [`link/copy.mjs`](link/copy.mjs)，`tests/link-degradation.test.js` 按 §9 降级矩阵逐行核对。
 - **「未安装」和「未配对」是两件事。** 装了但没配对时要说去桌面粘贴扩展 ID，不能说没装。
-- **队列有两层。** 用户确认了字段但桌面不在 → `SaveIntent`（没有 messageId、没有申请 UUID、没有 epoch）；选好绑定谁之后 → Bound outbox（铸 `messageId`、盖当时的 `sourceRestoreEpoch`）。两者都存在 `chrome.storage.local`，只用 `desktopSaveIntents` / `desktopOutbox` / `desktopClientInstanceId` / `desktopPairing` 四个 key。
+- **队列有两层。** 用户确认了字段但桌面不在 → `SaveIntent`（没有 messageId、没有申请 UUID、没有 epoch）；选好绑定谁之后 → Bound outbox（铸 `messageId`、盖当时的 `sourceRestoreEpoch`）。两者都存在 `chrome.storage.local`，只用 `desktopSaveIntents` / `desktopOutbox` / `desktopClientInstanceId` / `desktopPairing` 四个 key；D08 的填写留档再加一个 `desktopFillRecords`（同样两层：未选申请的留档意图 → 选定之后才是 `fill.submit`）。
 - **`sourceRestoreEpoch` 盖上就不改。** 重试时信封换成最新握手身份，载荷不换。桌面恢复过备份之后，旧 epoch 的消息一律暂停，只能走 `outbox.reconcile`，由用户决定关联 / 丢弃 / 另存。
 - **重试沿用原 `messageId`。** 换 ID 就是第二条申请。
 

--- a/content.css
+++ b/content.css
@@ -499,7 +499,15 @@
   color: #b45309;
 }
 
-.resume-pro__candidates {
+/* The hidden attribute has to win inside the sidebar. Several panels (the save form, the
+   candidate box, the fill-record card) are flex boxes toggled with `hidden`, and an author
+   `display` rule beats the browser's own [hidden] rule — they would all show, empty. */
+.resume-pro [hidden] {
+  display: none !important;
+}
+
+.resume-pro__candidates,
+.resume-pro__fill-record {
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/content.js
+++ b/content.js
@@ -130,6 +130,13 @@
         <button class="resume-pro__manager-button" id="resume-pro-cancel-fill" type="button" hidden>取消 AI 等待（保留本地匹配）</button>
         <p id="resume-pro-wait-hint" role="status" hidden></p>
         <div class="resume-pro__status" id="resume-pro-status" aria-live="polite"></div>
+        <div class="resume-pro__fill-record" id="resume-pro-fill-record" hidden>
+          <p class="resume-pro__save-note" id="resume-pro-fill-record-summary"></p>
+          <div class="resume-pro__save-actions">
+            <button class="resume-pro__ai-button" type="button" id="resume-pro-fill-record-save">留档到桌面</button>
+            <button class="resume-pro__manager-button" type="button" id="resume-pro-fill-record-skip">不留档</button>
+          </div>
+        </div>
         <details class="resume-pro__diagnostics" id="resume-pro-diagnostics" hidden>
           <summary>填写诊断（不含简历内容）</summary>
           <textarea id="resume-pro-diagnostics-text" readonly aria-label="填写诊断摘要，可选择复制" rows="14"></textarea>
@@ -766,6 +773,9 @@
     }
 
     button.disabled = true;
+    // Warm the desktop modules while the fill runs, so that when it ends the page can be read
+    // for the archive offer without waiting on anything (see offerFillRecord).
+    loadDesktopModules().catch(() => {});
     const repeatButton = shadowRoot?.querySelector("#resume-pro-repeat-fill");
     if (repeatButton) repeatButton.disabled = true;
     button.textContent = "正在扫描网页...";
@@ -924,7 +934,8 @@
       if (waitHint) waitHint.hidden = true;
       if (timer !== null) window.clearInterval(timer);
       if (phase) timing[phase] = performance.now() - phaseStart;
-      const summary = formatFillDiagnostics({ ...timing, totalMs: performance.now() - totalStart,
+      const totalMs = performance.now() - totalStart;
+      const summary = formatFillDiagnostics({ ...timing, totalMs,
         fieldCount, filledCount, outcome, diagnostics });
       const panel = shadowRoot?.querySelector("#resume-pro-diagnostics");
       const text = shadowRoot?.querySelector("#resume-pro-diagnostics-text");
@@ -936,6 +947,15 @@
       button.disabled = false;
       if (repeatButton) repeatButton.disabled = false;
       button.textContent = "一键 AI 填写";
+      // A page with nothing to fill produced nothing worth archiving.
+      if (fieldCount > 0) {
+        offerFillRecord({
+          outcome, cancelled: cancelRequested, fieldCount, filledCount, unconfirmedCount,
+          timing: { scanMs: timing.scanMs, roundTripMs: timing.roundTripMs, fillMs: timing.fillMs, totalMs },
+          templateName: activeTemplate?.name,
+          endedAt: new Date().toISOString()
+        }, activeTemplate).catch(() => {});
+      }
     }
   }
 
@@ -1664,14 +1684,18 @@
 
   let desktopModules = null;
   let pendingFields = null;
+  // The finished fill the card is offering to archive. Held only until the user answers.
+  let pendingFill = null;
 
   async function loadDesktopModules() {
     if (!desktopModules) {
-      const [extract, copy] = await Promise.all([
+      const [extract, copy, fillrecords, snapshot] = await Promise.all([
         import(chrome.runtime.getURL("link/extract.mjs")),
-        import(chrome.runtime.getURL("link/copy.mjs"))
+        import(chrome.runtime.getURL("link/copy.mjs")),
+        import(chrome.runtime.getURL("link/fillrecords.mjs")),
+        import(chrome.runtime.getURL("link/snapshot.mjs"))
       ]);
-      desktopModules = { extract, copy };
+      desktopModules = { extract, copy, fillrecords, snapshot };
     }
     return desktopModules;
   }
@@ -1680,6 +1704,8 @@
     sidebar.querySelector("#resume-pro-save-job")?.addEventListener("click", handleSaveJobClick);
     sidebar.querySelector("#resume-pro-confirm-submit")?.addEventListener("click", handleConfirmSubmitClick);
     sidebar.querySelector("#resume-pro-save-cancel")?.addEventListener("click", closeSaveForm);
+    sidebar.querySelector("#resume-pro-fill-record-save")?.addEventListener("click", handleRecordFillClick);
+    sidebar.querySelector("#resume-pro-fill-record-skip")?.addEventListener("click", closeFillRecord);
     sidebar.querySelector("#resume-pro-save-form")?.addEventListener("submit", (event) => {
       event.preventDefault();
       submitSaveForm({ force: false });
@@ -1762,6 +1788,169 @@
     }
     shadowRoot.querySelector("#resume-pro-bind-new").hidden = true;
     box.hidden = false;
+  }
+
+  // --- D08: archiving a finished fill ----------------------------------------------------
+  //
+  // After every fill the sidebar may offer to archive it. It never blocks the fill and never
+  // throws into it, and a profile that has never paired a desktop is not asked at all: those
+  // users keep nothing. What is offered is counts and timings; the field values stay here.
+
+  async function offerFillRecord(raw, template) {
+    const card = shadowRoot?.querySelector("#resume-pro-fill-record");
+    if (!card) return;
+    // Read the page before waiting on the worker: on a single-page site the user can move on
+    // to the next posting meanwhile, and this fill must not be filed under that one. The
+    // modules were warmed when the fill started; if they were not, and the page changed while
+    // they loaded, there is no posting to offer this fill under.
+    const pageUrl = location.href;
+    const { extract, copy, fillrecords, snapshot } = await loadDesktopModules();
+    if (location.href !== pageUrl) return;
+    const job = extract.extractJobFields(document, pageUrl);
+    const link = await chrome.runtime.sendMessage({ type: "DESKTOP_LINK_STATE" });
+    if (!link?.everPaired) return;
+    pendingFill = {
+      ...raw,
+      urlRedacted: job.sourceUrl,
+      templateVersion: (await snapshot.templateVersionOf(template)) || "",
+      pluginVersion: chrome.runtime.getManifest().version,
+      job: { company: job.company, title: job.title, sourceUrl: job.sourceUrl }
+    };
+    // The summary is built from exactly what would be sent, so the card cannot promise more.
+    card.querySelector("#resume-pro-fill-record-summary").textContent =
+      copy.describeFillOffer(fillrecords.buildFillPayload(pendingFill));
+    card.hidden = false;
+  }
+
+  function closeFillRecord() {
+    const card = shadowRoot?.querySelector("#resume-pro-fill-record");
+    if (card) card.hidden = true;
+    pendingFill = null;
+  }
+
+  async function handleRecordFillClick() {
+    const raw = pendingFill;
+    if (!raw) return;
+    closeFillRecord();
+
+    let candidates = null;
+    if (raw.job?.company) {
+      try {
+        candidates = await chrome.runtime.sendMessage({ type: "DESKTOP_CANDIDATES_FOR", fields: raw.job });
+      } catch {
+        candidates = null;
+      }
+    }
+    if (candidates?.status !== "ok") {
+      // The desktop is not answering, or the page does not say which company this is. The
+      // fill waits, and the application is picked from the pending list later.
+      await recordFill(raw, null);
+      return;
+    }
+
+    const options = [...candidates.exact, ...candidates.sameCompany];
+    showFillCandidates(options, {
+      note: options.length
+        ? "这次填写属于哪条申请？"
+        : "桌面里还没有这家公司的申请。可以先「保存岗位到本地」，或者稍后在待同步里选择。",
+      onPick: applicationId => recordFill(raw, applicationId),
+      onLater: () => recordFill(raw, null)
+    });
+  }
+
+  async function recordFill(raw, applicationId) {
+    const { copy } = await loadDesktopModules();
+    let result;
+    try {
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_RECORD_FILL", raw, applicationId });
+    } catch {
+      result = { status: "rejected" };
+    }
+    setDesktopStatus(copy.describeFillRecordResult(result ?? { status: "rejected" }));
+    revealDesktopStatus();
+    refreshPendingList();
+  }
+
+  // The card sits under the fill result; the answer lands in the desktop section further
+  // down. Bring it into view so the click does not look like it did nothing.
+  function revealDesktopStatus() {
+    shadowRoot?.querySelector("#resume-pro-desktop-status")?.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+  }
+
+  // The same candidate box saving a job uses. There is no "new application" here: a fill
+  // belongs to an application that exists, and nothing is ever bound on the user's behalf.
+  function showFillCandidates(options, { note, onPick, onLater }) {
+    const box = shadowRoot?.querySelector("#resume-pro-candidates");
+    const list = shadowRoot?.querySelector("#resume-pro-candidate-list");
+    if (!box || !list) return;
+    shadowRoot.querySelector("#resume-pro-candidates-note").textContent = note;
+    list.textContent = "";
+    for (const candidate of options) {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "resume-pro__candidate";
+      row.textContent = `${candidate.company} · ${candidate.title}${candidate.stage ? `（${candidate.stage}）` : ""}`;
+      row.addEventListener("click", () => {
+        box.hidden = true;
+        onPick(candidate.applicationId);
+      });
+      list.appendChild(row);
+    }
+    shadowRoot.querySelector("#resume-pro-bind-new").hidden = true;
+    shadowRoot.querySelector("#resume-pro-bind-later").onclick = () => {
+      box.hidden = true;
+      onLater();
+    };
+    box.hidden = false;
+    box.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+  }
+
+  // What the desktop shows as an application's id. Checked before binding: a mistyped id would
+  // otherwise be queued and then refused on every attempt.
+  const APPLICATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  // A waiting record, bound from the pending list.
+  async function chooseFillApplication(record) {
+    const { copy } = await loadDesktopModules();
+    if (!record.job?.company) {
+      const typed = prompt("这条留档要记到哪条申请？请粘贴桌面里的申请 ID：")?.trim();
+      if (!typed) return;
+      if (!APPLICATION_ID_PATTERN.test(typed)) {
+        setDesktopStatus(copy.describeFillRecordResult({ status: "rejected", reason: "invalid_application_id" }));
+        return;
+      }
+      await bindFillRecord(record.recordId, typed);
+      return;
+    }
+    let candidates;
+    try {
+      candidates = await chrome.runtime.sendMessage({ type: "DESKTOP_CANDIDATES_FOR", fields: record.job });
+    } catch {
+      candidates = null;
+    }
+    if (candidates?.status !== "ok") {
+      setDesktopStatus(copy.describeFillRecordResult({ status: "recorded", mode: "unavailable" }));
+      return;
+    }
+    const options = [...candidates.exact, ...candidates.sameCompany];
+    showFillCandidates(options, {
+      note: options.length ? "这次填写属于哪条申请？" : "桌面里还没有这家公司的申请，请先保存岗位。",
+      onPick: applicationId => bindFillRecord(record.recordId, applicationId),
+      onLater: () => {}
+    });
+  }
+
+  async function bindFillRecord(recordId, applicationId) {
+    const { copy } = await loadDesktopModules();
+    let result;
+    try {
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_BIND_FILL", recordId, applicationId });
+    } catch {
+      result = { status: "pending" };
+    }
+    setDesktopStatus(copy.describeFillRecordResult(result ?? { status: "pending" }));
+    revealDesktopStatus();
+    refreshPendingList();
   }
 
   function closeSaveForm() {
@@ -1920,15 +2109,17 @@
 
     let intents = [];
     let outbox = [];
+    let fillRecords = [];
     try {
       const reply = await chrome.runtime.sendMessage({ type: "DESKTOP_LIST_QUEUE" });
       intents = reply?.intents || [];
       outbox = reply?.outbox || [];
+      fillRecords = reply?.fillRecords || [];
     } catch {
       return;
     }
 
-    const total = intents.length + outbox.length;
+    const total = intents.length + outbox.length + fillRecords.length;
     details.hidden = total === 0;
     shadowRoot.querySelector("#resume-pro-pending-count").textContent = String(total);
     list.textContent = "";
@@ -1949,12 +2140,22 @@
       list.appendChild(row);
     }
 
-    for (const entry of outbox) {
+    for (const record of fillRecords) {
       const row = pendingRow(
-        `${entry.payload?.company || ""} · ${entry.payload?.title || ""}`,
-        entry.payload?.sourceUrl,
-        describeOutboxState(entry)
+        `填写留档 · ${record.fill?.templateName || ""}`,
+        [record.job?.company, record.job?.title].filter(Boolean).join(" · "),
+        "待同步（尚未选择申请）"
       );
+      row.appendChild(rowButton("选择申请", () => chooseFillApplication(record)));
+      row.appendChild(rowButton("删除", async () => {
+        await chrome.runtime.sendMessage({ type: "DESKTOP_REMOVE_FILL", recordId: record.recordId });
+        refreshPendingList();
+      }));
+      list.appendChild(row);
+    }
+
+    for (const entry of outbox) {
+      const row = pendingRow(queueLabel(entry), entry.payload?.sourceUrl, describeOutboxState(entry));
       if (entry.status === "needs_user" || entry.status === "paused") {
         appendReconcileChoices(row, entry);
         list.appendChild(row);
@@ -1963,7 +2164,7 @@
       row.appendChild(rowButton("立即重试", async () => {
         const { copy } = await loadDesktopModules();
         const result = await chrome.runtime.sendMessage({ type: "DESKTOP_RETRY", messageId: entry.messageId });
-        setDesktopStatus(copy.describeBindResult(result ?? { status: "pending" }));
+        setDesktopStatus(describeQueueResult(copy, entry, result ?? { status: "pending" }));
         refreshPendingList();
       }));
       row.appendChild(rowButton("取消", async () => {
@@ -1972,6 +2173,20 @@
       }));
       list.appendChild(row);
     }
+  }
+
+  // Each kind of queued message has its own wording: a retried fill must not report that a
+  // job was saved, nor a refused one ask the user to check a company name.
+  function describeQueueResult(copy, entry, result) {
+    if (entry.messageType === "fill.submit") return copy.describeFillRecordResult(result);
+    if (entry.messageType === "submit.confirm") return copy.describeConfirmResult(result);
+    return copy.describeBindResult(result);
+  }
+
+  function queueLabel(entry) {
+    if (entry.messageType === "fill.submit") return `填写留档 · ${entry.payload?.templateName || ""}`;
+    if (entry.messageType === "submit.confirm") return "确认已投递";
+    return `${entry.payload?.company || ""} · ${entry.payload?.title || ""}`;
   }
 
   function pendingRow(label, title, state) {
@@ -2011,19 +2226,19 @@
     row.appendChild(rowButton("关联到已有申请", async () => {
       const applicationId = prompt("要关联到哪条申请？请粘贴桌面里的申请 ID：");
       if (!applicationId) return;
-      await resolvePaused(entry.messageId, "associate", applicationId.trim());
+      await resolvePaused(entry, "associate", applicationId.trim());
     }));
-    row.appendChild(rowButton("另存为新的", () => resolvePaused(entry.messageId, "resave")));
-    row.appendChild(rowButton("丢弃", () => resolvePaused(entry.messageId, "discard")));
+    row.appendChild(rowButton("另存为新的", () => resolvePaused(entry, "resave")));
+    row.appendChild(rowButton("丢弃", () => resolvePaused(entry, "discard")));
   }
 
-  async function resolvePaused(messageId, choice, applicationId) {
+  async function resolvePaused(entry, choice, applicationId) {
     const { copy } = await loadDesktopModules();
     const result = await chrome.runtime.sendMessage({
-      type: "DESKTOP_RESOLVE", messageId, choice, applicationId
+      type: "DESKTOP_RESOLVE", messageId: entry.messageId, choice, applicationId
     });
     if (choice !== "discard") {
-      setDesktopStatus(copy.describeBindResult(result ?? { status: "pending" }));
+      setDesktopStatus(describeQueueResult(copy, entry, result ?? { status: "pending" }));
     }
     refreshPendingList();
   }

--- a/desktop/scripts/plugin-release-assets.json
+++ b/desktop/scripts/plugin-release-assets.json
@@ -10,6 +10,7 @@
   "link/envelope.mjs",
   "link/errors.mjs",
   "link/extract.mjs",
+  "link/fillrecords.mjs",
   "link/intents.mjs",
   "link/limits.mjs",
   "link/messages.mjs",

--- a/docs/desktop-mvp/product-requirements.md
+++ b/docs/desktop-mvp/product-requirements.md
@@ -635,7 +635,7 @@ erDiagram
 
 ### 8.10 插件队列：SaveIntent 与 Bound outbox
 
-存在 `chrome.storage.local` 的新 key：`desktopSaveIntents`、`desktopOutbox`、`desktopClientInstanceId`、`desktopPairing`（上次成功握手的 archiveId/restoreEpoch/时间，不作提交凭证）。**禁止**占用 `templates` / `activeTemplateId` / `aiConfig` / `resumeProUpdateCache` / `resumeProDismissedVersion`。
+存在 `chrome.storage.local` 的新 key：`desktopSaveIntents`、`desktopOutbox`、`desktopClientInstanceId`、`desktopPairing`（上次成功握手的 archiveId/restoreEpoch/时间，不作提交凭证），以及 D08 增补的 `desktopFillRecords`（用户同意留档、尚未选定申请的填写记录；与 SaveIntent 同理，没有 `messageId` 与 epoch，选定申请后才变成 `fill.submit` 绑定消息）。**禁止**占用 `templates` / `activeTemplateId` / `aiConfig` / `resumeProUpdateCache` / `resumeProDismissedVersion`。
 
 **SaveIntent**（曾经配对且用户已确认字段；桌面不必当时可用）：
 

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -1,4 +1,4 @@
-import { MAX_INTENTS, MAX_OUTBOX } from './limits.mjs';
+import { MAX_FILL_RECORDS, MAX_INTENTS, MAX_OUTBOX } from './limits.mjs';
 
 // User-facing wording for every outcome of a save, in one table.
 //
@@ -167,3 +167,92 @@ export function describeConfirmResult(result) {
   // claim about the desktop's records that nothing has confirmed.
   return { tone: 'pending', text: '已排进待同步队列，桌面可用之后会更新阶段。' };
 }
+
+// --- D08: archiving a fill ------------------------------------------------------------
+//
+// Two things these sentences must never do: say the desktop has the record before a
+// persisted reply, and say anything about submitting. A completed fill is not a submission
+// (rule 1), and not even "not submitted" is said here, so the word cannot drift into a claim.
+
+const FILL_OUTCOMES = {
+  completed: '完成',
+  partial: '部分完成',
+  failed: '失败',
+  cancelled: '已取消'
+};
+
+/** One line describing a finished fill: counts of fields written into the page. */
+export function describeFillSummary(fill) {
+  const outcome = FILL_OUTCOMES[fill?.outcome] ?? '结束';
+  const written = `已写入网页 ${fill?.filledCount ?? 0}/${fill?.fieldCount ?? 0} 项`;
+  const unconfirmed = fill?.unconfirmedCount ? `，${fill.unconfirmedCount} 项未确认` : '';
+  return `这次填写${outcome}：${written}${unconfirmed}。`;
+}
+
+/** The card shown after a fill: what happened, and the question. */
+export function describeFillOffer(fill) {
+  return `${describeFillSummary(fill)}要把这次填写留档到桌面吗？只记结果和计数，不记填写的内容。`;
+}
+
+export function describeFillRecordResult(result) {
+  const { status, mode, reason, code } = result ?? {};
+
+  if (status === 'saved') {
+    // The only sentence that may say the desktop holds the record, and it runs only after a
+    // persisted reply.
+    return { tone: 'success', text: '已留档到桌面：这次填写的结果记在所选申请下。' };
+  }
+
+  if (status === 'recorded') {
+    if (mode === 'incompatible') {
+      return {
+        tone: 'pending',
+        text: '已记为待同步（尚未选择申请）。桌面程序的协议版本和插件对不上，升级之后才能留档。'
+      };
+    }
+    return {
+      tone: 'pending',
+      text: '已记为待同步（尚未选择申请）。桌面程序可用之后，在「待同步」里选择这次填写属于哪条申请。'
+    };
+  }
+
+  if (status === 'pending') {
+    return { tone: 'pending', text: '已排进待同步队列，桌面可用之后会自动发送。现在还没有留档到桌面。' };
+  }
+
+  if (status === 'duplicate') {
+    return { tone: 'pending', text: '这次填写已经在待同步队列里了，没有重复排一份。' };
+  }
+
+  if (status === 'rejected') {
+    if (reason === 'queue_full') {
+      return {
+        tone: 'warn',
+        text: `待同步的留档已满（${MAX_FILL_RECORDS} 条），这次没有留档。请先处理已有的几条。填表功能不受影响。`
+      };
+    }
+    if (reason === 'invalid_application_id') {
+      return { tone: 'warn', text: '这不是桌面里的申请 ID（形如 1a2b3c4d-…-…），这次没有绑定。请在桌面申请详情里复制 ID 再试。' };
+    }
+    if (reason === 'unknown_record') {
+      return { tone: 'warn', text: '这条留档已经不在待同步里了，可能已经发送过。' };
+    }
+    return { tone: 'warn', text: '这次没能留档，请稍后再试。填表功能不受影响。' };
+  }
+
+  if (status === 'not_recorded') {
+    return { tone: 'info', text: '还没有和桌面程序配对，这次没有留档。填表功能不受影响。' };
+  }
+
+  if (status === 'failed') {
+    return { tone: 'warn', text: FILL_REFUSALS[code] ?? REFUSALS[code] ?? '桌面拒绝了这次留档，请到桌面核对。' };
+  }
+
+  return { tone: 'warn', text: '这次没能留档到桌面，已经留在待同步里。' };
+}
+
+// A fill names an application that already exists, so the desktop's usual reason for
+// refusing one is that the application is gone — not that a company name is wrong.
+const FILL_REFUSALS = {
+  invalid_payload: '桌面上找不到所选的申请，这次没有留档。请在「待同步」里重新选择申请。'
+};

--- a/link/envelope.mjs
+++ b/link/envelope.mjs
@@ -34,6 +34,8 @@ export async function buildEnvelope({
   payload,
   identity = null,
   sourceRestoreEpoch = null,
+  // When the thing happened, if not now (a fill archived later). Envelope-level only.
+  occurredAt = null,
   now = () => new Date()
 }) {
   const body = { ...payload };
@@ -55,7 +57,7 @@ export async function buildEnvelope({
     messageId,
     clientInstanceId,
     messageType,
-    occurredAt: toUtcSubset(now()),
+    occurredAt: toUtcSubset(occurredAt ? new Date(occurredAt) : now()),
     payload: body
   };
 

--- a/link/fillrecords.mjs
+++ b/link/fillrecords.mjs
@@ -1,0 +1,187 @@
+import { MAX_FILL_RECORDS } from './limits.mjs';
+import { redactUrl } from './redact.mjs';
+
+// Same rule as SaveIntent (§5.2.3): only a profile that has reached a paired desktop keeps
+// anything. A profile that never did would be told its fill is "pending" forever.
+const MAY_RECORD = new Set(['ready', 'unavailable', 'incompatible']);
+
+const MAX_COUNT = 10000;
+const MAX_DURATION_MS = 3600000;
+
+/**
+ * The `fill.submit` payload body for one finished fill, from what content.js measured.
+ *
+ * An allowlist, not a filter: only these keys can leave, whatever else the caller passes.
+ * No field values, no AI matches, no prompt, no configuration — the same line
+ * `formatFillDiagnostics` holds for the copyable diagnostics (§8.8).
+ *
+ * `filledCount` is the number of fields actually written into the page. What the AI
+ * returned but was never written is not counted, and nothing here can say the site accepted
+ * anything: the plugin cannot know that.
+ */
+export function buildFillPayload(raw) {
+  const filledCount = count(raw?.filledCount);
+  const payload = {
+    outcome: outcomeOf(raw, filledCount),
+    fieldCount: count(raw?.fieldCount),
+    filledCount,
+    unconfirmedCount: count(raw?.unconfirmedCount)
+  };
+
+  const durationsMs = {};
+  const timing = raw?.timing ?? {};
+  for (const [key, source] of [['scan', 'scanMs'], ['match', 'roundTripMs'], ['fill', 'fillMs'], ['total', 'totalMs']]) {
+    const value = duration(timing[source]);
+    if (value !== null) durationsMs[key] = value;
+  }
+  payload.durationsMs = durationsMs;
+
+  // Redacted in the sidebar already; redacted again here, where the queue is written, so a
+  // caller that forgot cannot put a token into storage or onto the wire.
+  const url = redactUrl(String(raw?.urlRedacted ?? ''));
+  if (url?.sourceUrl) payload.urlRedacted = url.sourceUrl.slice(0, 2000);
+
+  payload.templateName = label(raw?.templateName, 200) || '未命名模板';
+  const version = label(raw?.templateVersion, 64);
+  if (version) payload.templateVersion = version;
+  const pluginVersion = label(raw?.pluginVersion, 64);
+  if (pluginVersion) payload.pluginVersion = pluginVersion;
+
+  return payload;
+}
+
+/**
+ * Cancelling only gives up on the AI wait; local matches already written stay written, so a
+ * cancelled fill that wrote something is partial. So is a failure that got some fields in:
+ * "failed" would tell the user nothing was touched when something was.
+ */
+function outcomeOf(raw, filledCount) {
+  if (raw?.cancelled) return filledCount > 0 ? 'partial' : 'cancelled';
+  if (raw?.outcome === 'success') return 'completed';
+  if (raw?.outcome === 'partial') return 'partial';
+  return filledCount > 0 ? 'partial' : 'failed';
+}
+
+function count(value) {
+  const number = Math.round(Number(value));
+  if (!Number.isFinite(number)) return 0;
+  return Math.min(Math.max(number, 0), MAX_COUNT);
+}
+
+function duration(value) {
+  if (value === null || value === undefined) return null;
+  const number = Math.round(Number(value));
+  if (!Number.isFinite(number)) return null;
+  return Math.min(Math.max(number, 0), MAX_DURATION_MS);
+}
+
+function label(value, max) {
+  return String(value ?? '').trim().slice(0, max);
+}
+
+const MAX_HINT_URL = 2000;
+
+// The sidebar's clock at the end of the fill, if it is a real time not in the future.
+function occurredAtOf(value, current) {
+  const at = Date.parse(value);
+  return Number.isFinite(at) && at <= current.getTime() ? new Date(at).toISOString() : current.toISOString();
+}
+
+/**
+ * Where to look for candidates when the record is bound later. Kept with the record, never
+ * sent in `fill.submit`: it is the same posting information a SaveIntent already holds.
+ */
+function jobHint(job) {
+  const url = redactUrl(String(job?.sourceUrl ?? ''))?.sourceUrl ?? '';
+  return {
+    company: label(job?.company, 200),
+    title: label(job?.title, 200),
+    // queryCandidates refuses a longer sourceUrl, and a cut URL would match nothing anyway.
+    sourceUrl: url.length <= MAX_HINT_URL ? url : ''
+  };
+}
+
+/**
+ * Fills the user chose to archive (D08). Like a SaveIntent, a record is not a message: no
+ * messageId, no epoch. It becomes a `fill.submit` only once the user has picked the
+ * application, against a desktop that answered.
+ */
+export function createFillRecords({ store, uuid, now }) {
+  async function create({ raw, mode }) {
+    if (!MAY_RECORD.has(mode)) return { status: 'not_recorded', reason: mode };
+
+    const record = {
+      recordId: uuid(),
+      clientInstanceId: await store.clientInstanceId(),
+      fill: buildFillPayload(raw),
+      job: jobHint(raw?.job),
+      applicationId: null,
+      createdAt: now().toISOString(),
+      // When the fill ended, sent as the event's occurredAt however late the record is bound.
+      occurredAt: occurredAtOf(raw?.endedAt, now()),
+      status: 'pending_bind'
+    };
+
+    let outcome;
+    await store.updateFillRecords(list => {
+      if (list.length >= MAX_FILL_RECORDS) {
+        outcome = { status: 'rejected', reason: 'queue_full' };
+        return list;
+      }
+      outcome = { status: 'recorded', record };
+      return [...list, record];
+    });
+    return outcome;
+  }
+
+  /**
+   * Take a waiting record for one application. Decided and written in one queued step, so
+   * two clicks cannot both see it waiting and both send it: the second is a duplicate.
+   */
+  async function claim(recordId, applicationId) {
+    let outcome;
+    await store.updateFillRecords(list => list.map(record => {
+      if (record.recordId !== recordId) return record;
+      if (record.status !== 'pending_bind') {
+        outcome = { status: 'duplicate' };
+        return record;
+      }
+      const claimed = { ...record, status: 'bound', applicationId };
+      outcome = { status: 'claimed', record: claimed };
+      return claimed;
+    }));
+    return outcome ?? { status: 'unknown' };
+  }
+
+  // The bound message was given up on. The record goes back to waiting, so the user can
+  // choose another application or delete it.
+  function unbind(recordId) {
+    return store.updateFillRecords(list => list.map(record => (
+      record.recordId === recordId ? { ...record, status: 'pending_bind', applicationId: null } : record
+    )));
+  }
+
+  return {
+    create,
+    claim,
+    unbind,
+    list: () => store.getFillRecords(),
+    remove: recordId => store.updateFillRecords(list => list.filter(record => record.recordId !== recordId)),
+    removeWaiting
+  };
+
+  /**
+   * Delete a record the user no longer wants — only while it is still waiting. A sidebar
+   * drawn before the record was bound elsewhere must not delete it from under its queued
+   * fill.submit, which would then be archived anyway.
+   */
+  async function removeWaiting(recordId) {
+    let removed = false;
+    await store.updateFillRecords(list => list.filter(record => {
+      if (record.recordId !== recordId || record.status !== 'pending_bind') return true;
+      removed = true;
+      return false;
+    }));
+    return removed;
+  };
+}

--- a/link/limits.mjs
+++ b/link/limits.mjs
@@ -6,6 +6,10 @@
 export const MAX_INTENTS = 100;
 export const MAX_OUTBOX = 100;
 
+// Fills the user chose to archive but has not bound to an application yet (D08). Same rule:
+// full means refuse and say so, never drop the oldest.
+export const MAX_FILL_RECORDS = 100;
+
 // A same-posting save inside this window is a double click rather than a decision, so the
 // wording says "just saved" instead of "already pending". Either way it is refused as a
 // duplicate: a pending intent for the same posting always requires an explicit "save again",

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -11,7 +11,12 @@ export const MSG = {
   cancel: 'DESKTOP_CANCEL',
   resolve: 'DESKTOP_RESOLVE',
   confirmSubmit: 'DESKTOP_CONFIRM_SUBMIT',
-  candidatesFor: 'DESKTOP_CANDIDATES_FOR'
+  candidatesFor: 'DESKTOP_CANDIDATES_FOR',
+  // D08: archiving a finished fill.
+  linkState: 'DESKTOP_LINK_STATE',
+  recordFill: 'DESKTOP_RECORD_FILL',
+  bindFill: 'DESKTOP_BIND_FILL',
+  removeFill: 'DESKTOP_REMOVE_FILL'
 };
 
 export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -80,12 +80,36 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     });
   }
 
+  /**
+   * Send one archived fill (D08) to the application the user picked.
+   *
+   * The record has already been claimed for that application (link/fillrecords.mjs), which
+   * is what stops two clicks from sending it twice. The payload is the allowlisted fill body
+   * plus the application; field values never get this far.
+   */
+  async function sendFill({ record, applicationId, identity }) {
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+    if (!applicationId) return { status: 'rejected', reason: 'no_application' };
+    return enqueue({
+      messageType: 'fill.submit',
+      payload: { applicationId, ...record.fill },
+      applicationId,
+      intentId: null,
+      recordId: record.recordId,
+      occurredAt: record.occurredAt ?? null,
+      identity
+    });
+  }
+
   // Persist, then send. Never the other way round: an entry that exists only in flight cannot
   // be retried with the same identity after the worker dies.
-  async function enqueue({ messageType, payload, applicationId, intentId, identity }) {
+  async function enqueue({ messageType, payload, applicationId, intentId, recordId = null, occurredAt = null, identity }) {
     const entry = {
       messageId: uuid(),
       intentId,
+      recordId,
+      // When it happened, if that is not "now" (a fill recorded offline): every attempt says so.
+      ...(occurredAt ? { occurredAt } : {}),
       clientInstanceId: await store.clientInstanceId(),
       messageType,
       archiveId: identity.archiveId,
@@ -110,6 +134,10 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     let outcome = null;
     await store.updateOutbox(list => {
       if (intentId && list.some(item => item.intentId === intentId)) {
+        outcome = { status: 'duplicate', reason: 'already_queued' };
+        return list;
+      }
+      if (recordId && list.some(item => item.recordId === recordId)) {
         outcome = { status: 'duplicate', reason: 'already_queued' };
         return list;
       }
@@ -157,6 +185,7 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
       payload: entry.payload,
       identity,
       sourceRestoreEpoch: entry.sourceRestoreEpoch,
+      occurredAt: entry.occurredAt,
       now
     });
 
@@ -166,9 +195,7 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
       // The desktop has committed. Only now may the intent and the queue entry go, and only
       // now may the sidebar say the desktop has it.
       await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
-      if (entry.intentId) {
-        await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
-      }
+      await forgetSource(store, entry);
       return {
         status: 'saved',
         messageId: entry.messageId,
@@ -245,10 +272,24 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     queryCandidates,
     bindAndSend,
     confirmSubmit,
+    sendFill,
     drainOnce,
     deliverOne,
     markDue,
     list: () => store.getOutbox(),
     remove: messageId => store.updateOutbox(list => list.filter(item => item.messageId !== messageId))
   };
+}
+
+/**
+ * The intent or fill record a finished entry came from. Called once the desktop holds the
+ * write (or the user discarded it): the source has nothing left to wait for.
+ */
+export async function forgetSource(store, entry) {
+  if (entry.intentId) {
+    await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
+  }
+  if (entry.recordId) {
+    await store.updateFillRecords(list => list.filter(item => item.recordId !== entry.recordId));
+  }
 }

--- a/link/reconcile.mjs
+++ b/link/reconcile.mjs
@@ -1,5 +1,6 @@
 import { buildEnvelope } from './envelope.mjs';
 import { sendOnce } from './transport.mjs';
+import { forgetSource } from './outbox.mjs';
 import {
   MAX_RECONCILE_ITEMS,
   payloadBodySha256,
@@ -58,9 +59,7 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
           // The desktop already executed it. Drop the queue entry and the intent behind it,
           // and add nothing: `applied` confirms history, it does not license a rewrite.
           await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
-          if (entry.intentId) {
-            await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
-          }
+          await forgetSource(store, entry);
           report.applied.push({ messageId: entry.messageId, resultId: answer.resultId });
           continue;
         }
@@ -99,9 +98,7 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
 
     if (choice === 'discard') {
       await store.updateOutbox(list => list.filter(item => item.messageId !== messageId));
-      if (entry.intentId) {
-        await store.updateIntents(list => list.filter(item => item.intentId !== entry.intentId));
-      }
+      await forgetSource(store, entry);
       return { status: 'discarded' };
     }
 

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -10,7 +10,7 @@ import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
  * "saved on the desktop" are different claims, and the difference has to survive the trip to
  * the sidebar rather than being decided by whoever formats the string.
  */
-export function createRouter({ session, intents, outbox, drain, reconcile, extensionId }) {
+export function createRouter({ session, intents, outbox, drain, reconcile, fillRecords = null, store = null, extensionId }) {
   async function handle(message) {
     const type = message?.type;
     if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
@@ -54,7 +54,41 @@ export function createRouter({ session, intents, outbox, drain, reconcile, exten
     }
 
     if (type === MSG.listQueue) {
-      return { intents: await intents.list(), outbox: await outbox.list() };
+      // Bound records are shown through their outbox entry; only the waiting ones are listed.
+      const waiting = fillRecords
+        ? (await fillRecords.list()).filter(record => record.status === 'pending_bind')
+        : [];
+      return { intents: await intents.list(), outbox: await outbox.list(), fillRecords: waiting };
+    }
+
+    if (type === MSG.linkState) {
+      // Answered from storage alone. Probing here would start the native host — and with it
+      // the desktop application — after every single fill, for a card most users dismiss.
+      return { everPaired: Boolean(await store?.hasEverPaired()) };
+    }
+
+    if (type === MSG.recordFill) {
+      const probe = await session.probe();
+      const created = await fillRecords.create({ raw: message.raw, mode: probe.mode });
+      if (created.status !== 'recorded') return { ...created, mode: probe.mode };
+      if (!message.applicationId || probe.mode !== 'ready') return { ...created, mode: probe.mode };
+      const sent = await bindFill(created.record.recordId, message.applicationId, probe.identity);
+      return { ...sent, record: created.record, mode: probe.mode };
+    }
+
+    if (type === MSG.bindFill) {
+      // A fresh handshake, for the same reason as MSG.bind: the stamped epoch has to be the
+      // one the write will be judged against, not whatever was current when the list was drawn.
+      const probe = await session.probe();
+      // Nothing is queued without a desktop to stamp the epoch: the record keeps waiting for a
+      // choice, and saying "pending" would promise an automatic send that will not happen.
+      if (probe.mode !== 'ready') return { status: 'recorded', mode: probe.mode };
+      return bindFill(message.recordId, message.applicationId, probe.identity);
+    }
+
+    if (type === MSG.removeFill) {
+      const removed = await fillRecords.removeWaiting(message.recordId);
+      return removed ? { ok: true } : { ok: false, reason: 'not_waiting' };
     }
 
     if (type === MSG.retry) {
@@ -64,9 +98,11 @@ export function createRouter({ session, intents, outbox, drain, reconcile, exten
     }
 
     if (type === MSG.cancel) {
-      // Giving up on the bound message. The intent stays, so the user can pick a different
-      // application or delete it outright.
+      // Giving up on the bound message. The intent or fill record stays, so the user can
+      // pick a different application or delete it outright.
+      const entry = (await outbox.list()).find(item => item.messageId === message.messageId);
       await drain.cancel(message.messageId);
+      if (entry?.recordId && fillRecords) await fillRecords.unbind(entry.recordId);
       return { ok: true };
     }
 
@@ -99,6 +135,18 @@ export function createRouter({ session, intents, outbox, drain, reconcile, exten
     }
 
     return null;
+  }
+
+  // Claim first, then queue. The claim is what makes a second click a duplicate; a queue
+  // that refuses the entry hands the record back so it is not stuck as "bound" to nothing.
+  async function bindFill(recordId, applicationId, identity) {
+    if (!applicationId) return { status: 'rejected', reason: 'no_application' };
+    const claim = await fillRecords.claim(recordId, applicationId);
+    if (claim.status === 'unknown') return { status: 'rejected', reason: 'unknown_record' };
+    if (claim.status === 'duplicate') return { status: 'duplicate' };
+    const result = await outbox.sendFill({ record: claim.record, applicationId, identity });
+    if (result.status === 'rejected') await fillRecords.unbind(recordId);
+    return result;
   }
 
   return { handle };

--- a/link/snapshot.mjs
+++ b/link/snapshot.mjs
@@ -59,31 +59,11 @@ export function isSecretFieldValue(value) {
  * the fill without a snapshot rather than failing the fill.
  */
 export async function buildSnapshot(template, { now = () => new Date() } = {}) {
-  let omittedFieldCount = 0;
-  const groups = [];
-
-  for (const group of Array.isArray(template?.groups) ? template.groups : []) {
-    const fields = [];
-    const secretGroup = isSecretFieldName(group?.name);
-    for (const field of Array.isArray(group?.fields) ? group.fields : []) {
-      const key = String(field?.key ?? '').trim();
-      if (!key) continue;
-      const value = String(field?.value ?? '');
-      if (secretGroup || isSecretFieldName(key) || isSecretFieldValue(value)) {
-        omittedFieldCount += 1;
-        continue;
-      }
-      fields.push({ key, value });
-    }
-    if (fields.length) groups.push({ name: String(group?.name ?? '').trim() || '未分类', fields });
-  }
-
+  const { groups, omittedFieldCount } = keptGroups(template);
   if (!groups.length) return { error: 'empty' };
 
   const templateName = String(template?.name ?? '').trim() || '未命名模板';
-  // The content short code D01 §8.5 asks for when the plugin has no revision counter. It
-  // covers the groups only, so two captures of an unchanged template share a version.
-  const templateVersion = (await sha256Hex(encoder.encode(canonicalJson(groups)))).slice(0, 12);
+  const templateVersion = await versionOf(groups);
 
   const bytes = encoder.encode(canonicalJson({
     format: SNAPSHOT_FORMAT,
@@ -105,6 +85,45 @@ export async function buildSnapshot(template, { now = () => new Date() } = {}) {
     templateVersion,
     omittedFieldCount
   };
+}
+
+/**
+ * The version a snapshot of this template would carry, without building one. A fill record
+ * reports it even when the user keeps the snapshot to themselves, so both must agree.
+ */
+export async function templateVersionOf(template) {
+  const { groups } = keptGroups(template);
+  return groups.length ? versionOf(groups) : null;
+}
+
+// The groups and fields a snapshot keeps: blank keys and secret-looking fields are dropped.
+function keptGroups(template) {
+  let omittedFieldCount = 0;
+  const groups = [];
+
+  for (const group of Array.isArray(template?.groups) ? template.groups : []) {
+    const fields = [];
+    const secretGroup = isSecretFieldName(group?.name);
+    for (const field of Array.isArray(group?.fields) ? group.fields : []) {
+      const key = String(field?.key ?? '').trim();
+      if (!key) continue;
+      const value = String(field?.value ?? '');
+      if (secretGroup || isSecretFieldName(key) || isSecretFieldValue(value)) {
+        omittedFieldCount += 1;
+        continue;
+      }
+      fields.push({ key, value });
+    }
+    if (fields.length) groups.push({ name: String(group?.name ?? '').trim() || '未分类', fields });
+  }
+
+  return { groups, omittedFieldCount };
+}
+
+// The content short code D01 §8.5 asks for when the plugin has no revision counter. It covers
+// the kept groups only, so two captures of an unchanged template share a version.
+async function versionOf(groups) {
+  return (await sha256Hex(encoder.encode(canonicalJson(groups)))).slice(0, 12);
 }
 
 /** Split snapshot bytes into protocol chunks, each with its own digest. */

--- a/link/store.mjs
+++ b/link/store.mjs
@@ -1,10 +1,11 @@
-// The four keys D01 allocated to the desktop link. Nothing else in chrome.storage.local
-// belongs to it.
+// The keys allocated to the desktop link: D01's four, plus D08's fill records (the §8.10
+// list was extended for it). Nothing else in chrome.storage.local belongs to it.
 export const KEYS = {
   intents: 'desktopSaveIntents',
   outbox: 'desktopOutbox',
   clientInstanceId: 'desktopClientInstanceId',
-  pairing: 'desktopPairing'
+  pairing: 'desktopPairing',
+  fillRecords: 'desktopFillRecords'
 };
 
 // Keys the existing plugin owns. Listed so the boundary is testable, not just documented.
@@ -62,6 +63,9 @@ export function createStore({ storage, uuid }) {
 
     getOutbox: () => readList(KEYS.outbox),
     updateOutbox: change => updateList(KEYS.outbox, change),
+
+    getFillRecords: () => readList(KEYS.fillRecords),
+    updateFillRecords: change => updateList(KEYS.fillRecords, change),
 
     async getPairing() {
       const stored = await storage.get([KEYS.pairing]);

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -6,6 +6,7 @@ import { createOutbox } from './outbox.mjs';
 import { createReconcile } from './reconcile.mjs';
 import { createDrain, ALARM_NAME } from './drain.mjs';
 import { createRouter } from './router.mjs';
+import { createFillRecords } from './fillrecords.mjs';
 import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
 
 /**
@@ -40,6 +41,8 @@ export function installDesktopLink(api) {
     outbox,
     drain,
     reconcile,
+    fillRecords: createFillRecords(deps),
+    store,
     extensionId: api.runtime.id
   });
 

--- a/tests/link-degradation.test.js
+++ b/tests/link-degradation.test.js
@@ -109,3 +109,70 @@ test('a confirmed submission says so and nothing more', async () => {
   assert.match(pending.text, /待同步/);
   assert.equal(pending.text.includes('已投递'), false);
 });
+
+// --- D08: archiving a fill -----------------------------------------------------------
+
+test('only a persisted fill.submit is described as archived on the desktop', async () => {
+  const { describeFillRecordResult } = await load();
+  const saved = describeFillRecordResult({ status: 'saved' });
+  assert.match(saved.text, /已留档到桌面/);
+
+  for (const result of [
+    { status: 'recorded', mode: 'unavailable' },
+    { status: 'recorded', mode: 'incompatible' },
+    { status: 'pending' },
+    { status: 'duplicate' },
+    { status: 'rejected', reason: 'queue_full' },
+    { status: 'rejected', reason: 'unknown_record' },
+    { status: 'not_recorded', reason: 'never_paired' },
+    { status: 'failed', code: 'invalid_payload' },
+    { status: 'something_new' }
+  ]) {
+    const copy = describeFillRecordResult(result);
+    assert.equal(typeof copy.text, 'string');
+    assert.equal(copy.text.includes('已留档到桌面'), false, JSON.stringify(result));
+  }
+});
+
+test('no fill wording ever says the application was submitted', async () => {
+  // Rule 1: a completed fill is not a submission. Not even "not yet submitted" is said here,
+  // so the word cannot drift into a claim.
+  const { describeFillRecordResult, describeFillSummary, describeFillOffer } = await load();
+  const texts = [
+    describeFillOffer({ outcome: 'completed', fieldCount: 3, filledCount: 3, unconfirmedCount: 0 }),
+    describeFillRecordResult({ status: 'saved' }).text,
+    describeFillRecordResult({ status: 'recorded', mode: 'unavailable' }).text,
+    describeFillRecordResult({ status: 'pending' }).text
+  ];
+  for (const outcome of ['completed', 'partial', 'failed', 'cancelled']) {
+    texts.push(describeFillSummary({ outcome, fieldCount: 12, filledCount: 9, unconfirmedCount: 3 }));
+  }
+  for (const text of texts) {
+    assert.equal(/投递|提交/.test(text), false, text);
+  }
+});
+
+test('the fill summary counts what was written into the page, not what the site accepted', async () => {
+  const { describeFillSummary } = await load();
+  const text = describeFillSummary({ outcome: 'partial', fieldCount: 12, filledCount: 9, unconfirmedCount: 3 });
+  assert.match(text, /部分完成/);
+  assert.match(text, /已写入网页 9\/12 项/);
+  assert.match(text, /3 项未确认/);
+  assert.equal(/已保存|已接受/.test(text), false);
+  assert.doesNotMatch(describeFillSummary({ outcome: 'completed', fieldCount: 5, filledCount: 5, unconfirmedCount: 0 }), /未确认/);
+});
+
+test('a full fill-record queue is refused in words, with filling unaffected', async () => {
+  const { describeFillRecordResult } = await load();
+  const copy = describeFillRecordResult({ status: 'rejected', reason: 'queue_full' });
+  assert.match(copy.text, /已满/);
+  assert.match(copy.text, /100/);
+  assert.match(copy.text, /填表/);
+});
+
+test('a refused fill names the likely cause: the application is gone', async () => {
+  const { describeFillRecordResult } = await load();
+  const copy = describeFillRecordResult({ status: 'failed', code: 'invalid_payload' });
+  assert.match(copy.text, /找不到所选的申请/);
+  assert.doesNotMatch(copy.text, /公司和岗位/);
+});

--- a/tests/link-fill-submit.test.js
+++ b/tests/link-fill-submit.test.js
@@ -1,0 +1,295 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const LATER_EPOCH = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+const EVENT = '99999999-9999-4999-8999-999999999999';
+
+const RAW = {
+  outcome: 'partial',
+  cancelled: false,
+  fieldCount: 12,
+  filledCount: 9,
+  unconfirmedCount: 3,
+  timing: { scanMs: 40, roundTripMs: 80, fillMs: 120, totalMs: 240 },
+  urlRedacted: 'https://jobs.example.com/apply',
+  templateName: '默认模板',
+  templateVersion: '0123456789ab',
+  pluginVersion: '0.4.0',
+  job: { company: '星河科技', title: '后端开发', sourceUrl: 'https://jobs.example.com/apply' }
+};
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+const PAIRED = () => fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } });
+
+function handshake(message, epoch = EPOCH) {
+  return {
+    response: {
+      protocolVersion: 1, correlationId: message.messageId, ok: true,
+      payload: { appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1, archiveId: ARCHIVE, restoreEpoch: epoch, capabilities: ['handshake', 'fill.submit'] }
+    }
+  };
+}
+
+const saved = message => ({
+  response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId: EVENT, payload: { resultKind: 'event' } }
+});
+
+const closed = () => ({ lastError: 'Error when communicating with the native messaging host.' });
+
+/**
+ * The whole worker side, wired the way link/worker.mjs wires it, over a scripted desktop.
+ * `desktop(message)` answers every native message; tests switch it between phases.
+ */
+async function harness({ storage = PAIRED(), desktop = closed } = {}) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createReconcile } = await import('../link/reconcile.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+  const { createFillRecords } = await import('../link/fillrecords.mjs');
+  const { createRouter } = await import('../link/router.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date('2026-09-12T08:00:00.000Z');
+  const store = createStore({ storage, uuid });
+  const state = { desktop };
+  const sent = [];
+  const sendNative = async (host, message) => {
+    sent.push(message);
+    return state.desktop(message);
+  };
+  const deps = { store, sendNative, sleep: async () => {}, uuid, now };
+  const session = createSession(deps);
+  const outbox = createOutbox(deps);
+  const reconcile = createReconcile({ ...deps, outbox });
+  const alarms = { async create() {}, async clear() { return true; } };
+  const drain = createDrain({ session, outbox, reconcile, alarms, now });
+  const fillRecords = createFillRecords(deps);
+  const router = createRouter({
+    session, intents: createIntents(deps), outbox, drain, reconcile, fillRecords, store,
+    extensionId: 'abcdefghijklmnopabcdefghijklmnop'
+  });
+  const writes = type => sent.filter(message => message.messageType === type);
+  return { router, storage, sent, state, writes, outbox, reconcile, drain };
+}
+
+// A desktop that handshakes and saves every write.
+const onlineDesktop = message => (message.messageType === 'handshake' ? handshake(message) : saved(message));
+
+test('the sidebar learns whether to offer a fill record without waking the desktop', async () => {
+  const paired = await harness();
+  assert.deepEqual(await paired.router.handle({ type: 'DESKTOP_LINK_STATE' }), { everPaired: true });
+  const fresh = await harness({ storage: fakeStorage() });
+  assert.deepEqual(await fresh.router.handle({ type: 'DESKTOP_LINK_STATE' }), { everPaired: false });
+  assert.equal(paired.sent.length + fresh.sent.length, 0, 'no native host was started to answer this');
+});
+
+test('a fill recorded against a chosen application becomes exactly one fill.submit', async () => {
+  const { router, storage, writes } = await harness({ desktop: onlineDesktop });
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+
+  assert.equal(result.status, 'saved');
+  const [message] = writes('fill.submit');
+  assert.equal(writes('fill.submit').length, 1);
+  assert.equal(message.payload.applicationId, APPLICATION);
+  assert.equal(message.payload.outcome, 'partial');
+  assert.equal(message.payload.filledCount, 9);
+  assert.equal(message.payload.unconfirmedCount, 3);
+  assert.equal(message.payload.sourceRestoreEpoch, EPOCH);
+  assert.match(message.payload.payloadSha256, /^[0-9a-f]{64}$/);
+  // Nothing about the fill is left behind once the desktop has it.
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+test('the envelope the plugin builds passes the vendored validator', async () => {
+  const { validateRequest } = await import('../link/protocol/validate.mjs');
+  const { router, writes } = await harness({ desktop: onlineDesktop });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+  await validateRequest(writes('fill.submit')[0]);
+});
+
+test('with the desktop closed the fill waits as a record, and nothing claims it was archived', async () => {
+  const { router, storage, writes } = await harness();
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+
+  assert.equal(result.status, 'recorded');
+  assert.equal(result.mode, 'unavailable');
+  assert.equal(writes('fill.submit').length, 0);
+  assert.equal(storage.data.desktopFillRecords.length, 1);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+});
+
+test('a profile that never paired keeps nothing', async () => {
+  const { router, storage } = await harness({ storage: fakeStorage() });
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  assert.equal(result.status, 'not_recorded');
+  assert.equal('desktopFillRecords' in storage.data, false);
+  assert.equal('desktopOutbox' in storage.data, false);
+});
+
+test('a waiting record is bound later from the pending list and sent once', async () => {
+  const { router, storage, state, writes } = await harness();
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+
+  state.desktop = onlineDesktop;
+  const bound = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(bound.status, 'saved');
+  assert.equal(writes('fill.submit').length, 1);
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+});
+
+test('binding the same record twice queues it once', async () => {
+  const { router, writes, storage } = await harness({ desktop: onlineDesktop });
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+
+  const results = await Promise.all([
+    router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION }),
+    router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION })
+  ]);
+  assert.deepEqual(results.map(result => result.status).sort(), ['duplicate', 'saved']);
+  assert.equal(writes('fill.submit').length, 1, 'two clicks, one event');
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+});
+
+test('a record already sent cannot be bound again by a sidebar drawn before it went', async () => {
+  const { router, writes } = await harness({ desktop: onlineDesktop });
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  const again = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(again.status, 'rejected');
+  assert.equal(again.reason, 'unknown_record');
+  assert.equal(writes('fill.submit').length, 1);
+});
+
+test('the same messageId is resent until the desktop answers, and the event is written once', async () => {
+  const { router, state, storage, writes } = await harness({
+    desktop: message => (message.messageType === 'handshake' ? handshake(message) : closed())
+  });
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+  assert.equal(result.status, 'pending');
+  const [entry] = storage.data.desktopOutbox;
+  assert.equal(entry.messageType, 'fill.submit');
+  assert.equal(storage.data.desktopFillRecords[0].status, 'bound');
+
+  state.desktop = onlineDesktop;
+  const retried = await router.handle({ type: 'DESKTOP_RETRY', messageId: entry.messageId });
+  assert.equal(retried.status, 'saved');
+  const ids = writes('fill.submit').map(message => message.messageId);
+  assert.deepEqual([...new Set(ids)], [entry.messageId], 'every attempt reused the one messageId');
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+});
+
+test('cancelling a queued fill puts the record back so another application can be chosen', async () => {
+  const { router, storage } = await harness({
+    desktop: message => (message.messageType === 'handshake' ? handshake(message) : closed())
+  });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+  const [entry] = storage.data.desktopOutbox;
+  await router.handle({ type: 'DESKTOP_CANCEL', messageId: entry.messageId });
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+  assert.equal(storage.data.desktopFillRecords[0].applicationId, null);
+});
+
+test('removing a waiting record deletes it and sends nothing', async () => {
+  const { router, storage, sent } = await harness();
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  const before = sent.length;
+  await router.handle({ type: 'DESKTOP_REMOVE_FILL', recordId: record.recordId });
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+  assert.equal(sent.length, before);
+});
+
+test('the pending list shows waiting records next to the queue', async () => {
+  const { router } = await harness();
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  const listed = await router.handle({ type: 'DESKTOP_LIST_QUEUE' });
+  assert.equal(listed.fillRecords.length, 1);
+  assert.deepEqual(listed.intents, []);
+  assert.deepEqual(listed.outbox, []);
+});
+
+test('after a restore, an applied fill leaves no record behind and a discarded one neither', async () => {
+  for (const [status, choice] of [['applied', null], ['not_found', 'discard']]) {
+    const { router, storage, state, drain } = await harness({
+      desktop: message => (message.messageType === 'handshake' ? handshake(message) : closed())
+    });
+    await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+    const [entry] = storage.data.desktopOutbox;
+    assert.equal(entry.sourceRestoreEpoch, EPOCH);
+
+    // The desktop comes back restored: a new epoch, and a reconcile answer for the old write.
+    state.desktop = message => {
+      if (message.messageType === 'handshake') return handshake(message, LATER_EPOCH);
+      if (message.messageType === 'outbox.reconcile') {
+        return {
+          response: {
+            protocolVersion: 1, correlationId: message.messageId, ok: true,
+            payload: { items: message.payload.items.map(item => ({ ...item, status, ...(status === 'applied' ? { resultId: EVENT } : {}) })) }
+          }
+        };
+      }
+      return closed();
+    };
+    await drain.run();
+
+    if (choice) {
+      assert.equal(storage.data.desktopOutbox[0].status, 'needs_user', 'not_found stops for the user');
+      await router.handle({ type: 'DESKTOP_RESOLVE', messageId: entry.messageId, choice });
+    }
+    assert.deepEqual(storage.data.desktopOutbox, [], status);
+    assert.deepEqual(storage.data.desktopFillRecords, [], status);
+  }
+});
+
+test('a fill bound days later still says when it happened', async () => {
+  const { router, state, writes } = await harness();
+  const endedAt = '2026-09-09T10:00:00.000Z';
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: { ...RAW, endedAt } });
+  state.desktop = onlineDesktop;
+  await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(writes('fill.submit')[0].occurredAt, endedAt);
+
+  // A time from the future, or none, falls back to when the record was made.
+  const other = await harness();
+  const { record: later } = await other.router.handle({ type: 'DESKTOP_RECORD_FILL', raw: { ...RAW, endedAt: '2027-01-01T00:00:00.000Z' } });
+  assert.equal(later.occurredAt, '2026-09-12T08:00:00.000Z');
+});
+
+test('choosing an application while the desktop is closed leaves the record waiting, and says so', async () => {
+  const { router, storage } = await harness();
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  const result = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(result.status, 'recorded', 'not "pending": nothing was queued');
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+});
+
+test('a record already bound cannot be deleted from a sidebar drawn before the bind', async () => {
+  const { router, storage } = await harness({ desktop: message => (message.messageType === 'handshake' ? handshake(message) : closed()) });
+  const { record } = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION });
+  assert.equal(storage.data.desktopFillRecords[0].status, 'bound');
+  const result = await router.handle({ type: 'DESKTOP_REMOVE_FILL', recordId: record.recordId });
+  assert.equal(result.ok, false);
+  assert.equal(storage.data.desktopFillRecords.length, 1);
+  assert.equal(storage.data.desktopOutbox.filter(entry => entry.messageType === 'fill.submit').length, 1);
+});

--- a/tests/link-fillrecords.test.js
+++ b/tests/link-fillrecords.test.js
@@ -1,0 +1,193 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+// What content.js hands over when a fill ends: its own counters and timings, the page URL
+// already redacted, the template label. Nothing else.
+const RAW = {
+  outcome: 'success',
+  cancelled: false,
+  fieldCount: 12,
+  filledCount: 10,
+  unconfirmedCount: 0,
+  timing: { scanMs: 40.4, roundTripMs: 80.6, fillMs: 120.2, totalMs: 241.9 },
+  urlRedacted: 'https://jobs.example.com/apply?utm_source=mail',
+  templateName: '默认模板',
+  templateVersion: '0123456789ab',
+  pluginVersion: '0.4.0',
+  job: { company: '星河科技', title: '后端开发', sourceUrl: 'https://jobs.example.com/apply' }
+};
+
+async function load() {
+  return import('../link/fillrecords.mjs');
+}
+
+async function makeRecords(storage = fakeStorage()) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createFillRecords } = await load();
+  let minted = 0;
+  const store = createStore({ storage, uuid: () => 'client-1' });
+  const records = createFillRecords({
+    store,
+    uuid: () => `record-${++minted}`,
+    now: () => new Date('2026-09-12T08:00:00.000Z')
+  });
+  return { records, store, storage };
+}
+
+test('fill outcomes map onto the protocol vocabulary, cancellation included', async () => {
+  const { buildFillPayload } = await load();
+  const outcome = raw => buildFillPayload({ ...RAW, ...raw }).outcome;
+  assert.equal(outcome({ outcome: 'success' }), 'completed');
+  assert.equal(outcome({ outcome: 'partial' }), 'partial');
+  assert.equal(outcome({ outcome: 'failed', filledCount: 0 }), 'failed');
+  assert.equal(outcome({ outcome: 'failed', cancelled: true, filledCount: 0 }), 'cancelled');
+  // Cancelling only drops the AI wait; what local matching already wrote stays written.
+  assert.equal(outcome({ outcome: 'success', cancelled: true, filledCount: 3 }), 'partial');
+  // A failure after some fields were written did write them; "failed" would hide that.
+  assert.equal(outcome({ outcome: 'failed', filledCount: 2 }), 'partial');
+});
+
+test('the payload carries counts, timings and labels and nothing else', async () => {
+  const { buildFillPayload } = await load();
+  const payload = buildFillPayload({
+    ...RAW,
+    matches: [{ fieldId: 'f1', value: '张三' }],
+    values: ['张三'],
+    aiConfig: { apiKey: 'sk-synthetic' },
+    prompt: 'synthetic prompt'
+  });
+  assert.deepEqual(Object.keys(payload).sort(), [
+    'durationsMs', 'fieldCount', 'filledCount', 'outcome', 'pluginVersion',
+    'templateName', 'templateVersion', 'unconfirmedCount', 'urlRedacted'
+  ]);
+  assert.deepEqual(payload.durationsMs, { scan: 40, match: 81, fill: 120, total: 242 });
+  const text = JSON.stringify(payload);
+  for (const leak of ['张三', 'sk-synthetic', 'synthetic prompt', 'fieldId']) {
+    assert.equal(text.includes(leak), false, `${leak} leaked`);
+  }
+});
+
+test('the URL is redacted again on the worker side', async () => {
+  const { buildFillPayload } = await load();
+  const payload = buildFillPayload({
+    ...RAW,
+    urlRedacted: 'https://jobs.example.com/apply?access_token=abc&code=42&utm_source=mail#frag'
+  });
+  assert.equal(payload.urlRedacted, 'https://jobs.example.com/apply?utm_source=mail');
+});
+
+test('counts and timings are clamped to what the protocol accepts', async () => {
+  const { buildFillPayload } = await load();
+  const payload = buildFillPayload({
+    ...RAW,
+    fieldCount: 20000,
+    filledCount: -3,
+    unconfirmedCount: 1.7,
+    timing: { scanMs: null, roundTripMs: Number.NaN, fillMs: 9e9, totalMs: 5 }
+  });
+  assert.equal(payload.fieldCount, 10000);
+  assert.equal(payload.filledCount, 0);
+  assert.equal(payload.unconfirmedCount, 2);
+  assert.deepEqual(payload.durationsMs, { fill: 3600000, total: 5 });
+});
+
+test('a missing template name falls back rather than failing the record', async () => {
+  const { buildFillPayload } = await load();
+  assert.equal(buildFillPayload({ ...RAW, templateName: '   ' }).templateName, '未命名模板');
+  assert.equal(buildFillPayload({ ...RAW, templateName: 'x'.repeat(300) }).templateName.length, 200);
+  assert.equal('templateVersion' in buildFillPayload({ ...RAW, templateVersion: '' }), false);
+});
+
+test('a fill record is kept only for a profile that can ever reach a desktop', async () => {
+  for (const mode of ['not_installed', 'never_paired', 'not_paired']) {
+    const { records, storage } = await makeRecords();
+    const result = await records.create({ raw: RAW, mode });
+    assert.deepEqual(result, { status: 'not_recorded', reason: mode });
+    assert.equal('desktopFillRecords' in storage.data, false, mode);
+  }
+  for (const mode of ['ready', 'unavailable', 'incompatible']) {
+    const { records, storage } = await makeRecords();
+    const result = await records.create({ raw: RAW, mode });
+    assert.equal(result.status, 'recorded', mode);
+    assert.equal(storage.data.desktopFillRecords.length, 1);
+  }
+});
+
+test('a record holds the fill, a job hint for finding candidates, and no identity', async () => {
+  const { records } = await makeRecords();
+  const { record } = await records.create({ raw: RAW, mode: 'unavailable' });
+  assert.equal(record.recordId, 'record-1');
+  assert.equal(record.clientInstanceId, 'client-1');
+  assert.equal(record.status, 'pending_bind');
+  assert.equal(record.applicationId, null);
+  assert.equal(record.createdAt, '2026-09-12T08:00:00.000Z');
+  assert.equal(record.fill.outcome, 'completed');
+  assert.deepEqual(record.job, { company: '星河科技', title: '后端开发', sourceUrl: 'https://jobs.example.com/apply' });
+  for (const forbidden of ['messageId', 'restoreEpoch', 'sourceRestoreEpoch', 'archiveId']) {
+    assert.equal(forbidden in record, false, forbidden);
+  }
+});
+
+test('the hundred-and-first record is refused and the rest are untouched', async () => {
+  const { records, storage } = await makeRecords();
+  for (let i = 0; i < 100; i += 1) {
+    assert.equal((await records.create({ raw: RAW, mode: 'unavailable' })).status, 'recorded');
+  }
+  const refused = await records.create({ raw: RAW, mode: 'unavailable' });
+  assert.deepEqual(refused, { status: 'rejected', reason: 'queue_full' });
+  assert.equal(storage.data.desktopFillRecords.length, 100);
+});
+
+test('claiming, unbinding and removing a record', async () => {
+  const { records, storage } = await makeRecords();
+  const { record } = await records.create({ raw: RAW, mode: 'ready' });
+  const claimed = await records.claim(record.recordId, 'app-1');
+  assert.equal(claimed.status, 'claimed');
+  assert.equal(claimed.record.recordId, record.recordId);
+  // A second claim is a double click, not a second decision.
+  assert.deepEqual(await records.claim(record.recordId, 'app-1'), { status: 'duplicate' });
+  assert.deepEqual(await records.claim('no-such-record', 'app-1'), { status: 'unknown' });
+  assert.deepEqual(
+    { status: storage.data.desktopFillRecords[0].status, applicationId: storage.data.desktopFillRecords[0].applicationId },
+    { status: 'bound', applicationId: 'app-1' }
+  );
+  await records.unbind(record.recordId);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+  assert.equal(storage.data.desktopFillRecords[0].applicationId, null);
+  await records.remove(record.recordId);
+  assert.deepEqual(storage.data.desktopFillRecords, []);
+});
+
+test('the fill records key is the only new key and the plugin keys are untouched', async () => {
+  const { KEYS, RESERVED_KEYS } = await import('../link/store.mjs');
+  assert.equal(KEYS.fillRecords, 'desktopFillRecords');
+  assert.equal(RESERVED_KEYS.includes('desktopFillRecords'), false);
+
+  const reserved = { templates: [{ id: 't' }], activeTemplateId: 't', aiConfig: { apiKey: 'k' } };
+  const { records, storage } = await makeRecords(fakeStorage(structuredClone(reserved)));
+  await records.create({ raw: RAW, mode: 'unavailable' });
+  for (const key of Object.keys(reserved)) assert.deepEqual(storage.data[key], reserved[key]);
+});
+
+test('a page URL too long for a candidate lookup is not kept as the hint', async () => {
+  // queryCandidates caps sourceUrl at 2,000 characters. A longer hint would make every
+  // lookup invalid, and a record with a company name would then have no way to be bound.
+  const { records } = await makeRecords();
+  const long = `https://jobs.example.com/apply?role=${'a'.repeat(2100)}`;
+  const { record } = await records.create({ raw: { ...RAW, job: { ...RAW.job, sourceUrl: long } }, mode: 'unavailable' });
+  assert.equal(record.job.company, '星河科技');
+  assert.equal(record.job.sourceUrl, '');
+});

--- a/tests/link-manifest.test.js
+++ b/tests/link-manifest.test.js
@@ -114,3 +114,48 @@ test('the handshake reports the same version the manifest declares', async () =>
     'link/session.mjs PLUGIN_VERSION must match manifest.json version'
   );
 });
+
+test('the sidebar offers archiving a fill and leaves the wording to link/copy.mjs', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  assert.match(source, /resume-pro-fill-record/);
+  assert.match(source, /DESKTOP_RECORD_FILL/);
+  assert.match(source, /DESKTOP_LINK_STATE/);
+  assert.match(source, /describeFillRecordResult/);
+  // Claiming the desktop has the record is copy.mjs's call alone, after a persisted reply.
+  assert.equal(source.includes('已留档到桌面'), false);
+});
+
+test('a hidden sidebar panel stays hidden even when its class sets a display', async () => {
+  // The save form, the candidate box and the fill-record card are flex boxes toggled with
+  // the `hidden` attribute. An author `display` rule beats the browser's [hidden] rule, so
+  // without this override every one of them shows, empty, on every page.
+  const css = fs.readFileSync(path.join(root, 'content.css'), 'utf8');
+  assert.match(css, /\.resume-pro \[hidden\]\s*\{\s*display:\s*none\s*!important;?\s*\}/);
+});
+
+test('a finished fill is filed under the page it ran on, not the one the user moved to', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  const body = source.slice(source.indexOf('async function offerFillRecord'), source.indexOf('function closeFillRecord'));
+  assert.ok(body.indexOf('extractJobFields(') > 0);
+  assert.ok(body.indexOf('extractJobFields(') < body.indexOf('DESKTOP_LINK_STATE'), 'read the page before waiting on the worker');
+  assert.match(body, /location\.href !== pageUrl/);
+});
+
+test('queue rows describe a retried or resolved entry in the words of its own kind', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  const describe = source.slice(source.indexOf('function describeQueueResult'));
+  assert.match(describe, /fill\.submit[\s\S]*describeFillRecordResult/);
+  const retry = source.slice(source.indexOf('"立即重试"'), source.indexOf('"立即重试"') + 400);
+  assert.match(retry, /describeQueueResult\(/);
+  const resolve = source.slice(source.indexOf('async function resolvePaused'), source.indexOf('function describeOutboxState'));
+  assert.match(resolve, /describeQueueResult\(/);
+  assert.equal(resolve.includes('describeBindResult('), false);
+});
+
+test('an application id typed by hand is checked before anything is bound', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  const body = source.slice(source.indexOf('async function chooseFillApplication'), source.indexOf('async function chooseFillApplication') + 900);
+  assert.match(body, /APPLICATION_ID_PATTERN\.test\(/);
+  const { describeFillRecordResult } = await import('../link/copy.mjs');
+  assert.match(describeFillRecordResult({ status: 'rejected', reason: 'invalid_application_id' }).text, /申请 ID/);
+});

--- a/tests/link-snapshot.test.js
+++ b/tests/link-snapshot.test.js
@@ -160,6 +160,17 @@ test('a 2 MiB snapshot needs at most 64 chunks, well inside the protocol limit',
   assert.equal(chunks.length, 64);
 });
 
+test('the template version a fill record carries is the one its snapshot would carry', async () => {
+  const { buildSnapshot, templateVersionOf } = await load();
+  const snapshot = await buildSnapshot(TEMPLATE, { now: at('2026-09-12T08:00:00.000Z') });
+  assert.equal(await templateVersionOf(TEMPLATE), snapshot.templateVersion);
+  const withSecret = structuredClone(TEMPLATE);
+  withSecret.groups[0].fields.push({ key: '登录密码', value: 'x' });
+  // Secret fields never enter the snapshot, so they do not change its version either.
+  assert.equal(await templateVersionOf(withSecret), snapshot.templateVersion);
+  assert.equal(await templateVersionOf({ name: 'empty', groups: [] }), null);
+});
+
 test('camelCase and Chinese credential names are recognised too', async () => {
   const { isSecretFieldName } = await load();
   for (const name of ['apiKey', 'accessToken', 'clientSecret', 'otpCode', 'userPassword', 'API 密钥', '访问令牌', '私钥']) {


### PR DESCRIPTION
Part of #22 — **PR 3 of 7** in [the D08 breakdown](docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md). Stacked on #57. 快照勾选框在 PR 4 接入，本 PR 只发填写事件。

## 只做

填完表后给出留档入口；用户同意并选定申请后，桌面时间线出现一条准确的填写事件。

- **`link/fillrecords.mjs`**
  - `buildFillPayload` 是 allowlist：只出结果、计数、耗时、脱敏 URL、模板名/版本、插件版本。**不出任何字段值、AI 返回值、prompt、配置**
  - outcome 映射：取消且没写入 → `cancelled`；取消或失败但已写入 → `partial`（不把写进去的抹掉）
  - `FillRecord` 是意图不是消息：没有 `messageId`、没有 epoch；从未配对的 profile 不存任何东西；上限 100
  - `claim()` 在一个串行步骤里把等待中的记录认领给一条申请——两次点击只发一条事件
- **outbox / reconcile**：`sendFill` + `recordId` 防重；桌面落库、对账 `applied`、用户丢弃时连同记录一起清；取消则把记录退回「待选择申请」
- **router**：`DESKTOP_LINK_STATE`（**只读存储**，不拉起 host——否则每次填表都会把桌面程序拉起来）、`DESKTOP_RECORD_FILL`、`DESKTOP_BIND_FILL`、`DESKTOP_REMOVE_FILL`
- **侧边栏**：填写结果下方出现留档卡片（从未配对不出现）；从桌面候选里选申请、**不默认选中、不代为绑定**；桌面不在则进待同步稍后选；全部文案在 `link/copy.mjs`，任何留档文案都不出现「投递」
- `snapshot.mjs`：`templateVersionOf`，与 `buildSnapshot` 共用算法
- 按负责人决定 Q1：`desktopFillRecords` 写入 D01 §8.10 与 README

## 顺带修掉的 D07 缺陷（未发布）

真实浏览器检查时发现：**D07 的保存表单和候选框在每个页面的侧边栏里都一直显示着（空的）**。原因是它们的 class 设了 `display:flex`，作者样式压过了浏览器的 `[hidden]` 规则。已加 `.resume-pro [hidden] { display: none !important }` 并加测试锁住。v0.3.1 不含 D07 界面，所以用户还没见过；不修的话下一个版本会带上。

## 真实浏览器检查（Windows，已发布插件 + 合成招聘页）

AI 接口指向拒绝连接的端口（本地规则匹配仍填 3/4 项），profile 标记为曾配对、桌面不运行：

- 填写前：保存表单、候选框、留档卡片都不显示（按渲染判断）✓
- 填写后：卡片出现在填写结果正下方——「这次填写部分完成：已写入网页 3/4 项。要把这次填写留档到桌面吗？只记结果和计数，不记填写的内容。」✓
- 点「留档到桌面」→ 桌面不可用 → 「已记为待同步（尚未选择申请）……」，待同步里出现「填写留档 · 合成模板」行 ✓
- `desktopFillRecords` 里只有计数、耗时、模板标签和岗位提示，**没有任何字段值** ✓

## 测试

`node --test tests/*.test.js`：427 通过（新增 `link-fillrecords` 10、`link-fill-submit` 14、文案 5、源码 2）

- outcome 映射 6 种；payload 只有 allowlist 字段（塞入字段值/Key/prompt 也带不出去）；SW 侧再脱敏一次 URL；计数与耗时钳到协议范围
- 桌面在线：恰好一条 `fill.submit`，信封过 vendored `validateRequest`；离线：记录 `pending_bind`、零写入；从未配对：什么都不存
- 同一 `messageId` 重发到桌面应答为止；双击绑定只发一条；已发出的记录不能被旧界面再绑一次；取消退回；恢复后 `applied` / 丢弃都不留残记录
- 现有填表回归（含 vm 沙箱里的 `handleAiFillClick` 测试）全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - AI 填写完成后，可选择将填写结果摘要留档到桌面端。
  - 支持选择申请、绑定记录、提交、重试、取消和删除。
  - 待同步列表新增填写留档记录，并显示对应状态与结果说明。
  - 增加填写统计信息，包括结果、字段数量、耗时、模板名称和完成时间。

- **界面优化**
  - 新增填写留档卡片及相关提示。
  - 改进侧边栏面板的显示与隐藏效果。

- **文档**
  - 补充填写留档及待同步队列的使用说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->