### PR TITLE
feat(d08): upload the staged snapshot and clean up only on the complete ACK (#22, PR 4/7)

### DIFF
--- a/content.css
+++ b/content.css
@@ -517,6 +517,21 @@
   background: rgba(248, 250, 252, 0.9);
 }
 
+.resume-pro__fill-record-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #475569;
+  cursor: pointer;
+}
+
+.resume-pro__fill-record-option input {
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
 .resume-pro__candidate-list {
   display: flex;
   flex-direction: column;

--- a/content.js
+++ b/content.js
@@ -132,6 +132,10 @@
         <div class="resume-pro__status" id="resume-pro-status" aria-live="polite"></div>
         <div class="resume-pro__fill-record" id="resume-pro-fill-record" hidden>
           <p class="resume-pro__save-note" id="resume-pro-fill-record-summary"></p>
+          <label class="resume-pro__fill-record-option">
+            <input type="checkbox" id="resume-pro-fill-record-snapshot" checked>
+            <span>附上这次用的简历模板拷贝（先存在本机，传到桌面后可在申请里查看）</span>
+          </label>
           <div class="resume-pro__save-actions">
             <button class="resume-pro__ai-button" type="button" id="resume-pro-fill-record-save">留档到桌面</button>
             <button class="resume-pro__manager-button" type="button" id="resume-pro-fill-record-skip">不留档</button>
@@ -1684,8 +1688,10 @@
 
   let desktopModules = null;
   let pendingFields = null;
-  // The finished fill the card is offering to archive. Held only until the user answers.
+  // The finished fill the card is offering to archive, and a copy of the template it used.
+  // Held only until the user answers; the template copy leaves only if the box is ticked.
   let pendingFill = null;
+  let pendingFillTemplate = null;
 
   async function loadDesktopModules() {
     if (!desktopModules) {
@@ -1809,6 +1815,9 @@
     const job = extract.extractJobFields(document, pageUrl);
     const link = await chrome.runtime.sendMessage({ type: "DESKTOP_LINK_STATE" });
     if (!link?.everPaired) return;
+    // The template the fill actually used, frozen now: editing the template before answering
+    // must not change what the snapshot says was used (D08 decision 2).
+    pendingFillTemplate = template ? structuredClone(template) : null;
     pendingFill = {
       ...raw,
       urlRedacted: job.sourceUrl,
@@ -1819,6 +1828,11 @@
     // The summary is built from exactly what would be sent, so the card cannot promise more.
     card.querySelector("#resume-pro-fill-record-summary").textContent =
       copy.describeFillOffer(fillrecords.buildFillPayload(pendingFill));
+    const option = card.querySelector("#resume-pro-fill-record-snapshot");
+    if (option) {
+      option.checked = true;
+      option.disabled = !pendingFillTemplate;
+    }
     card.hidden = false;
   }
 
@@ -1826,11 +1840,14 @@
     const card = shadowRoot?.querySelector("#resume-pro-fill-record");
     if (card) card.hidden = true;
     pendingFill = null;
+    pendingFillTemplate = null;
   }
 
   async function handleRecordFillClick() {
     const raw = pendingFill;
     if (!raw) return;
+    const withSnapshot = shadowRoot?.querySelector("#resume-pro-fill-record-snapshot")?.checked;
+    const snapshotTemplate = withSnapshot ? pendingFillTemplate : null;
     closeFillRecord();
 
     let candidates = null;
@@ -1844,7 +1861,7 @@
     if (candidates?.status !== "ok") {
       // The desktop is not answering, or the page does not say which company this is. The
       // fill waits, and the application is picked from the pending list later.
-      await recordFill(raw, null);
+      await recordFill(raw, null, snapshotTemplate);
       return;
     }
 
@@ -1853,16 +1870,16 @@
       note: options.length
         ? "这次填写属于哪条申请？"
         : "桌面里还没有这家公司的申请。可以先「保存岗位到本地」，或者稍后在待同步里选择。",
-      onPick: applicationId => recordFill(raw, applicationId),
-      onLater: () => recordFill(raw, null)
+      onPick: applicationId => recordFill(raw, applicationId, snapshotTemplate),
+      onLater: () => recordFill(raw, null, snapshotTemplate)
     });
   }
 
-  async function recordFill(raw, applicationId) {
+  async function recordFill(raw, applicationId, snapshotTemplate) {
     const { copy } = await loadDesktopModules();
     let result;
     try {
-      result = await chrome.runtime.sendMessage({ type: "DESKTOP_RECORD_FILL", raw, applicationId });
+      result = await chrome.runtime.sendMessage({ type: "DESKTOP_RECORD_FILL", raw, applicationId, snapshotTemplate });
     } catch {
       result = { status: "rejected" };
     }
@@ -2110,11 +2127,15 @@
     let intents = [];
     let outbox = [];
     let fillRecords = [];
+    let expired = new Set();
+    let copy;
     try {
       const reply = await chrome.runtime.sendMessage({ type: "DESKTOP_LIST_QUEUE" });
       intents = reply?.intents || [];
       outbox = reply?.outbox || [];
       fillRecords = reply?.fillRecords || [];
+      expired = new Set(reply?.expiredSnapshots || []);
+      ({ copy } = await loadDesktopModules());
     } catch {
       return;
     }
@@ -2146,6 +2167,10 @@
         [record.job?.company, record.job?.title].filter(Boolean).join(" · "),
         "待同步（尚未选择申请）"
       );
+      if (record.snapshot && expired.has(record.snapshot.snapshotId)) {
+        appendNote(row, "附带的简历快照已暂存超过 30 天，要继续还是丢弃？");
+        row.appendChild(rowButton("丢弃快照", () => dropSnapshot(record.snapshot.snapshotId)));
+      }
       row.appendChild(rowButton("选择申请", () => chooseFillApplication(record)));
       row.appendChild(rowButton("删除", async () => {
         await chrome.runtime.sendMessage({ type: "DESKTOP_REMOVE_FILL", recordId: record.recordId });
@@ -2154,7 +2179,20 @@
       list.appendChild(row);
     }
 
-    for (const entry of outbox) {
+    for (const entry of outbox.filter(item => item.messageType === "snapshot.upload")) {
+      const state = copy.describeSnapshotUpload(entry, { expired: expired.has(entry.snapshotId) });
+      const row = pendingRow(`简历快照 · ${entry.payload?.templateName || ""}`, "", state.text);
+      if (state.retry) {
+        row.appendChild(rowButton("立即重试", async () => {
+          await chrome.runtime.sendMessage({ type: "DESKTOP_RETRY", messageId: entry.messageId });
+          refreshPendingList();
+        }));
+      }
+      row.appendChild(rowButton(entry.status === "bytes_lost" ? "移除" : "丢弃快照", () => dropSnapshot(entry.snapshotId)));
+      list.appendChild(row);
+    }
+
+    for (const entry of outbox.filter(item => item.messageType !== "snapshot.upload")) {
       const row = pendingRow(queueLabel(entry), entry.payload?.sourceUrl, describeOutboxState(entry));
       if (entry.status === "needs_user" || entry.status === "paused") {
         appendReconcileChoices(row, entry);
@@ -2173,6 +2211,18 @@
       }));
       list.appendChild(row);
     }
+  }
+
+  function appendNote(row, text) {
+    const note = document.createElement("em");
+    note.textContent = text;
+    row.appendChild(note);
+  }
+
+  // The fill record stays; only the snapshot copy and its upload go.
+  async function dropSnapshot(snapshotId) {
+    await chrome.runtime.sendMessage({ type: "DESKTOP_DROP_SNAPSHOT", snapshotId });
+    refreshPendingList();
   }
 
   // Each kind of queued message has its own wording: a retried fill must not report that a

--- a/desktop/scripts/plugin-release-assets.json
+++ b/desktop/scripts/plugin-release-assets.json
@@ -28,6 +28,7 @@
   "link/staging.mjs",
   "link/store.mjs",
   "link/transport.mjs",
+  "link/uploads.mjs",
   "link/worker.mjs",
   "vendor/pdfjs/LICENSE",
   "vendor/pdfjs/cmaps/78-EUC-H.bcmap",

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -1,4 +1,4 @@
-import { MAX_FILL_RECORDS, MAX_INTENTS, MAX_OUTBOX } from './limits.mjs';
+import { MAX_FILL_RECORDS, MAX_INTENTS, MAX_OUTBOX, MAX_STAGED_SNAPSHOTS } from './limits.mjs';
 
 // User-facing wording for every outcome of a save, in one table.
 //
@@ -191,10 +191,33 @@ export function describeFillSummary(fill) {
 
 /** The card shown after a fill: what happened, and the question. */
 export function describeFillOffer(fill) {
-  return `${describeFillSummary(fill)}要把这次填写留档到桌面吗？只记结果和计数，不记填写的内容。`;
+  return `${describeFillSummary(fill)}要把这次填写留档到桌面吗？留档记的是结果和计数，不记网页上填了什么。`;
 }
 
+// Why a fill was archived without its snapshot. The fill record itself is unaffected: a
+// snapshot is an attachment, and losing it never costs the user the record or the fill.
+const SNAPSHOT_ISSUES = {
+  too_large: '简历快照超过 2 MiB，这次没有附上；填写记录照常留档。',
+  empty: '模板里没有可以保存的字段，这次没有附上简历快照。',
+  staging_full: `暂存的简历快照已满（${MAX_STAGED_SNAPSHOTS} 份 / 20 MiB），这次没有附上。请先处理待同步里的旧留档。`,
+  staging_unavailable: '浏览器存储暂时不可用，这次没有附上简历快照；填写记录照常留档。',
+  bytes_lost: '暂存的简历快照已经丢失，这次只留档填写记录。',
+  queue_full: `待同步的消息已满（${MAX_OUTBOX} 条），简历快照这次没有排上。`
+};
+
 export function describeFillRecordResult(result) {
+  const copy = describeFillRecordStatus(result);
+  const extra = [];
+  if (result?.status === 'saved' && result.uploadQueued) {
+    extra.push('简历快照正在后台上传，传完之前本机会保留一份。');
+  }
+  if (result?.snapshotIssue && SNAPSHOT_ISSUES[result.snapshotIssue]) {
+    extra.push(SNAPSHOT_ISSUES[result.snapshotIssue]);
+  }
+  return extra.length ? { ...copy, text: `${copy.text}${extra.join('')}` } : copy;
+}
+
+function describeFillRecordStatus(result) {
   const { status, mode, reason, code } = result ?? {};
 
   if (status === 'saved') {
@@ -256,3 +279,24 @@ export function describeFillRecordResult(result) {
 const FILL_REFUSALS = {
   invalid_payload: '桌面上找不到所选的申请，这次没有留档。请在「待同步」里重新选择申请。'
 };
+
+/**
+ * One queued snapshot upload in the pending list. A lost copy is never offered as "retry":
+ * there is nothing left to send, and rebuilding it from today's template would upload a
+ * different resume under the old name (walkthrough 10.10).
+ */
+export function describeSnapshotUpload(entry, { expired = false } = {}) {
+  const acked = (entry?.chunks ?? []).filter(chunk => chunk.acked).length;
+  const total = entry?.chunkCount ?? 0;
+  const byStatus = {
+    bytes_lost: { text: '简历快照暂存丢失，请重新留档或在桌面导入。', retry: false },
+    failed: { text: `简历快照被桌面拒绝，已停下（${REFUSALS[entry?.lastError] ?? '原因未知'}）`, retry: true },
+    stalled: { text: '简历快照重试多次仍未传完，等你决定继续还是丢弃。', retry: true },
+    paused: { text: '桌面换过档案库，简历快照已暂停。', retry: false },
+    needs_user: { text: '桌面换过档案库，简历快照等你决定。', retry: false },
+    completed: { text: '简历快照已传完，正在清理本机的暂存副本。', retry: false },
+    discarding: { text: '已放弃这份简历快照，本机副本暂时删不掉，下次启动时再删；它不会再发送。', retry: false }
+  };
+  const copy = byStatus[entry?.status] ?? { text: `简历快照上传中（已传 ${acked}/${total} 块）`, retry: true };
+  return expired ? { ...copy, text: `${copy.text}已暂存超过 30 天，要继续发送还是丢弃？` } : copy;
+}

--- a/link/drain.mjs
+++ b/link/drain.mjs
@@ -14,6 +14,18 @@ export function nextDelayMs(attempts) {
 }
 
 /**
+ * A snapshot upload waits while the fill event it belongs to is still in the queue (D08
+ * decision 7). Queue order alone does not hold: an event backing off is not due, the upload
+ * behind it would be, and an event that failed may never go at all. Until the event is
+ * accepted the upload is not work — neither for a pass nor for an alarm or a host start.
+ */
+export function waitsForFill(entry, queue) {
+  return entry.messageType === 'snapshot.upload'
+    && Boolean(entry.recordId)
+    && queue.some(item => item.messageType === 'fill.submit' && item.recordId === entry.recordId);
+}
+
+/**
  * Drives the outbox on a schedule the service worker can survive.
  *
  * MV3 evicts the worker while entries are still queued, so the wake-up is a chrome alarm
@@ -52,7 +64,8 @@ export function createDrain({ session, outbox, reconcile = null, alarms, now }) 
   // Work the queue can make progress on by itself: a pending entry to send, or a paused one
   // waiting to be reconciled against the archive that exists now.
   async function hasWork() {
-    return (await outbox.list()).some(entry => entry.status === 'pending' || entry.status === 'paused');
+    const queue = await outbox.list();
+    return queue.some(entry => (entry.status === 'pending' && !waitsForFill(entry, queue)) || entry.status === 'paused');
   }
 
   async function retryNow(messageId) {
@@ -73,8 +86,9 @@ export function createDrain({ session, outbox, reconcile = null, alarms, now }) 
   // The next alarm is set for the earliest entry that still has a rung left. A stalled entry
   // is deliberately not counted: nothing about waiting longer will change it.
   async function scheduleNext() {
-    const due = (await outbox.list())
-      .filter(entry => entry.status === 'pending' && entry.nextAttemptAt)
+    const queue = await outbox.list();
+    const due = queue
+      .filter(entry => entry.status === 'pending' && entry.nextAttemptAt && !waitsForFill(entry, queue))
       .map(entry => Date.parse(entry.nextAttemptAt))
       .filter(Number.isFinite);
 

--- a/link/fillrecords.mjs
+++ b/link/fillrecords.mjs
@@ -5,6 +5,10 @@ import { redactUrl } from './redact.mjs';
 // anything. A profile that never did would be told its fill is "pending" forever.
 const MAY_RECORD = new Set(['ready', 'unavailable', 'incompatible']);
 
+export function mayRecord(mode) {
+  return MAY_RECORD.has(mode);
+}
+
 const MAX_COUNT = 10000;
 const MAX_DURATION_MS = 3600000;
 
@@ -107,7 +111,7 @@ function jobHint(job) {
  * application, against a desktop that answered.
  */
 export function createFillRecords({ store, uuid, now }) {
-  async function create({ raw, mode }) {
+  async function create({ raw, mode, snapshot = null }) {
     if (!MAY_RECORD.has(mode)) return { status: 'not_recorded', reason: mode };
 
     const record = {
@@ -115,6 +119,8 @@ export function createFillRecords({ store, uuid, now }) {
       clientInstanceId: await store.clientInstanceId(),
       fill: buildFillPayload(raw),
       job: jobHint(raw?.job),
+      // Metadata of the staged snapshot (D08 §8.5): the bytes are in IndexedDB, never here.
+      snapshot,
       applicationId: null,
       createdAt: now().toISOString(),
       // When the fill ended, sent as the event's occurredAt however late the record is bound.
@@ -154,10 +160,21 @@ export function createFillRecords({ store, uuid, now }) {
   }
 
   // The bound message was given up on. The record goes back to waiting, so the user can
-  // choose another application or delete it.
-  function unbind(recordId) {
+  // choose another application or delete it. A snapshot that was bound with it is dropped:
+  // its chunks carry the old application in their identity and cannot be sent elsewhere.
+  function unbind(recordId, { dropSnapshot = false } = {}) {
+    return store.updateFillRecords(list => list.map(record => {
+      if (record.recordId !== recordId) return record;
+      const next = { ...record, status: 'pending_bind', applicationId: null };
+      if (dropSnapshot) next.snapshot = null;
+      return next;
+    }));
+  }
+
+  // The user gave up on a snapshot; the fill itself is kept.
+  function dropSnapshot(snapshotId) {
     return store.updateFillRecords(list => list.map(record => (
-      record.recordId === recordId ? { ...record, status: 'pending_bind', applicationId: null } : record
+      record.snapshot?.snapshotId === snapshotId ? { ...record, snapshot: null } : record
     )));
   }
 
@@ -165,6 +182,7 @@ export function createFillRecords({ store, uuid, now }) {
     create,
     claim,
     unbind,
+    dropSnapshot,
     list: () => store.getFillRecords(),
     remove: recordId => store.updateFillRecords(list => list.filter(record => record.recordId !== recordId)),
     removeWaiting

--- a/link/limits.mjs
+++ b/link/limits.mjs
@@ -32,3 +32,12 @@ export const MAX_STAGED_BYTES = 20 * 1024 * 1024;
 
 // An unfinished snapshot older than this is brought to the user. It is never deleted for age.
 export const STAGING_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+
+// A staged snapshot no record refers to was left by a worker that died between staging and
+// writing the record. Only cleaned up after this long, so one still on its way is not touched.
+export const ORPHAN_STAGING_GRACE_MS = 60 * 60 * 1000;
+
+// A snapshot binding whose fill.submit never reached the queue is treated as an interrupted
+// bind once it is this old. The two writes are milliseconds apart; this only has to be longer
+// than any bind still in progress when a worker starts.
+export const BIND_INTERRUPTED_GRACE_MS = 2 * 60 * 1000;

--- a/link/messages.mjs
+++ b/link/messages.mjs
@@ -16,7 +16,8 @@ export const MSG = {
   linkState: 'DESKTOP_LINK_STATE',
   recordFill: 'DESKTOP_RECORD_FILL',
   bindFill: 'DESKTOP_BIND_FILL',
-  removeFill: 'DESKTOP_REMOVE_FILL'
+  removeFill: 'DESKTOP_REMOVE_FILL',
+  dropSnapshot: 'DESKTOP_DROP_SNAPSHOT'
 };
 
 export const DESKTOP_MESSAGE_TYPES = new Set(Object.values(MSG));

--- a/link/outbox.mjs
+++ b/link/outbox.mjs
@@ -1,7 +1,8 @@
 import { buildEnvelope } from './envelope.mjs';
 import { sendOnce } from './transport.mjs';
 import { MAX_OUTBOX } from './limits.mjs';
-import { nextDelayMs } from './drain.mjs';
+import { nextDelayMs, waitsForFill } from './drain.mjs';
+import { SNAPSHOT_UPLOAD } from './uploads.mjs';
 
 /**
  * Bound messages: the queue that exists once the user has chosen what to bind to.
@@ -15,7 +16,7 @@ import { nextDelayMs } from './drain.mjs';
  *    the current handshake, the payload remembers what the user actually chose. Refreshing
  *    the payload would silently replay the job into an archive the user never saw.
  */
-export function createOutbox({ store, uuid, now, sendNative, sleep }) {
+export function createOutbox({ store, uuid, now, sendNative, sleep, uploads = null }) {
   const wire = { sendNative, sleep };
 
   async function queryCandidates({ identity, fields }) {
@@ -87,12 +88,19 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
    * is what stops two clicks from sending it twice. The payload is the allowlisted fill body
    * plus the application; field values never get this far.
    */
-  async function sendFill({ record, applicationId, identity }) {
+  async function sendFill({ record, applicationId, identity, snapshot = null }) {
     if (!identity) return { status: 'rejected', reason: 'no_identity' };
     if (!applicationId) return { status: 'rejected', reason: 'no_application' };
+    const payload = { applicationId, ...record.fill };
+    // The event names its snapshot by id and content digest, never by bytes (§8.5). The
+    // protocol requires the two together or neither.
+    if (snapshot?.snapshotId && snapshot?.sha256) {
+      payload.snapshotId = snapshot.snapshotId;
+      payload.sha256 = snapshot.sha256;
+    }
     return enqueue({
       messageType: 'fill.submit',
-      payload: { applicationId, ...record.fill },
+      payload,
       applicationId,
       intentId: null,
       recordId: record.recordId,
@@ -166,6 +174,8 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     for (const entry of await store.getOutbox()) {
       if (entry.status !== 'pending') continue;
       if (!isDue(entry)) continue;
+      // Read again: the event this upload waits for may have been accepted earlier in this pass.
+      if (waitsForFill(entry, await store.getOutbox())) continue;
       const result = await deliver(entry, identity);
       if (result.status === 'saved') saved.push(result);
       else if (result.status === 'failed') failed.push(result);
@@ -175,7 +185,31 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     return { saved, pending, failed };
   }
 
+  /**
+   * Queue an entry built elsewhere — a snapshot upload (link/uploads.mjs). Same guards as a
+   * bound message: no second entry under the same id, and a full queue refuses rather than
+   * dropping the oldest. Not sent here; the drain picks it up.
+   */
+  async function add(entry) {
+    let outcome = { status: 'queued' };
+    await store.updateOutbox(list => {
+      if (list.some(item => item.messageId === entry.messageId)) {
+        outcome = { status: 'duplicate', reason: 'already_queued' };
+        return list;
+      }
+      if (list.length >= MAX_OUTBOX) {
+        outcome = { status: 'rejected', reason: 'queue_full' };
+        return list;
+      }
+      return [...list, entry];
+    });
+    return outcome;
+  }
+
   async function deliver(entry, identity) {
+    if (entry.messageType === SNAPSHOT_UPLOAD) {
+      return uploads ? uploads.deliver(entry, identity) : { status: 'pending', messageId: entry.messageId };
+    }
     if (!identity) return { status: 'pending', entry };
 
     const message = await buildEnvelope({
@@ -259,8 +293,10 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
   }
 
   async function deliverOne(messageId, identity) {
-    const entry = (await store.getOutbox()).find(item => item.messageId === messageId);
+    const queue = await store.getOutbox();
+    const entry = queue.find(item => item.messageId === messageId);
     if (!entry) return { status: 'rejected', reason: 'unknown_message' };
+    if (waitsForFill(entry, queue)) return { status: 'pending', messageId };
     return deliver(entry, identity);
   }
 
@@ -273,6 +309,7 @@ export function createOutbox({ store, uuid, now, sendNative, sleep }) {
     bindAndSend,
     confirmSubmit,
     sendFill,
+    add,
     drainOnce,
     deliverOne,
     markDue,

--- a/link/reconcile.mjs
+++ b/link/reconcile.mjs
@@ -1,6 +1,7 @@
 import { buildEnvelope } from './envelope.mjs';
 import { sendOnce } from './transport.mjs';
 import { forgetSource } from './outbox.mjs';
+import { SNAPSHOT_UPLOAD } from './uploads.mjs';
 import {
   MAX_RECONCILE_ITEMS,
   payloadBodySha256,
@@ -29,7 +30,9 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
 
   /** Ask the desktop what it knows about each paused message. */
   async function run(identity) {
-    const paused = (await store.getOutbox()).filter(entry => entry.status === 'paused');
+    // A snapshot upload stays paused here: its identity is one per chunk, and asking about
+    // it is a separate batch (see reconcileSnapshots).
+    const paused = (await store.getOutbox()).filter(entry => entry.status === 'paused' && entry.messageType !== SNAPSHOT_UPLOAD);
     const report = { applied: [], needsUser: [], unreachable: [] };
 
     for (let at = 0; at < paused.length; at += MAX_RECONCILE_ITEMS) {

--- a/link/router.mjs
+++ b/link/router.mjs
@@ -1,4 +1,7 @@
 import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
+import { mayRecord } from './fillrecords.mjs';
+import { SNAPSHOT_UPLOAD } from './uploads.mjs';
+import { MAX_OUTBOX } from './limits.mjs';
 
 /**
  * Turns sidebar messages into desktop-link operations.
@@ -10,7 +13,7 @@ import { DESKTOP_MESSAGE_TYPES, MSG } from './messages.mjs';
  * "saved on the desktop" are different claims, and the difference has to survive the trip to
  * the sidebar rather than being decided by whoever formats the string.
  */
-export function createRouter({ session, intents, outbox, drain, reconcile, fillRecords = null, store = null, extensionId }) {
+export function createRouter({ session, intents, outbox, drain, reconcile, fillRecords = null, store = null, uploads = null, extensionId }) {
   async function handle(message) {
     const type = message?.type;
     if (!DESKTOP_MESSAGE_TYPES.has(type)) return null;
@@ -58,7 +61,8 @@ export function createRouter({ session, intents, outbox, drain, reconcile, fillR
       const waiting = fillRecords
         ? (await fillRecords.list()).filter(record => record.status === 'pending_bind')
         : [];
-      return { intents: await intents.list(), outbox: await outbox.list(), fillRecords: waiting };
+      const expiredSnapshots = uploads ? await uploads.expired() : [];
+      return { intents: await intents.list(), outbox: await outbox.list(), fillRecords: waiting, expiredSnapshots };
     }
 
     if (type === MSG.linkState) {
@@ -69,11 +73,25 @@ export function createRouter({ session, intents, outbox, drain, reconcile, fillR
 
     if (type === MSG.recordFill) {
       const probe = await session.probe();
-      const created = await fillRecords.create({ raw: message.raw, mode: probe.mode });
-      if (created.status !== 'recorded') return { ...created, mode: probe.mode };
-      if (!message.applicationId || probe.mode !== 'ready') return { ...created, mode: probe.mode };
+      // Staged before the record exists, so a record never points at bytes that are not there.
+      // Nothing is staged for a profile that may not keep a record at all.
+      let snapshot = null;
+      let snapshotIssue = null;
+      if (message.snapshotTemplate && uploads && mayRecord(probe.mode)) {
+        const staged = await uploads.stage(message.snapshotTemplate);
+        snapshot = staged.snapshot ?? null;
+        snapshotIssue = staged.issue ?? null;
+      }
+      const created = await fillRecords.create({ raw: message.raw, mode: probe.mode, snapshot });
+      if (created.status !== 'recorded') {
+        if (snapshot) await uploads.discard(snapshot.snapshotId);
+        return { ...created, mode: probe.mode };
+      }
+      if (!message.applicationId || probe.mode !== 'ready') {
+        return { ...created, mode: probe.mode, snapshotIssue };
+      }
       const sent = await bindFill(created.record.recordId, message.applicationId, probe.identity);
-      return { ...sent, record: created.record, mode: probe.mode };
+      return { ...sent, record: created.record, mode: probe.mode, snapshotIssue: sent.snapshotIssue ?? snapshotIssue };
     }
 
     if (type === MSG.bindFill) {
@@ -87,8 +105,20 @@ export function createRouter({ session, intents, outbox, drain, reconcile, fillR
     }
 
     if (type === MSG.removeFill) {
+      const record = (await fillRecords.list()).find(item => item.recordId === message.recordId);
       const removed = await fillRecords.removeWaiting(message.recordId);
-      return removed ? { ok: true } : { ok: false, reason: 'not_waiting' };
+      if (!removed) return { ok: false, reason: 'not_waiting' };
+      if (record?.snapshot && uploads) await uploads.abandon(record.snapshot.snapshotId);
+      return { ok: true };
+    }
+
+    if (type === MSG.dropSnapshot) {
+      // Delete the copy first, then the entry: a crash in between leaves an entry whose bytes
+      // are gone — reported as such — rather than an upload that quietly comes back. A copy
+      // IndexedDB will not delete yet leaves a tombstone instead (uploads.abandon).
+      await uploads?.abandon(message.snapshotId);
+      await fillRecords?.dropSnapshot(message.snapshotId);
+      return { ok: true };
     }
 
     if (type === MSG.retry) {
@@ -100,9 +130,25 @@ export function createRouter({ session, intents, outbox, drain, reconcile, fillR
     if (type === MSG.cancel) {
       // Giving up on the bound message. The intent or fill record stays, so the user can
       // pick a different application or delete it outright.
-      const entry = (await outbox.list()).find(item => item.messageId === message.messageId);
+      const queue = await outbox.list();
+      const entry = queue.find(item => item.messageId === message.messageId);
+      if (entry?.messageType === SNAPSHOT_UPLOAD) {
+        // Giving up on the snapshot only; the fill event is its own message.
+        await uploads?.abandon(entry.snapshotId);
+        await fillRecords?.dropSnapshot(entry.snapshotId);
+        return { ok: true };
+      }
+      if (entry?.recordId && fillRecords) {
+        // Giving up on a bound fill gives up on the snapshot bound with it: its chunks name
+        // this application and could not be sent to another one.
+        for (const related of queue.filter(item => item.recordId === entry.recordId && item.messageType === SNAPSHOT_UPLOAD)) {
+          await uploads?.abandon(related.snapshotId);
+        }
+        await drain.cancel(entry.messageId);
+        await fillRecords.unbind(entry.recordId, { dropSnapshot: true });
+        return { ok: true };
+      }
       await drain.cancel(message.messageId);
-      if (entry?.recordId && fillRecords) await fillRecords.unbind(entry.recordId);
       return { ok: true };
     }
 
@@ -144,9 +190,43 @@ export function createRouter({ session, intents, outbox, drain, reconcile, fillR
     const claim = await fillRecords.claim(recordId, applicationId);
     if (claim.status === 'unknown') return { status: 'rejected', reason: 'unknown_record' };
     if (claim.status === 'duplicate') return { status: 'duplicate' };
-    const result = await outbox.sendFill({ record: claim.record, applicationId, identity });
-    if (result.status === 'rejected') await fillRecords.unbind(recordId);
-    return result;
+
+    // The snapshot is bound in IndexedDB before either message is queued (link/uploads.mjs).
+    let upload = null;
+    let snapshotIssue = null;
+    if (claim.record.snapshot && uploads && (await outbox.list()).length > MAX_OUTBOX - 2) {
+      // The event and its upload go in together or not at all: an event queued in the last
+      // free place would name a snapshot that has nowhere to wait.
+      await fillRecords.unbind(recordId);
+      return { status: 'rejected', reason: 'queue_full' };
+    }
+    if (claim.record.snapshot && uploads) {
+      const prepared = await uploads.prepare({ record: claim.record, applicationId, identity });
+      upload = prepared.entry ?? null;
+      snapshotIssue = prepared.issue ?? null;
+    }
+
+    const result = await outbox.sendFill({
+      record: claim.record,
+      applicationId,
+      identity,
+      snapshot: upload ? claim.record.snapshot : null
+    });
+    if (result.status === 'rejected') {
+      // prepare() already wrote the binding into IndexedDB; take it back, or the next
+      // repair() would send a snapshot whose event was never queued.
+      if (upload) await uploads.release(upload.snapshotId);
+      await fillRecords.unbind(recordId);
+      return result;
+    }
+    // Queued after the event, and held until the event is accepted (drain.waitsForFill).
+    // Started by the worker once the sidebar has its answer; a snapshot of a few hundred KiB
+    // is several host starts.
+    if (upload) {
+      const added = await outbox.add(upload);
+      if (added.status === 'rejected') snapshotIssue = 'queue_full';
+    }
+    return { ...result, snapshotIssue, uploadQueued: Boolean(upload) && !snapshotIssue };
   }
 
   return { handle };

--- a/link/uploads.mjs
+++ b/link/uploads.mjs
@@ -1,0 +1,391 @@
+import { buildEnvelope } from './envelope.mjs';
+import { sendOnce } from './transport.mjs';
+import { buildSnapshot, encodeBase64, planChunks } from './snapshot.mjs';
+import { nextDelayMs } from './drain.mjs';
+import { BIND_INTERRUPTED_GRACE_MS, MAX_OUTBOX, ORPHAN_STAGING_GRACE_MS } from './limits.mjs';
+
+// A plugin-local queue kind, never a wire message type: one entry per snapshot, carrying the
+// identity of every chunk. Its `messageId` is the snapshotId (entries are keyed by messageId
+// everywhere in the queue); the wire ids are the per-chunk `chunkMessageId`s.
+export const SNAPSHOT_UPLOAD = 'snapshot.upload';
+
+export function firstUnacked(chunks) {
+  const index = chunks.findIndex(chunk => !chunk.acked);
+  return index === -1 ? chunks.length : index;
+}
+
+/**
+ * Record a chunk ACK. The cursor is the first chunk not yet acknowledged, counted from zero:
+ * an ACK for a later chunk never moves it past a gap (§8.5). The desktop's cursor is the
+ * durable truth — if it is behind chunks we believed acknowledged, those go back to unsent.
+ */
+export function applyChunkAck(entry, chunkIndex, desktopCursor) {
+  const chunks = entry.chunks.map(chunk => {
+    if (chunk.chunkIndex === chunkIndex) return { ...chunk, acked: true };
+    if (Number.isInteger(desktopCursor) && chunk.chunkIndex >= desktopCursor && chunk.chunkIndex < chunkIndex) {
+      return { ...chunk, acked: false };
+    }
+    return chunk;
+  });
+  return { ...entry, chunks, chunkCursor: firstUnacked(chunks) };
+}
+
+/**
+ * Snapshot uploads (D08): staging on confirmation, binding to an application, sending chunks
+ * in cursor order, and cleaning up only after the desktop's complete ACK.
+ *
+ * The rules that shape it (§8.5, walkthroughs 10.10 / 10.14 / 10.21):
+ *  - The bytes sent are always the staged originals. Nothing is rebuilt from the live template.
+ *  - Each chunk's id is minted once, written to IndexedDB before the queue entry exists, and
+ *    reused on every retry and after every restart.
+ *  - A chunk ACK advances the cursor; only a complete ACK deletes the staged copy, and that
+ *    delete happens after the queue entry says "completed", so a crash in between finishes the
+ *    cleanup instead of losing the copy early.
+ */
+export function createUploads({ store, staging, sendNative, sleep, uuid, now }) {
+  const wire = { sendNative, sleep };
+
+  /** Build and stage a snapshot of the template the fill used. */
+  async function stage(template) {
+    const built = await buildSnapshot(template, { now });
+    if (built.error) return { issue: built.error };
+    built.chunks = await planChunks(built.bytes);
+    const staged = await staging.stage(built);
+    if (staged.status === 'full') return { issue: 'staging_full' };
+    if (staged.status !== 'staged') return { issue: 'staging_unavailable' };
+    const { record } = staged;
+    return {
+      snapshot: {
+        snapshotId: record.snapshotId,
+        sha256: record.sha256,
+        byteSize: record.byteSize,
+        chunkCount: record.chunkCount,
+        staging: 'idb'
+      }
+    };
+  }
+
+  /**
+   * Bind a staged snapshot to the application the fill was bound to, and return the queue
+   * entry to add. The chunk ids and the binding go into IndexedDB first: if the worker dies
+   * before the entry is queued, repair() rebuilds it from there with the same ids.
+   */
+  async function prepare({ record, applicationId, identity }) {
+    const snapshotId = record.snapshot?.snapshotId;
+    if (!snapshotId) return { issue: 'no_snapshot' };
+    let staged;
+    try {
+      staged = await staging.get(snapshotId);
+    } catch {
+      staged = null;
+    }
+    if (!staged) return { issue: 'bytes_lost' };
+
+    const clientInstanceId = await store.clientInstanceId();
+    const binding = {
+      recordId: record.recordId,
+      applicationId,
+      archiveId: identity.archiveId,
+      sourceRestoreEpoch: identity.restoreEpoch,
+      clientInstanceId,
+      templateName: staged.templateName,
+      boundAt: now().toISOString()
+    };
+    // Ids already minted for this very binding are kept; any other binding gets new ones —
+    // the application is part of each chunk's identity.
+    const sameBinding = staged.binding
+      && staged.binding.applicationId === applicationId
+      && staged.binding.sourceRestoreEpoch === identity.restoreEpoch;
+    const chunks = staged.chunks.map(chunk => ({
+      chunkIndex: chunk.chunkIndex,
+      chunkSha256: chunk.chunkSha256,
+      chunkMessageId: sameBinding && chunk.chunkMessageId ? chunk.chunkMessageId : uuid()
+    }));
+
+    try {
+      await staging.update(snapshotId, current => ({
+        ...current,
+        binding,
+        chunks: current.chunks.map(chunk => ({ ...chunk, chunkMessageId: chunks[chunk.chunkIndex].chunkMessageId }))
+      }));
+    } catch {
+      return { issue: 'staging_unavailable' };
+    }
+
+    return { entry: entryFor(staged, chunks, binding) };
+  }
+
+  function entryFor(staged, chunks, binding) {
+    return {
+      messageId: staged.snapshotId,
+      messageType: SNAPSHOT_UPLOAD,
+      snapshotId: staged.snapshotId,
+      recordId: binding.recordId,
+      intentId: null,
+      clientInstanceId: binding.clientInstanceId,
+      archiveId: binding.archiveId,
+      sourceRestoreEpoch: binding.sourceRestoreEpoch,
+      applicationId: binding.applicationId,
+      sha256: staged.sha256,
+      byteSize: staged.byteSize,
+      chunkCount: staged.chunkCount,
+      chunks: chunks.map(chunk => ({ ...chunk, acked: false })),
+      chunkCursor: 0,
+      // For the pending list only. Never sent: the wire payload is built per chunk.
+      payload: { applicationId: binding.applicationId, templateName: binding.templateName },
+      createdAt: staged.createdAt,
+      status: 'pending',
+      attempts: 0,
+      nextAttemptAt: now().toISOString(),
+      lastError: null
+    };
+  }
+
+  /**
+   * One pass over one snapshot: send chunks from the cursor until the desktop says the
+   * snapshot is complete, a send fails, or every chunk is acknowledged without a complete
+   * ACK (then the last chunk is resent once — the desktop answers a replay from its current
+   * state — and otherwise the entry waits on the retry ladder).
+   */
+  async function deliver(entry, identity) {
+    if (!identity) return { status: 'pending', messageId: entry.messageId };
+    if (entry.status === 'completed') return finish(entry);
+
+    let current = entry;
+    for (let sends = 0; sends <= current.chunkCount; sends += 1) {
+      const resending = current.chunkCursor >= current.chunkCount;
+      const index = resending ? current.chunkCount - 1 : current.chunkCursor;
+      let bytes = null;
+      try {
+        bytes = await staging.readChunk(current.snapshotId, index);
+      } catch {
+        bytes = null;
+      }
+      if (!bytes) {
+        // Never regenerated from the template: the user is told the copy is gone (10.10).
+        await patch(current.messageId, item => ({ ...item, status: 'bytes_lost', nextAttemptAt: null, lastError: 'bytes_lost' }));
+        return { status: 'failed', messageId: current.messageId, code: 'bytes_lost' };
+      }
+
+      const chunk = current.chunks[index];
+      const message = await buildEnvelope({
+        messageType: 'snapshot.chunk',
+        messageId: chunk.chunkMessageId,
+        clientInstanceId: current.clientInstanceId,
+        payload: {
+          snapshotId: current.snapshotId,
+          applicationId: current.applicationId,
+          chunkIndex: index,
+          chunkCount: current.chunkCount,
+          chunkSha256: chunk.chunkSha256,
+          snapshotSha256: current.sha256,
+          byteSize: current.byteSize,
+          bytesBase64: encodeBase64(bytes)
+        },
+        identity,
+        sourceRestoreEpoch: current.sourceRestoreEpoch,
+        now
+      });
+
+      const result = await sendOnce(message, wire);
+      if (result.status === 'ok') {
+        const ack = result.response.payload;
+        if (ack.ackKind === 'snapshot') return finish(current);
+        if (resending) return backoff(current, 'unavailable');
+        current = applyChunkAck(current, index, ack.chunkCursor);
+        const progressed = current;
+        await patch(current.messageId, item => ({
+          ...item,
+          chunks: progressed.chunks,
+          chunkCursor: progressed.chunkCursor,
+          attempts: 0,
+          lastError: null
+        }));
+        continue;
+      }
+
+      if (result.status === 'fatal') {
+        await patch(current.messageId, item => ({
+          ...item,
+          status: 'failed',
+          attempts: item.attempts + 1,
+          nextAttemptAt: null,
+          lastError: result.code
+        }));
+        return { status: 'failed', messageId: current.messageId, code: result.code };
+      }
+
+      return backoff(current, result.code ?? result.status);
+    }
+    return backoff(current, 'unavailable');
+  }
+
+  // The desktop holds the whole snapshot. Say so first, then delete the copy, then drop the
+  // entry: each step can be repeated after a crash without undoing the one before it.
+  async function finish(entry) {
+    await patch(entry.messageId, item => ({ ...item, status: 'completed', nextAttemptAt: null }));
+    try {
+      await staging.remove(entry.snapshotId);
+    } catch {
+      // Left for repair(): the entry still says completed.
+      return { status: 'saved', messageId: entry.messageId, applicationId: entry.applicationId };
+    }
+    await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+    return { status: 'saved', messageId: entry.messageId, applicationId: entry.applicationId };
+  }
+
+  async function backoff(entry, code) {
+    const attempts = (entry.attempts ?? 0) + 1;
+    const delay = nextDelayMs(attempts);
+    await patch(entry.messageId, item => ({
+      ...item,
+      attempts,
+      status: delay === null ? 'stalled' : 'pending',
+      nextAttemptAt: delay === null ? null : new Date(now().getTime() + delay).toISOString(),
+      lastError: code
+    }));
+    return { status: delay === null ? 'stalled' : 'pending', messageId: entry.messageId, code };
+  }
+
+  /**
+   * Delete a staged copy. Safe to call for one already gone. Returns false when IndexedDB
+   * refused; callers that must not let the copy come back use abandon() instead.
+   */
+  async function discard(snapshotId) {
+    try {
+      await staging.remove(snapshotId);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * The user gave up on a snapshot. Delete the copy, then its queue entry. If the copy cannot
+   * be deleted, the entry stays as a tombstone ('discarding') until it can: otherwise the
+   * binding still in IndexedDB would read to repair() as an interrupted upload, and the
+   * snapshot would be sent after all.
+   */
+  async function abandon(snapshotId) {
+    if (await discard(snapshotId)) {
+      await store.updateOutbox(list => list.filter(item => item.messageId !== snapshotId));
+      return { status: 'discarded' };
+    }
+    await store.updateOutbox(list => {
+      const tombstone = { status: 'discarding', nextAttemptAt: null, lastError: 'discard_failed' };
+      if (list.some(item => item.messageId === snapshotId)) {
+        return list.map(item => (item.messageId === snapshotId ? { ...item, ...tombstone } : item));
+      }
+      return [...list, {
+        messageId: snapshotId, messageType: SNAPSHOT_UPLOAD, snapshotId, recordId: null,
+        chunks: [], chunkCount: 0, payload: {}, attempts: 0, ...tombstone
+      }];
+    });
+    return { status: 'discarding' };
+  }
+
+  /**
+   * Undo prepare() for a bind that never got queued: the staged copy stays, unbound, for the
+   * user to bind again, and repair() has no binding to mistake for an interrupted upload.
+   */
+  async function release(snapshotId) {
+    try {
+      await staging.update(snapshotId, current => ({
+        ...current,
+        binding: null,
+        chunks: current.chunks.map(chunk => ({ ...chunk, chunkMessageId: null }))
+      }));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Bring the queue and IndexedDB back into agreement after a restart (§8.5: the two stores
+   * share no transaction, so IndexedDB carries enough to rebuild the queue entry).
+   */
+  async function repair() {
+    let staged;
+    try {
+      staged = await staging.list();
+    } catch {
+      return;
+    }
+    const outbox = await store.getOutbox();
+    const records = await store.getFillRecords();
+
+    for (const entry of outbox.filter(item => item.messageType === SNAPSHOT_UPLOAD)) {
+      if (entry.status === 'discarding') {
+        if (await discard(entry.snapshotId)) {
+          await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+        }
+        continue;
+      }
+      if (entry.status === 'completed') {
+        // The entry goes only with the copy: a staged record left behind with its binding
+        // would be rebuilt below and send chunks the desktop already has in full.
+        if (await discard(entry.snapshotId)) {
+          await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+        }
+        continue;
+      }
+      if (entry.status !== 'bytes_lost' && !staged.some(record => record.snapshotId === entry.snapshotId)) {
+        await patch(entry.messageId, item => ({ ...item, status: 'bytes_lost', nextAttemptAt: null, lastError: 'bytes_lost' }));
+      }
+    }
+
+    const queued = new Set(outbox.map(item => item.messageId));
+    for (const record of staged) {
+      if (record.binding) {
+        // A binding whose record is back to waiting is left over from a bind that was never
+        // queued (or given up on): the user has not chosen an application for it any more.
+        const owner = records.find(item => item.recordId === record.binding.recordId);
+        if (owner?.status === 'pending_bind' && !queued.has(record.snapshotId)) {
+          await release(record.snapshotId);
+          continue;
+        }
+        // Bound, but its fill.submit never reached the queue: the worker stopped between the
+        // two writes. An upload alone would archive the snapshot and lose the fill, so the
+        // record goes back to waiting for the user to bind it again.
+        const eventQueued = outbox.some(item => item.messageType === 'fill.submit' && item.recordId === record.binding.recordId);
+        if (owner?.status === 'bound' && !eventQueued && !queued.has(record.snapshotId)) {
+          const age = now().getTime() - Date.parse(record.binding.boundAt ?? record.createdAt);
+          if (age > BIND_INTERRUPTED_GRACE_MS) {
+            await release(record.snapshotId);
+            await store.updateFillRecords(list => list.map(item => (
+              item.recordId === owner.recordId ? { ...item, status: 'pending_bind', applicationId: null } : item
+            )));
+          }
+          continue;
+        }
+        if (!queued.has(record.snapshotId) && outbox.length >= MAX_OUTBOX) continue;
+        if (!queued.has(record.snapshotId) && record.chunks.every(chunk => chunk.chunkMessageId)) {
+          const entry = entryFor(record, record.chunks, record.binding);
+          await store.updateOutbox(list => (list.some(item => item.messageId === entry.messageId) ? list : [...list, entry]));
+        }
+        continue;
+      }
+      // Staged, then nothing ever referred to it: the worker died between staging and writing
+      // the record. Left alone for a while, since a record may still be on its way.
+      const referenced = records.some(item => item.snapshot?.snapshotId === record.snapshotId);
+      const age = now().getTime() - Date.parse(record.createdAt);
+      if (!referenced && age > ORPHAN_STAGING_GRACE_MS) await discard(record.snapshotId);
+    }
+  }
+
+  /** Snapshots old enough that the user should be asked about them (§8.5, 30 days). */
+  async function expired() {
+    try {
+      return (await staging.list()).filter(record => staging.isExpired(record)).map(record => record.snapshotId);
+    } catch {
+      return [];
+    }
+  }
+
+  const patch = (messageId, change) => store.updateOutbox(list =>
+    list.map(item => (item.messageId === messageId ? change(item) : item))
+  );
+
+  return { stage, prepare, deliver, discard, abandon, release, repair, expired };
+}

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -1,4 +1,4 @@
-import { nativeSender, sleep, storageAdapter } from './chrome.mjs';
+import { idbStore, nativeSender, sleep, storageAdapter } from './chrome.mjs';
 import { createStore } from './store.mjs';
 import { createSession } from './session.mjs';
 import { createIntents } from './intents.mjs';
@@ -7,6 +7,8 @@ import { createReconcile } from './reconcile.mjs';
 import { createDrain, ALARM_NAME } from './drain.mjs';
 import { createRouter } from './router.mjs';
 import { createFillRecords } from './fillrecords.mjs';
+import { createStaging } from './staging.mjs';
+import { createUploads } from './uploads.mjs';
 import { DESKTOP_MESSAGE_TYPES } from './messages.mjs';
 
 /**
@@ -30,8 +32,10 @@ export function installDesktopLink(api) {
     now: () => new Date()
   };
 
+  const staging = createStaging({ kv: idbStore(), now: deps.now, uuid: deps.uuid });
+  const uploads = createUploads({ ...deps, staging });
   const session = createSession(deps);
-  const outbox = createOutbox(deps);
+  const outbox = createOutbox({ ...deps, uploads });
   const reconcile = createReconcile({ ...deps, outbox });
   const drain = createDrain({ session, outbox, reconcile, alarms: api.alarms, now: deps.now });
 
@@ -43,12 +47,17 @@ export function installDesktopLink(api) {
     reconcile,
     fillRecords: createFillRecords(deps),
     store,
+    uploads,
     extensionId: api.runtime.id
   });
 
   api.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (!DESKTOP_MESSAGE_TYPES.has(message?.type)) return false;
-    router.handle(message).then(sendResponse).catch(error => {
+    router.handle(message).then(result => {
+      sendResponse(result);
+      // A bound snapshot starts uploading once the sidebar has its answer, not before it.
+      if (result?.uploadQueued) drain.run().catch(() => {});
+    }).catch(error => {
       // The sidebar is waiting on this port. An unhandled rejection here leaves the user
       // looking at a spinner with no way to find out what happened.
       sendResponse({ error: true, code: error?.code ?? 'unavailable', message: error?.message });
@@ -63,7 +72,9 @@ export function installDesktopLink(api) {
 
   // A cold worker has no timers left from its previous life. Without this pass the queue
   // waits for an alarm that nothing rescheduled, which for an offline queue means forever.
-  drain.run().catch(() => {});
+  // Repair first: IndexedDB and the queue share no transaction (§8.5), and a snapshot bound
+  // just before the last worker died may only exist on the IndexedDB side.
+  uploads.repair().catch(() => {}).then(() => drain.run()).catch(() => {});
 
   return router;
 }

--- a/tests/link-degradation.test.js
+++ b/tests/link-degradation.test.js
@@ -176,3 +176,45 @@ test('a refused fill names the likely cause: the application is gone', async () 
   assert.match(copy.text, /找不到所选的申请/);
   assert.doesNotMatch(copy.text, /公司和岗位/);
 });
+
+test('a fill archived without its snapshot says why, and still counts as archived', async () => {
+  const { describeFillRecordResult } = await load();
+  const reasons = {
+    too_large: /2 MiB/,
+    empty: /没有可以保存的字段/,
+    staging_full: /已满/,
+    staging_unavailable: /浏览器存储/,
+    bytes_lost: /丢失/,
+    queue_full: /已满/
+  };
+  for (const [issue, pattern] of Object.entries(reasons)) {
+    const saved = describeFillRecordResult({ status: 'saved', snapshotIssue: issue });
+    assert.match(saved.text, /已留档到桌面/, issue);
+    assert.match(saved.text, pattern, issue);
+    const waiting = describeFillRecordResult({ status: 'recorded', mode: 'unavailable', snapshotIssue: issue });
+    assert.match(waiting.text, pattern, issue);
+  }
+  assert.match(describeFillRecordResult({ status: 'saved', uploadQueued: true }).text, /后台上传/);
+});
+
+test('the offer does not claim nothing is kept when a snapshot may be attached', async () => {
+  const { describeFillOffer } = await load();
+  const text = describeFillOffer({ outcome: 'completed', fieldCount: 3, filledCount: 3, unconfirmedCount: 0 });
+  assert.doesNotMatch(text, /不记填写的内容/);
+  assert.match(text, /不记网页上填了什么/);
+});
+
+test('an upload in progress is described by chunks, and a lost copy is never "retry"', async () => {
+  const { describeSnapshotUpload } = await load();
+  const chunks = [true, true, false, false].map((acked, chunkIndex) => ({ chunkIndex, acked }));
+  assert.match(describeSnapshotUpload({ status: 'pending', chunkCount: 4, chunks }).text, /2\/4/);
+  const lost = describeSnapshotUpload({ status: 'bytes_lost', chunkCount: 4, chunks });
+  assert.match(lost.text, /暂存丢失/);
+  assert.match(lost.text, /重新留档|桌面导入/);
+  assert.equal(lost.retry, false);
+  assert.match(describeSnapshotUpload({ status: 'paused', chunkCount: 4, chunks }).text, /换过档案库/);
+  assert.match(describeSnapshotUpload({ status: 'pending', chunkCount: 4, chunks }, { expired: true }).text, /30 天/);
+  for (const status of ['pending', 'stalled', 'failed', 'bytes_lost', 'paused', 'needs_user', 'completed']) {
+    assert.doesNotMatch(describeSnapshotUpload({ status, chunkCount: 4, chunks }).text, /投递/, status);
+  }
+});

--- a/tests/link-manifest.test.js
+++ b/tests/link-manifest.test.js
@@ -133,6 +133,17 @@ test('a hidden sidebar panel stays hidden even when its class sets a display', a
   assert.match(css, /\.resume-pro \[hidden\]\s*\{\s*display:\s*none\s*!important;?\s*\}/);
 });
 
+test('the fill-record card offers the snapshot, ticked by default, and sends the template it used', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  // Owner decision Q3: attached unless the user unticks it, and visible before "留档".
+  assert.match(source, /<input type="checkbox" id="resume-pro-fill-record-snapshot" checked>/);
+  assert.match(source, /snapshotTemplate/);
+  // The snapshot is of the template the fill used, frozen when the fill started.
+  assert.match(source, /structuredClone\(template\)/);
+  assert.match(source, /DESKTOP_DROP_SNAPSHOT/);
+  assert.match(source, /describeSnapshotUpload/);
+});
+
 test('a finished fill is filed under the page it ran on, not the one the user moved to', async () => {
   const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
   const body = source.slice(source.indexOf('async function offerFillRecord'), source.indexOf('function closeFillRecord'));
@@ -145,7 +156,7 @@ test('queue rows describe a retried or resolved entry in the words of its own ki
   const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
   const describe = source.slice(source.indexOf('function describeQueueResult'));
   assert.match(describe, /fill\.submit[\s\S]*describeFillRecordResult/);
-  const retry = source.slice(source.indexOf('"立即重试"'), source.indexOf('"立即重试"') + 400);
+  const retry = source.slice(source.lastIndexOf('"立即重试"'), source.lastIndexOf('"立即重试"') + 400);
   assert.match(retry, /describeQueueResult\(/);
   const resolve = source.slice(source.indexOf('async function resolvePaused'), source.indexOf('function describeOutboxState'));
   assert.match(resolve, /describeQueueResult\(/);

--- a/tests/link-uploads.test.js
+++ b/tests/link-uploads.test.js
@@ -1,0 +1,659 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+const EVENT = '99999999-9999-4999-8999-999999999999';
+const DAY = 24 * 60 * 60 * 1000;
+
+const RAW = {
+  outcome: 'success', cancelled: false, fieldCount: 5, filledCount: 5, unconfirmedCount: 0,
+  timing: { scanMs: 1, roundTripMs: 2, fillMs: 3, totalMs: 6 },
+  urlRedacted: 'https://jobs.example.com/apply', templateName: '合成模板', pluginVersion: '0.4.0',
+  job: { company: '星河科技', title: '后端开发', sourceUrl: 'https://jobs.example.com/apply' }
+};
+
+// Big enough for three 32 KiB chunks.
+function template(value = '经历') {
+  return {
+    name: '合成模板',
+    groups: [{ name: '经历', fields: Array.from({ length: 300 }, (_, i) => ({ key: `项目${i}`, value: `${value}${i} `.repeat(30) })) }]
+  };
+}
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+function fakeKv({ failPut = false } = {}) {
+  const map = new Map();
+  const kv = {
+    map,
+    onDelete: null,
+    async get(key) { return map.has(key) ? structuredClone(map.get(key)) : undefined; },
+    async put(key, value) {
+      if (kv.failPut) throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
+      map.set(key, structuredClone(value));
+    },
+    async delete(key) { if (kv.onDelete) await kv.onDelete(key); map.delete(key); },
+    async list() { return [...map.values()].map(value => structuredClone(value)); }
+  };
+  kv.failPut = failPut;
+  return kv;
+}
+
+const closed = () => ({ lastError: 'Error when communicating with the native messaging host.' });
+
+function reply(message, payload, resultId = message.messageId) {
+  return { response: { protocolVersion: 1, correlationId: message.messageId, ok: true, resultId, payload } };
+}
+
+/**
+ * The desktop's side of D08, by the protocol's own rules: a chunk is kept under the id it
+ * first arrived with (a new id for the same chunk is a conflict), the cursor counts
+ * consecutive chunks from zero, and only a complete set earns ackKind: snapshot.
+ */
+function desktop({ online = true, dropCompleteAcks = 0, failCompletions = 0 } = {}) {
+  const model = { online, dropCompleteAcks, failCompletions, uploads: new Map(), events: [], chunkMessages: [] };
+  model.answer = message => {
+    if (!model.online) return closed();
+    if (message.messageType === 'handshake') {
+      return reply(message, { appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1, archiveId: ARCHIVE, restoreEpoch: EPOCH, capabilities: ['handshake'] }, undefined);
+    }
+    if (message.messageType === 'fill.submit') {
+      model.events.push(message);
+      return reply(message, { resultKind: 'event' }, EVENT);
+    }
+    if (message.messageType === 'snapshot.chunk') {
+      model.chunkMessages.push(message);
+      const p = message.payload;
+      const upload = model.uploads.get(p.snapshotId) ?? { chunks: new Map(), ids: new Map(), count: p.chunkCount, complete: false };
+      model.uploads.set(p.snapshotId, upload);
+      const known = upload.ids.get(p.chunkIndex);
+      if (known && known !== message.messageId) {
+        return { response: { protocolVersion: 1, correlationId: message.messageId, ok: false, error: { code: 'conflict', retryable: false, message: 'reminted' }, payload: {} } };
+      }
+      upload.ids.set(p.chunkIndex, message.messageId);
+      upload.chunks.set(p.chunkIndex, Buffer.from(p.bytesBase64, 'base64'));
+      let cursor = 0;
+      while (upload.chunks.has(cursor)) cursor += 1;
+      if (cursor === upload.count && model.failCompletions > 0) {
+        // Every chunk is durable but the snapshot file could not be written (PR 2's
+        // "snapshot directory not writable" case): only the chunk ACK is true.
+        model.failCompletions -= 1;
+        return reply(message, { ackKind: 'chunk', snapshotId: p.snapshotId, chunkIndex: p.chunkIndex, chunkCursor: cursor });
+      }
+      if (cursor === upload.count) {
+        upload.complete = true;
+        if (model.dropCompleteAcks > 0) {
+          model.dropCompleteAcks -= 1;
+          return closed();
+        }
+        return reply(message, { ackKind: 'snapshot', snapshotId: p.snapshotId, chunkIndex: p.chunkIndex, chunkCursor: cursor });
+      }
+      return reply(message, { ackKind: 'chunk', snapshotId: p.snapshotId, chunkIndex: p.chunkIndex, chunkCursor: cursor });
+    }
+    return closed();
+  };
+  model.bytesOf = snapshotId => {
+    const upload = model.uploads.get(snapshotId);
+    return Buffer.concat([...upload.chunks.keys()].sort((a, b) => a - b).map(key => upload.chunks.get(key)));
+  };
+  return model;
+}
+
+/** One service-worker lifetime over persistent storage. Build another to simulate a restart. */
+async function worker({ storage, kv, model, clock = { value: Date.parse('2026-09-12T08:00:00.000Z') } }) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createReconcile } = await import('../link/reconcile.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+  const { createFillRecords } = await import('../link/fillrecords.mjs');
+  const { createStaging } = await import('../link/staging.mjs');
+  const { createUploads } = await import('../link/uploads.mjs');
+  const { createRouter } = await import('../link/router.mjs');
+
+  let minted = 0;
+  const prefix = Math.random().toString(16).slice(2, 10).padEnd(8, '0');
+  const uuid = () => `${prefix}-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date(clock.value);
+  const store = createStore({ storage, uuid });
+  const sent = [];
+  const sendNative = async (host, message) => {
+    sent.push(message);
+    return model.answer(message);
+  };
+  const deps = { store, sendNative, sleep: async () => {}, uuid, now };
+  const staging = createStaging({ kv, now, uuid });
+  const uploads = createUploads({ ...deps, staging });
+  const session = createSession(deps);
+  const outbox = createOutbox({ ...deps, uploads });
+  const reconcile = createReconcile({ ...deps, outbox });
+  const drain = createDrain({ session, outbox, reconcile, alarms: { async create() {}, async clear() { return true; } }, now });
+  const fillRecords = createFillRecords(deps);
+  const router = createRouter({
+    session, intents: createIntents(deps), outbox, drain, reconcile, fillRecords, store, uploads,
+    extensionId: 'abcdefghijklmnopabcdefghijklmnop'
+  });
+  return { router, drain, uploads, staging, sent, clock };
+}
+
+const PAIRED = () => fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } });
+
+async function snapshotSha(tpl) {
+  const { buildSnapshot } = await import('../link/snapshot.mjs');
+  return (await buildSnapshot(tpl, { now: () => new Date('2026-09-12T08:00:00.000Z') })).sha256;
+}
+
+// --- recording with a snapshot --------------------------------------------------------
+
+test('a recorded fill with a snapshot stages the bytes before anything else', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ online: false });
+  const { router } = await worker({ storage, kv, model });
+
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  assert.equal(result.status, 'recorded');
+  const [record] = storage.data.desktopFillRecords;
+  assert.equal(record.snapshot.staging, 'idb');
+  assert.equal(record.snapshot.chunkCount, 3);
+  assert.equal(kv.map.size, 1);
+  assert.equal(kv.map.get(record.snapshot.snapshotId).sha256, record.snapshot.sha256);
+  // Metadata only in chrome.storage.local; the bytes are in IndexedDB alone.
+  assert.equal(JSON.stringify(storage.data).includes('项目1'), false);
+});
+
+test('a staging failure keeps the fill record and says why there is no snapshot', async () => {
+  for (const [kv, tpl, issue] of [
+    [fakeKv({ failPut: true }), template(), 'staging_unavailable'],
+    [fakeKv(), { name: 'huge', groups: [{ name: 'g', fields: [{ key: 'k', value: 'x'.repeat(2 * 1024 * 1024 + 10) }] }] }, 'too_large']
+  ]) {
+    const storage = PAIRED();
+    const { router } = await worker({ storage, kv, model: desktop({ online: false }) });
+    const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: tpl });
+    assert.equal(result.status, 'recorded', issue);
+    assert.equal(result.snapshotIssue, issue);
+    assert.equal(storage.data.desktopFillRecords[0].snapshot, null);
+  }
+});
+
+test('a record kept without a snapshot stages nothing', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const { router } = await worker({ storage, kv, model: desktop({ online: false }) });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW });
+  assert.equal(kv.map.size, 0);
+  assert.equal(storage.data.desktopFillRecords[0].snapshot, null);
+});
+
+test('a profile that never paired stages nothing either', async () => {
+  const kv = fakeKv();
+  // No pairing on record and no desktop answering: the never-paired mode.
+  const { router } = await worker({ storage: fakeStorage(), kv, model: desktop({ online: false }) });
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  assert.equal(result.status, 'not_recorded');
+  assert.equal(kv.map.size, 0);
+});
+
+// --- uploading ------------------------------------------------------------------------
+
+test('binding uploads the original bytes chunk by chunk after the fill event', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  const { router, drain, sent } = await worker({ storage, kv, model });
+
+  const result = await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  assert.equal(result.status, 'saved');
+  await drain.run();
+
+  const fill = model.events[0];
+  const snapshotId = fill.payload.snapshotId;
+  assert.match(snapshotId, /^[0-9a-f-]{36}$/);
+  assert.equal(fill.payload.sha256, await snapshotSha(template()));
+  const firstChunk = sent.findIndex(message => message.messageType === 'snapshot.chunk');
+  const fillAt = sent.findIndex(message => message.messageType === 'fill.submit');
+  assert.ok(fillAt < firstChunk, 'the event goes first, the chunks after it');
+
+  assert.equal(model.uploads.get(snapshotId).complete, true);
+  assert.equal((await import('node:crypto')).createHash('sha256').update(model.bytesOf(snapshotId)).digest('hex'), fill.payload.sha256);
+  // Complete ACK: the IndexedDB copy and the queue entry are both gone.
+  assert.equal(kv.map.size, 0);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+test('every chunk has its own id, none shared with the fill event', async () => {
+  const storage = PAIRED();
+  const model = desktop();
+  const { router, drain } = await worker({ storage, kv: fakeKv(), model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  await drain.run();
+  const ids = model.chunkMessages.map(message => message.messageId);
+  assert.equal(new Set(ids).size, 3);
+  assert.equal(ids.includes(model.events[0].messageId), false);
+});
+
+test('every chunk envelope passes the vendored validator', async () => {
+  const { validateRequest } = await import('../link/protocol/validate.mjs');
+  const storage = PAIRED();
+  const model = desktop();
+  const { router, drain } = await worker({ storage, kv: fakeKv(), model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  await drain.run();
+  for (const message of model.chunkMessages) await validateRequest(message);
+});
+
+test('walkthrough 10.14: a restart mid-upload resumes with the same ids and the same bytes', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  let first = await worker({ storage, kv, model });
+  await first.router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template('第一版') });
+  const queued = storage.data.desktopOutbox.find(item => item.messageType === 'snapshot.upload');
+  assert.ok(queued.chunkCount >= 3, `the scenario needs a third chunk to interrupt (got ${queued.chunkCount})`);
+
+  // The desktop answers two chunks, then disappears.
+  const answer = model.answer;
+  let chunks = 0;
+  model.answer = message => {
+    if (message.messageType === 'snapshot.chunk' && ++chunks > 2) return closed();
+    return answer(message);
+  };
+  await first.drain.run();
+  const [entry] = storage.data.desktopOutbox;
+  assert.equal(entry.chunkCursor, 2);
+  const idOfChunk2 = entry.chunks[2].chunkMessageId;
+  const triedBefore = first.sent.filter(message => message.messageType === 'snapshot.chunk' && message.payload.chunkIndex === 2);
+  assert.ok(triedBefore.length >= 1 && triedBefore.every(message => message.messageId === idOfChunk2));
+
+  // The worker is evicted (all memory gone) and the user edits the template meanwhile.
+  model.answer = answer;
+  first = null;
+  const second = await worker({ storage, kv, model, clock: { value: Date.parse('2026-09-12T08:05:00.000Z') } });
+  await second.uploads.repair();
+  await second.drain.run();
+
+  const sentAfter = second.sent.filter(message => message.messageType === 'snapshot.chunk' && message.payload.chunkIndex === 2);
+  assert.ok(sentAfter.length >= 1, 'chunk 2 was sent again after the restart');
+  assert.ok(sentAfter.every(message => message.messageId === idOfChunk2), 'the resumed chunk was not re-minted');
+  assert.equal(second.sent.some(message => message.messageType === 'snapshot.chunk' && message.payload.chunkIndex < 2), false,
+    'chunks the desktop already acknowledged were not sent again');
+  const snapshotId = model.events[0].payload.snapshotId;
+  assert.equal(model.uploads.get(snapshotId).complete, true);
+  const digest = (await import('node:crypto')).createHash('sha256').update(model.bytesOf(snapshotId)).digest('hex');
+  assert.equal(digest, await snapshotSha(template('第一版')), 'the v1 bytes arrived, not v2');
+  assert.equal(kv.map.size, 0);
+});
+
+test('walkthrough 10.10: confirmed offline, template changed, uploaded later as the original', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ online: false });
+  const { router, drain } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template('第一版') });
+  const [record] = storage.data.desktopFillRecords;
+
+  model.online = true;
+  const bound = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(bound.status, 'saved');
+  await drain.run();
+  const digest = (await import('node:crypto')).createHash('sha256').update(model.bytesOf(record.snapshot.snapshotId)).digest('hex');
+  assert.equal(digest, await snapshotSha(template('第一版')));
+});
+
+test('a lost complete ACK keeps the copy until a resend is answered with one', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  // Two: the transport retries a failed send once on its own, so one lost reply is not enough
+  // to reach the queue.
+  const model = desktop({ dropCompleteAcks: 2 });
+  const { router, drain, clock } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+
+  kv.onDelete = async () => {
+    // Deleting the staged bytes is only allowed once the entry says the desktop has it all.
+    assert.equal(storage.data.desktopOutbox[0].status, 'completed');
+  };
+  await drain.run();
+  assert.equal(kv.map.size, 1, 'no complete ACK arrived, so the copy stays');
+  assert.equal(storage.data.desktopOutbox.length, 1);
+
+  clock.value += 10 * 60 * 1000;
+  await drain.run();
+  assert.equal(kv.map.size, 0);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  const lastChunks = model.chunkMessages.filter(message => message.payload.chunkIndex === 2);
+  assert.equal(lastChunks.length, 3, 'two lost answers, then the resend that got one');
+  assert.equal(new Set(lastChunks.map(message => message.messageId)).size, 1, 'always under its own id');
+});
+
+test('a chunk ACK that skips ahead does not move the cursor past a gap', async () => {
+  const { applyChunkAck } = await import('../link/uploads.mjs');
+  const entry = {
+    chunkCount: 3, chunkCursor: 0,
+    chunks: [0, 1, 2].map(chunkIndex => ({ chunkIndex, chunkMessageId: `c${chunkIndex}`, chunkSha256: 'x', acked: false }))
+  };
+  const afterTwo = applyChunkAck(entry, 2, 0);
+  assert.equal(afterTwo.chunkCursor, 0);
+  const afterZero = applyChunkAck(afterTwo, 0, 1);
+  assert.equal(afterZero.chunkCursor, 1);
+  // The desktop is the durable truth: a cursor behind what we believed means resend from it.
+  const believed = applyChunkAck(applyChunkAck(entry, 0, 1), 1, 2);
+  assert.equal(applyChunkAck(believed, 2, 1).chunkCursor, 1);
+});
+
+test('a crash between writing the chunk ids and queueing the upload is repaired with those ids', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  const { router, drain } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  // Lose the queued upload as if the worker died right after the IndexedDB write.
+  storage.data.desktopOutbox = storage.data.desktopOutbox.filter(entry => entry.messageType !== 'snapshot.upload');
+  const staged = [...kv.map.values()][0];
+  const mintedIds = staged.chunks.map(chunk => chunk.chunkMessageId);
+  assert.ok(mintedIds.every(Boolean));
+
+  const again = await worker({ storage, kv, model });
+  await again.uploads.repair();
+  await again.drain.run();
+  assert.deepEqual(model.chunkMessages.map(message => message.messageId), mintedIds);
+  void drain;
+});
+
+test('an upload whose bytes vanished stops and says so instead of regenerating them', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ online: false });
+  const { router, uploads, drain } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  const [record] = storage.data.desktopFillRecords;
+  model.online = true;
+  await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  kv.map.clear(); // the user cleared site data, or IndexedDB was evicted
+  await uploads.repair();
+  await drain.run();
+  const entry = storage.data.desktopOutbox.find(item => item.messageType === 'snapshot.upload');
+  assert.equal(entry.status, 'bytes_lost');
+  assert.equal(model.chunkMessages.length, 0);
+});
+
+test('cancelling the queued fill drops its snapshot too and hands the record back', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  model.answer = (answer => message => (message.messageType === 'handshake' ? answer(message) : closed()))(model.answer);
+  const { router } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  const fill = storage.data.desktopOutbox.find(entry => entry.messageType === 'fill.submit');
+  await router.handle({ type: 'DESKTOP_CANCEL', messageId: fill.messageId });
+  assert.deepEqual(storage.data.desktopOutbox, []);
+  assert.equal(kv.map.size, 0);
+  const [record] = storage.data.desktopFillRecords;
+  assert.equal(record.status, 'pending_bind');
+  assert.equal(record.snapshot, null);
+});
+
+test('deleting a waiting record deletes its staged snapshot', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const { router } = await worker({ storage, kv, model: desktop({ online: false }) });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  const [record] = storage.data.desktopFillRecords;
+  await router.handle({ type: 'DESKTOP_REMOVE_FILL', recordId: record.recordId });
+  assert.equal(kv.map.size, 0);
+});
+
+test('a snapshot older than thirty days is listed for the user and never deleted for age', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const { router, uploads, clock } = await worker({ storage, kv, model: desktop({ online: false }) });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  const snapshotId = storage.data.desktopFillRecords[0].snapshot.snapshotId;
+
+  clock.value += 29 * DAY;
+  assert.deepEqual((await router.handle({ type: 'DESKTOP_LIST_QUEUE' })).expiredSnapshots, []);
+  clock.value += 2 * DAY;
+  assert.deepEqual((await router.handle({ type: 'DESKTOP_LIST_QUEUE' })).expiredSnapshots, [snapshotId]);
+  await uploads.repair();
+  assert.equal(kv.map.size, 1, 'repair never removes a snapshot the user was not asked about');
+
+  await router.handle({ type: 'DESKTOP_DROP_SNAPSHOT', snapshotId });
+  assert.equal(kv.map.size, 0);
+  assert.equal(storage.data.desktopFillRecords[0].snapshot, null, 'the fill itself is kept');
+});
+
+test('a staged snapshot nobody references is cleaned up once it is clearly abandoned', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const { uploads, staging, clock } = await worker({ storage, kv, model: desktop({ online: false }) });
+  const { buildSnapshot, planChunks } = await import('../link/snapshot.mjs');
+  const built = await buildSnapshot(template());
+  built.chunks = await planChunks(built.bytes);
+  await staging.stage(built); // staged, then the worker died before the record was written
+  await uploads.repair();
+  assert.equal(kv.map.size, 1, 'too recent: a record may still be on its way');
+  clock.value += 2 * 60 * 60 * 1000;
+  await uploads.repair();
+  assert.equal(kv.map.size, 0);
+});
+
+test('every chunk acknowledged but no complete ACK: the last chunk is resent to finish it', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ failCompletions: 1 });
+  const { router, drain } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  await drain.run();
+  const snapshotId = model.events[0].payload.snapshotId;
+  assert.equal(model.uploads.get(snapshotId).complete, true);
+  const last = model.uploads.get(snapshotId).count - 1;
+  assert.equal(model.chunkMessages.filter(message => message.payload.chunkIndex === last).length, 2);
+  assert.equal(kv.map.size, 0);
+  assert.deepEqual(storage.data.desktopOutbox, []);
+});
+
+// --- review follow-ups ----------------------------------------------------------------
+
+// A desktop that takes the fill event but drops every chunk: the upload stays queued.
+function chunksNeverArrive(model) {
+  const answer = model.answer;
+  model.answer = message => (message.messageType === 'snapshot.chunk' ? closed() : answer(message));
+  return () => { model.answer = answer; };
+}
+
+test('a snapshot the user gave up on is never sent, even when deleting the copy failed', async () => {
+  for (const how of ['drop', 'cancel']) {
+    const storage = PAIRED();
+    const kv = fakeKv();
+    const model = desktop();
+    const restore = chunksNeverArrive(model);
+    const { router } = await worker({ storage, kv, model });
+    await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+    const upload = storage.data.desktopOutbox.find(entry => entry.messageType === 'snapshot.upload');
+    assert.ok(upload, how);
+
+    kv.onDelete = async () => { throw Object.assign(new Error('transient'), { name: 'UnknownError' }); };
+    if (how === 'drop') await router.handle({ type: 'DESKTOP_DROP_SNAPSHOT', snapshotId: upload.snapshotId });
+    else await router.handle({ type: 'DESKTOP_CANCEL', messageId: upload.messageId });
+    assert.equal(kv.map.size, 1, `${how}: the copy is still there`);
+
+    // Next worker start: the binding is still in IndexedDB, but the user's decision stands.
+    kv.onDelete = null;
+    restore();
+    const again = await worker({ storage, kv, model });
+    await again.uploads.repair();
+    await again.drain.run();
+    assert.equal(model.chunkMessages.length, 0, `${how}: nothing was sent`);
+    assert.equal(kv.map.size, 0, `${how}: the copy is gone now`);
+    assert.equal(storage.data.desktopOutbox.some(entry => entry.messageType === 'snapshot.upload'), false, how);
+  }
+});
+
+test('a bind refused for a full queue leaves no binding for repair to send', async () => {
+  const { MAX_OUTBOX } = await import('../link/limits.mjs');
+  const filler = Array.from({ length: MAX_OUTBOX }, (_, i) => ({
+    messageId: `filler-${i}`, messageType: 'job.save', payload: {}, status: 'stalled', nextAttemptAt: null, attempts: 9
+  }));
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ online: false });
+  const { router } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  const [record] = storage.data.desktopFillRecords;
+  storage.data.desktopOutbox = filler;
+  model.online = true;
+
+  const result = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(result.status, 'rejected');
+  assert.equal([...kv.map.values()][0].binding, null);
+
+  storage.data.desktopOutbox = [];
+  const again = await worker({ storage, kv, model });
+  await again.uploads.repair();
+  await again.drain.run();
+  assert.equal(model.chunkMessages.length, 0);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+  assert.ok(storage.data.desktopFillRecords[0].snapshot, 'the snapshot is still there to bind later');
+});
+
+test('the snapshot waits until its fill event has been accepted', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  const answer = model.answer;
+  let refuseEvents = true;
+  model.answer = message => (message.messageType === 'fill.submit' && refuseEvents ? closed() : answer(message));
+  const { router, drain, sent, clock } = await worker({ storage, kv, model });
+
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  await drain.run();
+  assert.equal(model.chunkMessages.length, 0, 'no chunk while the event is backing off');
+
+  refuseEvents = false;
+  clock.value += 60 * 60 * 1000;
+  await drain.run();
+  await drain.run();
+  const fillAt = sent.findIndex(message => message.messageType === 'fill.submit' && model.events.includes(message));
+  const firstChunk = sent.findIndex(message => message.messageType === 'snapshot.chunk');
+  assert.ok(fillAt >= 0 && firstChunk > fillAt, 'the accepted event comes before any chunk');
+  assert.equal(kv.map.size, 0, 'and the snapshot then completes');
+});
+
+test('an upload held behind a failed fill event does not keep the desktop awake', async () => {
+  const { waitsForFill } = await import('../link/drain.mjs');
+  const fill = { messageId: 'f', messageType: 'fill.submit', recordId: 'r1', status: 'failed' };
+  const upload = { messageId: 's', messageType: 'snapshot.upload', recordId: 'r1', status: 'pending', nextAttemptAt: '2026-09-12T08:00:00.000Z' };
+  assert.equal(waitsForFill(upload, [fill, upload]), true);
+  assert.equal(waitsForFill(upload, [upload]), false);
+  assert.equal(waitsForFill(fill, [fill, upload]), false);
+
+  const { createDrain } = await import('../link/drain.mjs');
+  let probes = 0;
+  const alarms = [];
+  const drain = createDrain({
+    session: { async probe() { probes += 1; return { mode: 'unavailable' }; } },
+    outbox: { async list() { return [fill, upload]; } },
+    alarms: { async create(name, info) { alarms.push(info); }, async clear() { return true; } },
+    now: () => new Date('2026-09-12T09:00:00.000Z')
+  });
+  const result = await drain.run();
+  assert.equal(result.mode, 'idle');
+  assert.equal(probes, 0, 'nothing it can send, so no host start');
+  assert.equal(alarms.length, 0);
+});
+
+// --- review follow-ups, second round ---------------------------------------------------
+
+// The worker died after prepare() wrote the binding and before fill.submit was queued.
+async function interruptedBind() {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  const restore = chunksNeverArrive(model);
+  const answer = model.answer;
+  model.answer = message => (message.messageType === 'fill.submit' ? closed() : answer(message));
+  const { router, clock } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  storage.data.desktopOutbox = [];
+  model.answer = answer;
+  restore();
+  return { storage, kv, model, clock };
+}
+
+test('a bind cut off before its event was queued is handed back, never sent as a bare snapshot', async () => {
+  const { storage, kv, model, clock } = await interruptedBind();
+  clock.value += 10 * 60 * 1000;
+  const again = await worker({ storage, kv, model, clock });
+  await again.uploads.repair();
+  await again.drain.run();
+  assert.equal(model.chunkMessages.length, 0);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+  assert.ok(storage.data.desktopFillRecords[0].snapshot, 'the snapshot is kept for the next bind');
+  assert.equal([...kv.map.values()][0].binding, null);
+});
+
+test('a bind still in progress is not mistaken for an interrupted one', async () => {
+  const { storage, kv, model, clock } = await interruptedBind();
+  const again = await worker({ storage, kv, model, clock });
+  await again.uploads.repair();
+  assert.equal(storage.data.desktopFillRecords[0].status, 'bound');
+  assert.ok([...kv.map.values()][0].binding, 'left alone');
+  assert.equal(storage.data.desktopOutbox.length, 0, 'and not rebuilt into an upload either');
+});
+
+test('a fill with a snapshot needs two free places in the queue, or it is not bound at all', async () => {
+  const { MAX_OUTBOX } = await import('../link/limits.mjs');
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop({ online: false });
+  const { router } = await worker({ storage, kv, model });
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, snapshotTemplate: template() });
+  const [record] = storage.data.desktopFillRecords;
+  storage.data.desktopOutbox = Array.from({ length: MAX_OUTBOX - 1 }, (_, i) => ({
+    messageId: `filler-${i}`, messageType: 'job.save', payload: {}, status: 'stalled', nextAttemptAt: null, attempts: 9
+  }));
+  model.online = true;
+  const result = await router.handle({ type: 'DESKTOP_BIND_FILL', recordId: record.recordId, applicationId: APPLICATION });
+  assert.equal(result.status, 'rejected');
+  assert.equal(result.reason, 'queue_full');
+  assert.equal(storage.data.desktopOutbox.length, MAX_OUTBOX - 1);
+  assert.equal(storage.data.desktopFillRecords[0].status, 'pending_bind');
+  assert.equal([...kv.map.values()][0].binding, null);
+});
+
+test('a completed upload whose copy still cannot be deleted keeps its entry until it can', async () => {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  const { router, drain } = await worker({ storage, kv, model });
+  kv.onDelete = async () => { throw new Error('transient'); };
+  await router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template() });
+  await drain.run();
+  assert.equal(storage.data.desktopOutbox[0].status, 'completed');
+
+  const again = await worker({ storage, kv, model });
+  await again.uploads.repair();
+  assert.equal(storage.data.desktopOutbox.length, 1, 'still there: the copy is');
+  kv.onDelete = null;
+  const sentBefore = model.chunkMessages.length;
+  const third = await worker({ storage, kv, model });
+  await third.uploads.repair();
+  await third.drain.run();
+  assert.equal(model.chunkMessages.length, sentBefore, 'nothing resent');
+  assert.equal(storage.data.desktopOutbox.length, 0);
+  assert.equal(kv.map.size, 0);
+});


### PR DESCRIPTION
Part of #22 — **PR 4 of 7** in [the D08 breakdown](docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md). Stacked on #59.

## 只做

把 PR 1 的暂存与 PR 2 的桌面 ACK 接起来：勾选快照的留档，最终在桌面存下**当时那份字节**；中途断线、SW 回收、浏览器重启都从原字节继续。

- **`link/uploads.mjs`**
  - 暂存填写时实际用的模板；绑定时铸每块 `chunkMessageId`，**先连同绑定信息写进 IndexedDB，再建队列条目**
  - 按游标顺序从暂存字节发块；分片 ACK 推进游标，**不跳洞**，且以桌面的持久游标为准
  - 只有 `ackKind: snapshot` 才结束：条目先记为 `completed` 再删 IDB，崩在中间会把清理做完而不是提前丢副本
  - 所有块都 ACK 了却没有完整 ACK → 重发最后一块（桌面按当前状态回答重放，并重试组装）
  - 字节不见了 → `bytes_lost`，**绝不从活模板重建**（走查 10.10）
  - `repair()`：IDB 有绑定但队列丢了条目 → 用同样的块 id 重建；无人引用且超过 1 小时的孤儿暂存才清理；**从不因为过期而删**
- `fill.submit` 在绑定了快照时带 `snapshotId` + `sha256`；事件先发，快照块后发
- 暂存失败（超 2 MiB、空、满、IDB 不可用）→ 留档照常、说明为什么没附快照
- 取消已绑定的留档会连同快照一起丢（块身份里含申请）；丢弃快照则保留留档
- 侧边栏：「附上这次用的简历模板拷贝」**默认勾选**（负责人决定 Q3），拷贝的是填写开始时冻结的模板；待同步里显示上传进度、暂存丢失、超过 30 天，并可「丢弃快照」
- 对账暂不处理快照条目（留给 PR 5），暂停时只能丢弃
- SW 启动先 `repair()` 再排空；绑定快照后回复侧边栏、再在后台开始上传

## 测试

`node --test tests/*.test.js`：449 通过（新增 `link-uploads` 18、文案 3、源码 1）

- **走查 10.14**：3+ 块，桌面回了两块后消失；丢弃全部内存态（模拟 SW 回收）重建 → 用原 id 续发块 2，已 ACK 的块不重发；期间改模板，桌面最终拿到的仍是 v1 字节
- **走查 10.10**：离线确认 → 改模板 → 桌面恢复 → 绑定上传 → 桌面字节等于 v1
- **走查 10.21**：每块 id 互不相同且不等于 `fill.submit` 的 id；ACK 跳到块 2 时游标仍为 0；桌面游标落后时回退重发
- 完整 ACK 连丢两次 → 副本一直保留（`kv.delete` 里断言条目已是 `completed`）→ 退避后重发 → 清理
- 组装失败只回分片 ACK → 重发最后一块 → 完成
- 崩在「写 IDB 之后、入队之前」→ `repair()` 用同一批 id 重建
- IDB 被清空 → `bytes_lost`，零次发块
- 配额错误 / 超 2 MiB → 留档不带快照、说明原因；从未配对 → 什么都不暂存
- 30 天：29 天不提示、31 天提示，`repair()` 不删；丢弃快照后留档仍在
- 每个块信封都过 vendored `validateRequest`

## 真实浏览器检查（Windows，已发布插件，桌面不运行）

勾选框默认勾选；点「留档」后快照（v1 文档）进了扩展源 IndexedDB，`chrome.storage.local` 里只有 `snapshotId` / `sha256` / `byteSize` / `chunkCount` 这些元数据。带桌面的端到端在 PR 7。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
