### PR TITLE
feat(d08): reconcile paused snapshot uploads after a restore (#22, PR 5/7)

### DIFF
--- a/content.js
+++ b/content.js
@@ -2182,6 +2182,15 @@
     for (const entry of outbox.filter(item => item.messageType === "snapshot.upload")) {
       const state = copy.describeSnapshotUpload(entry, { expired: expired.has(entry.snapshotId) });
       const row = pendingRow(`简历快照 · ${entry.payload?.templateName || ""}`, "", state.text);
+      if (entry.status === "paused" || entry.status === "needs_user") {
+        // After a restore the only ways out are the user's: upload the kept original again
+        // under a new identity, or let it go. Never a plain retry of the old chunks.
+        appendNote(row, copy.describeSnapshotReconcile(entry.reconcileStatus).text);
+        row.appendChild(rowButton("重新上传到当前档案", () => resolvePaused(entry, "resave")));
+        row.appendChild(rowButton("丢弃快照", () => resolvePaused(entry, "discard")));
+        list.appendChild(row);
+        continue;
+      }
       if (state.retry) {
         row.appendChild(rowButton("立即重试", async () => {
           await chrome.runtime.sendMessage({ type: "DESKTOP_RETRY", messageId: entry.messageId });
@@ -2229,6 +2238,7 @@
   // job was saved, nor a refused one ask the user to check a company name.
   function describeQueueResult(copy, entry, result) {
     if (entry.messageType === "fill.submit") return copy.describeFillRecordResult(result);
+    if (entry.messageType === "snapshot.upload") return copy.describeSnapshotResolveResult(result);
     if (entry.messageType === "submit.confirm") return copy.describeConfirmResult(result);
     return copy.describeBindResult(result);
   }
@@ -2288,7 +2298,9 @@
       type: "DESKTOP_RESOLVE", messageId: entry.messageId, choice, applicationId
     });
     if (choice !== "discard") {
-      setDesktopStatus(describeQueueResult(copy, entry, result ?? { status: "pending" }));
+      // A resaved snapshot is queued, not yet on the desktop: described as pending.
+      const shown = result?.status === "queued" ? { status: "pending" } : (result ?? { status: "pending" });
+      setDesktopStatus(describeQueueResult(copy, entry, shown));
     }
     refreshPendingList();
   }

--- a/docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md
+++ b/docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md
@@ -290,8 +290,8 @@
 - 对账：每块一项 `{clientInstanceId, messageId: chunkMessageId, sourceRestoreEpoch, payloadSha256: <块身份摘要>, snapshotId, chunkIndex}`，按 32 分批（64 块 = 2 批）。结果按块回填，汇总成快照级状态给用户看：全部 `applied`、部分 `applied`、存在 `conflict` / `not_found` / `unverifiable` / `purged`。
 - 用户出口：
   - **丢弃**：删 IDB + 删条目；
-  - **另存**：为 **所有块** 新铸 `chunkMessageId`、盖当前 epoch、记录旧身份（`previousIdentity`，每块一份），**先写 IDB 与 outbox 再发送**，重试不得生成第三套身份；`applicationId` 改由用户重新选（恢复后旧申请可能已不存在）；
-  - **关联**：对快照而言等于「另存到指定申请」（`applicationId` 是块身份的一部分，换申请就是新块身份），UI 上合并成同一个入口，避免让用户理解两种说法。
+  - **另存**：**换一个新的 `snapshotId`**，并为所有块新铸 `chunkMessageId`、盖当前 epoch、记录旧身份（`previousIdentity`：旧 snapshotId、旧 epoch、旧块 id 列表），**先写 IDB 再换 outbox 条目、然后才发送**，重试不得生成第三套身份。必须换 snapshotId：桌面 `snapshot_uploads` 以 `snapshot_id` 唯一，每块都核对父记录的 epoch，同一个 snapshotId 在新 epoch 下只会被判 `conflict`（实现时核实，原计划只写了换块 id）。同一条留档还在队列里暂停的 `fill.submit` 会改指向新的 snapshotId；如果恢复后的档案里那条 `fill.submit` 已经是 `applied`（备份含事件、不含快照块），事件不可改写，它仍指向旧 snapshotId——另存的快照照常登记在同一申请下（桌面快照列表可见），只是不再从那条事件跳转。要从事件链接过去需要协议加字段，记为 D12 / 后续 issue。另存用排队的一步先把条目占成 `resaving`，双击只会产生一份新快照；
+  - **关联**：对快照而言等于「另存到指定申请」（`applicationId` 是块身份的一部分）。`reconcile.resolve` 已支持 `associate` 带 `applicationId`；侧边栏本期只给「重新上传到当前档案」（原申请）与「丢弃快照」两个出口——原申请在恢复后的档案里不存在时，块会被桌面以 `invalid_payload` 拒绝，用户再丢弃即可。
 - `applied` 不授予重写许可；`not_found` 不代表从未执行，不自动重写（§8.11）。
 - 另存时仍用 IDB 里的 **原字节**，不从当前模板重建。
 

--- a/link/copy.mjs
+++ b/link/copy.mjs
@@ -300,3 +300,32 @@ export function describeSnapshotUpload(entry, { expired = false } = {}) {
   const copy = byStatus[entry?.status] ?? { text: `简历快照上传中（已传 ${acked}/${total} 块）`, retry: true };
   return expired ? { ...copy, text: `${copy.text}已暂存超过 30 天，要继续发送还是丢弃？` } : copy;
 }
+
+// A snapshot upload paused by a restore. Neither answer below lets the plugin act alone, and
+// uploading again always means a new snapshot identity in the archive that exists now.
+const SNAPSHOT_RECONCILE = {
+  applied: '恢复后的档案库里有这份快照全部分片的记录，但无法确认它是否已完整入库。',
+  not_found: '恢复后的档案库里没有这份快照的上传记录。这不等于没有传过——可能只是这份备份不含它。',
+  conflict: '恢复后的档案库里有身份相同但内容不同的分片，没有自动处理。',
+  unverifiable: '桌面无法核实这份快照传到了哪一步，不会自动重传。',
+  purged: '这份快照所属的记录在桌面上已被永久删除。'
+};
+
+/** What the sidebar says after the user resolved a paused snapshot. */
+export function describeSnapshotResolveResult(result) {
+  const { status, reason } = result ?? {};
+  if (status === 'queued' || status === 'pending') {
+    return { tone: 'pending', text: '会用当前档案库的新身份重新上传同一份简历快照，等这次填写的留档发出之后开始。' };
+  }
+  if (status === 'discarded') return { tone: 'info', text: '已丢弃这份简历快照，填写记录不受影响。' };
+  if (status === 'rejected' && SNAPSHOT_ISSUES[reason]) return { tone: 'warn', text: SNAPSHOT_ISSUES[reason] };
+  return { tone: 'warn', text: '没能重新上传这份简历快照，它还留在待同步里。' };
+}
+
+export function describeSnapshotReconcile(status) {
+  return {
+    tone: 'warn',
+    text: `${SNAPSHOT_RECONCILE[status] ?? '桌面换过档案库，这份简历快照等你决定。'}可以把本机保留的原始快照重新上传到当前档案库，或者丢弃它。`,
+    choices: ['resave', 'discard']
+  };
+}

--- a/link/drain.mjs
+++ b/link/drain.mjs
@@ -58,6 +58,9 @@ export function createDrain({ session, outbox, reconcile = null, alarms, now }) 
     const result = await outbox.drainOnce({ identity: probe.identity });
     const reconciled = reconcile ? await reconcile.run(probe.identity) : null;
     await scheduleNext();
+    // A paused entry the desktop could not answer about stays paused, and only pending
+    // entries set alarms: without this the "next pass" it waits for might never come.
+    if (reconciled?.unreachable?.length) await schedule(MIN_ALARM_DELAY_MS);
     return { mode: probe.mode, ...result, reconciled };
   }
 

--- a/link/reconcile.mjs
+++ b/link/reconcile.mjs
@@ -16,7 +16,7 @@ import {
  * an archive the user never chose. Paused messages may only ask a read-only question —
  * `outbox.reconcile` — and the answer never authorises a replay.
  */
-export function createReconcile({ store, outbox, uuid, now, sendNative, sleep }) {
+export function createReconcile({ store, outbox, uuid, now, sendNative, sleep, uploads = null }) {
   const wire = { sendNative, sleep };
 
   /** Freeze everything whose bound epoch is not the current one. */
@@ -79,7 +79,80 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
       }
     }
 
+    await reconcileUploads(identity, report);
     return report;
+  }
+
+  /**
+   * Paused snapshot uploads: every chunk is asked about by its full old identity, in batches
+   * the protocol allows. No answer settles a snapshot on its own — not even `applied` for every
+   * chunk, which proves the chunks are in this archive's history, not that the snapshot was
+   * ever completed there. The entry waits for the user with the answer that most needs them.
+   */
+  async function reconcileUploads(identity, report) {
+    const paused = (await store.getOutbox()).filter(entry => entry.status === 'paused' && entry.messageType === SNAPSHOT_UPLOAD);
+    if (!paused.length) return;
+
+    const items = [];
+    for (const entry of paused) {
+      for (const chunk of entry.chunks) items.push(await chunkIdentityOf(entry, chunk));
+    }
+
+    const answers = new Map();
+    for (let at = 0; at < items.length; at += MAX_RECONCILE_ITEMS) {
+      const batch = items.slice(at, at + MAX_RECONCILE_ITEMS);
+      const message = await buildEnvelope({
+        messageType: 'outbox.reconcile',
+        messageId: uuid(),
+        clientInstanceId: await store.clientInstanceId(),
+        payload: { items: batch },
+        identity,
+        now
+      });
+      const result = await sendOnce(message, wire);
+      if (result.status !== 'ok') continue;
+      for (const answer of result.response.payload.items) {
+        answers.set(`${answer.snapshotId}:${answer.chunkIndex}`, answer.status);
+      }
+    }
+
+    for (const entry of paused) {
+      const statuses = entry.chunks.map(chunk => answers.get(`${entry.snapshotId}:${chunk.chunkIndex}`));
+      if (statuses.some(status => status === undefined)) {
+        // Part of it went unanswered: stay paused and ask again on the next pass.
+        report.unreachable.push(entry.messageId);
+        continue;
+      }
+      const summary = summarise(statuses);
+      await patch(entry.messageId, item => ({
+        ...item,
+        status: 'needs_user',
+        reconcileStatus: summary,
+        chunkReconcile: statuses,
+        nextAttemptAt: null
+      }));
+      report.needsUser.push({ messageId: entry.messageId, status: summary });
+    }
+  }
+
+  async function chunkIdentityOf(entry, chunk) {
+    return {
+      clientInstanceId: entry.clientInstanceId,
+      messageId: chunk.chunkMessageId,
+      sourceRestoreEpoch: entry.sourceRestoreEpoch,
+      payloadSha256: await snapshotChunkIdentitySha256({
+        sourceRestoreEpoch: entry.sourceRestoreEpoch,
+        snapshotId: entry.snapshotId,
+        applicationId: entry.applicationId,
+        chunkIndex: chunk.chunkIndex,
+        chunkCount: entry.chunkCount,
+        chunkSha256: chunk.chunkSha256,
+        snapshotSha256: entry.sha256,
+        byteSize: entry.byteSize
+      }),
+      snapshotId: entry.snapshotId,
+      chunkIndex: chunk.chunkIndex
+    };
   }
 
   /**
@@ -98,6 +171,8 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
       // message that may already be in flight is how one decision becomes two applications.
       return { status: 'rejected', reason: 'not_paused' };
     }
+
+    if (entry.messageType === SNAPSHOT_UPLOAD) return resolveUpload(entry, { choice, applicationId, identity });
 
     if (choice === 'discard') {
       await store.updateOutbox(list => list.filter(item => item.messageId !== messageId));
@@ -144,6 +219,56 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
     return outbox.deliverOne(replacement.messageId, identity);
   }
 
+  /**
+   * A paused snapshot upload: discard it, or upload the same bytes again under a new identity
+   * against the archive that exists now. "Associate" is the same act aimed at a chosen
+   * application — the application is part of every chunk's identity, so there is no way to
+   * re-point the old chunks.
+   */
+  async function resolveUpload(entry, { choice, applicationId, identity }) {
+    if (choice === 'discard') {
+      // abandon() keeps a tombstone if IndexedDB will not delete the copy yet.
+      if (uploads) await uploads.abandon(entry.snapshotId);
+      else await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
+      return { status: 'discarded' };
+    }
+    if (!identity) return { status: 'rejected', reason: 'no_identity' };
+    if (!uploads) return { status: 'rejected', reason: 'unsupported' };
+
+    // Claimed in one queued step before anything is minted. Two clicks would otherwise both
+    // read the same paused entry and stage the same bytes under two new snapshot ids.
+    let claimed = false;
+    await store.updateOutbox(list => list.map(item => {
+      if (item.messageId !== entry.messageId) return item;
+      if (item.status !== 'paused' && item.status !== 'needs_user') return item;
+      claimed = true;
+      return { ...item, status: 'resaving', resumeStatus: item.status };
+    }));
+    if (!claimed) return { status: 'rejected', reason: 'not_paused' };
+
+    const moved = await uploads.resave(entry, { identity, applicationId: choice === 'associate' ? applicationId : null });
+    if (!moved.entry) {
+      await patch(entry.messageId, item => ({ ...item, status: item.resumeStatus ?? 'needs_user', resumeStatus: undefined }));
+      return { status: 'rejected', reason: moved.issue };
+    }
+    const replacement = moved.entry;
+
+    await store.updateOutbox(list => list
+      .filter(item => item.messageId !== entry.messageId)
+      .map(item => (
+        // A fill still waiting on the same decision should name the snapshot that will exist.
+        item.recordId && item.recordId === entry.recordId && item.messageType === 'fill.submit'
+          && (item.status === 'paused' || item.status === 'needs_user')
+          ? { ...item, payload: { ...item.payload, snapshotId: replacement.snapshotId } }
+          : item
+      ))
+      .concat(replacement));
+    // Only now that nothing refers to it: delete the old copy, or leave a tombstone that stops
+    // repair() from reading its binding as an interrupted upload.
+    await uploads.abandon(entry.snapshotId);
+    return { status: 'queued', messageId: replacement.messageId, uploadQueued: true };
+  }
+
   // Full prior identity, exactly as §8.11 specifies. The digest is recomputed from the stored
   // payload the same way it was computed when the message was first built.
   async function identityOf(entry) {
@@ -169,4 +294,18 @@ export function createReconcile({ store, outbox, uuid, now, sendNative, sleep })
   );
 
   return { pauseStale, run, resolve };
+}
+
+// The answer that most needs a person, when the chunks of one snapshot disagree.
+const URGENCY = ['conflict', 'purged', 'unverifiable', 'not_found', 'applied'];
+
+function summarise(statuses) {
+  for (const status of URGENCY) {
+    if (status === 'applied') {
+      if (statuses.every(item => item === 'applied')) return 'applied';
+      continue;
+    }
+    if (statuses.includes(status)) return status;
+  }
+  return 'unverifiable';
 }

--- a/link/staging.mjs
+++ b/link/staging.mjs
@@ -94,6 +94,22 @@ export function createStaging({ kv, now = () => new Date(), uuid }) {
     return new Uint8Array(record.bytes.slice(chunk.start, chunk.end));
   }
 
+  /**
+   * Store a whole record under its own id, verified by reading it back. Used to move staged
+   * bytes to a new snapshot identity; no quota check, since it replaces a record already counted.
+   */
+  function put(record) {
+    return serial(async () => {
+      await kv.put(record.snapshotId, record);
+      const stored = await kv.get(record.snapshotId);
+      if (!stored?.bytes || (await sha256Hex(new Uint8Array(stored.bytes))) !== record.sha256) {
+        await kv.delete(record.snapshotId).catch(() => {});
+        throw new Error('readback_mismatch');
+      }
+      return stored;
+    });
+  }
+
   function update(snapshotId, change) {
     return serial(async () => {
       const record = await get(snapshotId);
@@ -123,5 +139,5 @@ export function createStaging({ kv, now = () => new Date(), uuid }) {
     return now().getTime() - Date.parse(record.createdAt) > STAGING_EXPIRY_MS;
   }
 
-  return { stage, get, readChunk, update, remove, list, usage, isExpired };
+  return { stage, get, put, readChunk, update, remove, list, usage, isExpired };
 }

--- a/link/uploads.mjs
+++ b/link/uploads.mjs
@@ -248,6 +248,66 @@ export function createUploads({ store, staging, sendNative, sleep, uuid, now }) 
   }
 
   /**
+   * The user chose to upload a paused snapshot again after a restore (§8.11, walkthrough
+   * 10.23). Same bytes, new identity throughout: a new snapshotId — the desktop keys an upload
+   * by it and checks its epoch on every chunk — and a new id for every chunk, stamped with the
+   * current epoch. The old identity is kept as a record, never as a credential.
+   *
+   * The new record is staged first; the caller then swaps the queue entry and abandons the
+   * old copy. A crash leaves at worst a staged record repair() turns back into its entry.
+   */
+  async function resave(entry, { identity, applicationId = null }) {
+    let staged;
+    try {
+      staged = await staging.get(entry.snapshotId);
+    } catch {
+      staged = null;
+    }
+    if (!staged) return { issue: 'bytes_lost' };
+
+    const snapshotId = uuid();
+    const binding = {
+      recordId: entry.recordId,
+      applicationId: applicationId ?? entry.applicationId,
+      archiveId: identity.archiveId,
+      sourceRestoreEpoch: identity.restoreEpoch,
+      clientInstanceId: entry.clientInstanceId,
+      templateName: staged.templateName
+    };
+    const chunks = staged.chunks.map(chunk => ({
+      chunkIndex: chunk.chunkIndex,
+      chunkSha256: chunk.chunkSha256,
+      chunkMessageId: uuid()
+    }));
+    const moved = {
+      ...staged,
+      snapshotId,
+      binding,
+      chunks: staged.chunks.map(chunk => ({ ...chunk, chunkMessageId: chunks[chunk.chunkIndex].chunkMessageId }))
+    };
+
+    try {
+      await staging.put(moved);
+    } catch {
+      return { issue: 'staging_unavailable' };
+    }
+    // The old copy is deleted by the caller once the queue names the replacement
+    // (reconcile.resolveUpload → abandon), so a failed delete leaves a tombstone, not an upload.
+
+    return {
+      entry: {
+        ...entryFor(moved, chunks, binding),
+        previousIdentity: {
+          clientInstanceId: entry.clientInstanceId,
+          snapshotId: entry.snapshotId,
+          sourceRestoreEpoch: entry.sourceRestoreEpoch,
+          chunkMessageIds: entry.chunks.map(chunk => chunk.chunkMessageId)
+        }
+      }
+    };
+  }
+
+  /**
    * Delete a staged copy. Safe to call for one already gone. Returns false when IndexedDB
    * refused; callers that must not let the copy come back use abandon() instead.
    */
@@ -316,6 +376,12 @@ export function createUploads({ store, staging, sendNative, sleep, uuid, now }) 
     const records = await store.getFillRecords();
 
     for (const entry of outbox.filter(item => item.messageType === SNAPSHOT_UPLOAD)) {
+      if (entry.status === 'resaving') {
+        // The worker stopped in the middle of a resave. The user's decision is asked again;
+        // a replacement that was already staged is rebuilt below from its own binding.
+        await patch(entry.messageId, item => ({ ...item, status: item.resumeStatus ?? 'needs_user', resumeStatus: undefined }));
+        continue;
+      }
       if (entry.status === 'discarding') {
         if (await discard(entry.snapshotId)) {
           await store.updateOutbox(list => list.filter(item => item.messageId !== entry.messageId));
@@ -387,5 +453,5 @@ export function createUploads({ store, staging, sendNative, sleep, uuid, now }) 
     list.map(item => (item.messageId === messageId ? change(item) : item))
   );
 
-  return { stage, prepare, deliver, discard, abandon, release, repair, expired };
+  return { stage, prepare, deliver, resave, discard, abandon, release, repair, expired };
 }

--- a/link/worker.mjs
+++ b/link/worker.mjs
@@ -36,7 +36,7 @@ export function installDesktopLink(api) {
   const uploads = createUploads({ ...deps, staging });
   const session = createSession(deps);
   const outbox = createOutbox({ ...deps, uploads });
-  const reconcile = createReconcile({ ...deps, outbox });
+  const reconcile = createReconcile({ ...deps, outbox, uploads });
   const drain = createDrain({ session, outbox, reconcile, alarms: api.alarms, now: deps.now });
 
   const router = createRouter({

--- a/tests/link-degradation.test.js
+++ b/tests/link-degradation.test.js
@@ -218,3 +218,16 @@ test('an upload in progress is described by chunks, and a lost copy is never "re
     assert.doesNotMatch(describeSnapshotUpload({ status, chunkCount: 4, chunks }).text, /投递/, status);
   }
 });
+
+test('a snapshot paused by a restore explains the answer and offers only upload-again or discard', async () => {
+  const { describeSnapshotReconcile } = await load();
+  for (const status of ['applied', 'not_found', 'conflict', 'unverifiable', 'purged', undefined]) {
+    const copy = describeSnapshotReconcile(status);
+    assert.deepEqual(copy.choices, ['resave', 'discard'], String(status));
+    assert.doesNotMatch(copy.text, /投递/, String(status));
+    assert.doesNotMatch(copy.text, /已上传|已保存到桌面/, String(status));
+  }
+  // `applied` for every chunk proves history, not a finished snapshot, so it is not "done".
+  assert.match(describeSnapshotReconcile('applied').text, /无法确认/);
+  assert.match(describeSnapshotReconcile('not_found').text, /不等于没有/);
+});

--- a/tests/link-manifest.test.js
+++ b/tests/link-manifest.test.js
@@ -170,3 +170,10 @@ test('an application id typed by hand is checked before anything is bound', asyn
   const { describeFillRecordResult } = await import('../link/copy.mjs');
   assert.match(describeFillRecordResult({ status: 'rejected', reason: 'invalid_application_id' }).text, /申请 ID/);
 });
+
+test('every reconcile button hands resolvePaused the entry itself', async () => {
+  const source = fs.readFileSync(path.join(root, 'content.js'), 'utf8');
+  assert.equal(/resolvePaused\(entry\.messageId/.test(source), false);
+  const { describeSnapshotResolveResult } = await import('../link/copy.mjs');
+  assert.match(describeSnapshotResolveResult({ status: 'pending' }).text, /重新上传/);
+});

--- a/tests/link-reconcile-snapshot.test.js
+++ b/tests/link-reconcile-snapshot.test.js
@@ -1,0 +1,311 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const ARCHIVE = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const EPOCH = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const RESTORED = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const APPLICATION = '77777777-7777-4777-8777-777777777777';
+const EVENT = '99999999-9999-4999-8999-999999999999';
+
+const RAW = {
+  outcome: 'success', cancelled: false, fieldCount: 5, filledCount: 5, unconfirmedCount: 0,
+  timing: { scanMs: 1, roundTripMs: 2, fillMs: 3, totalMs: 6 },
+  urlRedacted: 'https://jobs.example.com/apply', templateName: '合成模板', pluginVersion: '0.4.0',
+  job: { company: '星河科技', title: '后端开发', sourceUrl: 'https://jobs.example.com/apply' }
+};
+
+function template(fields = 300) {
+  return {
+    name: '合成模板',
+    groups: [{ name: '经历', fields: Array.from({ length: fields }, (_, i) => ({ key: `项目${i}`, value: `合成经历描述${i} `.repeat(30) })) }]
+  };
+}
+
+function fakeStorage(initial = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    async get(keys) {
+      const out = {};
+      for (const name of (Array.isArray(keys) ? keys : [keys])) if (name in data) out[name] = data[name];
+      return out;
+    },
+    async set(values) { Object.assign(data, values); }
+  };
+}
+
+function fakeKv() {
+  const map = new Map();
+  const kv = {
+    map,
+    onDelete: null,
+    async get(key) { return map.has(key) ? structuredClone(map.get(key)) : undefined; },
+    async put(key, value) { map.set(key, structuredClone(value)); },
+    async delete(key) { if (kv.onDelete) await kv.onDelete(key); map.delete(key); },
+    async list() { return [...map.values()].map(value => structuredClone(value)); }
+  };
+  return kv;
+}
+
+const closed = () => ({ lastError: 'Error when communicating with the native messaging host.' });
+const reply = (message, payload, resultId) => ({
+  response: { protocolVersion: 1, correlationId: message.messageId, ok: true, ...(resultId ? { resultId } : {}), payload }
+});
+
+/** A desktop whose epoch can be moved, that answers reconcile with a scripted status per chunk. */
+function desktop() {
+  const model = { epoch: EPOCH, writes: true, reconcileBatches: [], statusFor: () => 'not_found', chunks: [], fills: [] };
+  model.answer = message => {
+    if (message.messageType === 'handshake') {
+      return reply(message, { appVersion: '0.1.0', minProtocolVersion: 1, maxProtocolVersion: 1, archiveId: ARCHIVE, restoreEpoch: model.epoch, capabilities: ['handshake'] });
+    }
+    if (message.messageType === 'outbox.reconcile') {
+      model.reconcileBatches.push(message.payload.items);
+      return reply(message, {
+        items: message.payload.items.map(item => {
+          const status = model.statusFor(item);
+          return { ...item, status, ...(status === 'applied' ? { resultId: item.messageId } : {}) };
+        })
+      });
+    }
+    if (!model.writes) return closed();
+    if (message.messageType === 'fill.submit') {
+      model.fills.push(message);
+      return reply(message, { resultKind: 'event' }, EVENT);
+    }
+    if (message.messageType === 'snapshot.chunk') {
+      model.chunks.push(message);
+      const p = message.payload;
+      const last = p.chunkIndex === p.chunkCount - 1;
+      return reply(message, { ackKind: last ? 'snapshot' : 'chunk', snapshotId: p.snapshotId, chunkIndex: p.chunkIndex, chunkCursor: p.chunkIndex + 1 }, message.messageId);
+    }
+    return closed();
+  };
+  return model;
+}
+
+async function worker({ storage, kv, model, clock = { value: Date.parse('2026-09-12T08:00:00.000Z') }, alarms = { async create() {}, async clear() { return true; } } }) {
+  const { createStore } = await import('../link/store.mjs');
+  const { createSession } = await import('../link/session.mjs');
+  const { createIntents } = await import('../link/intents.mjs');
+  const { createOutbox } = await import('../link/outbox.mjs');
+  const { createReconcile } = await import('../link/reconcile.mjs');
+  const { createDrain } = await import('../link/drain.mjs');
+  const { createFillRecords } = await import('../link/fillrecords.mjs');
+  const { createStaging } = await import('../link/staging.mjs');
+  const { createUploads } = await import('../link/uploads.mjs');
+  const { createRouter } = await import('../link/router.mjs');
+
+  let minted = 0;
+  const uuid = () => `00000000-0000-4000-8000-${String(++minted).padStart(12, '0')}`;
+  const now = () => new Date(clock.value);
+  const store = createStore({ storage, uuid });
+  const sent = [];
+  const deps = {
+    store, uuid, now, sleep: async () => {},
+    sendNative: async (host, message) => {
+      sent.push({ message, kvKeys: [...kv.map.keys()] });
+      return model.answer(message);
+    }
+  };
+  const staging = createStaging({ kv, now, uuid });
+  const uploads = createUploads({ ...deps, staging });
+  const session = createSession(deps);
+  const outbox = createOutbox({ ...deps, uploads });
+  const reconcile = createReconcile({ ...deps, outbox, uploads });
+  const drain = createDrain({ session, outbox, reconcile, alarms, now });
+  const fillRecords = createFillRecords(deps);
+  const router = createRouter({
+    session, intents: createIntents(deps), outbox, drain, reconcile, fillRecords, store, uploads,
+    extensionId: 'abcdefghijklmnopabcdefghijklmnop'
+  });
+  return { router, drain, sent, clock, uploads };
+}
+
+const PAIRED = () => fakeStorage({ desktopPairing: { archiveId: ARCHIVE, restoreEpoch: EPOCH, at: 1 } });
+
+/** A fill with a snapshot, bound while the desktop refused writes, then the desktop is restored. */
+async function queuedThenRestored({ fields = 300, alarms } = {}) {
+  const storage = PAIRED();
+  const kv = fakeKv();
+  const model = desktop();
+  model.writes = false;
+  const w = await worker({ storage, kv, model, ...(alarms ? { alarms } : {}) });
+  await w.router.handle({ type: 'DESKTOP_RECORD_FILL', raw: RAW, applicationId: APPLICATION, snapshotTemplate: template(fields) });
+  model.epoch = RESTORED;
+  model.writes = true;
+  return { storage, kv, model, ...w };
+}
+
+const upload = storage => storage.data.desktopOutbox.find(entry => entry.messageType === 'snapshot.upload');
+const fill = storage => storage.data.desktopOutbox.find(entry => entry.messageType === 'fill.submit');
+
+test('after a restore, the snapshot upload and its fill are paused and nothing is written', async () => {
+  const { storage, model, drain, sent } = await queuedThenRestored();
+  const before = sent.length;
+  await drain.run();
+  assert.notEqual(upload(storage).status, 'pending');
+  assert.notEqual(fill(storage).status, 'pending');
+  const writes = sent.slice(before).map(item => item.message.messageType).filter(type => type === 'snapshot.chunk' || type === 'fill.submit');
+  assert.deepEqual(writes, [], 'walkthrough 10.21 counter-example 4: no old chunk is replayed');
+  assert.equal(model.chunks.length, 0);
+});
+
+test('every chunk of a paused snapshot is asked about by its full old identity, 32 at a time', async () => {
+  const { snapshotChunkIdentitySha256 } = await import('../link/protocol/validate.mjs');
+  const { storage, model, drain } = await queuedThenRestored({ fields: 2000 });
+  const entry = upload(storage);
+  assert.ok(entry.chunkCount > 32, `needs more than one batch (got ${entry.chunkCount})`);
+  await drain.run();
+
+  const chunkItems = model.reconcileBatches.flat().filter(item => item.snapshotId);
+  assert.ok(model.reconcileBatches.every(batch => batch.length <= 32));
+  assert.equal(chunkItems.length, entry.chunkCount);
+  const byIndex = new Map(chunkItems.map(item => [item.chunkIndex, item]));
+  for (const chunk of entry.chunks) {
+    const item = byIndex.get(chunk.chunkIndex);
+    assert.equal(item.messageId, chunk.chunkMessageId);
+    assert.equal(item.sourceRestoreEpoch, EPOCH);
+    assert.equal(item.snapshotId, entry.snapshotId);
+    assert.equal(item.payloadSha256, await snapshotChunkIdentitySha256({
+      sourceRestoreEpoch: EPOCH, snapshotId: entry.snapshotId, applicationId: APPLICATION,
+      chunkIndex: chunk.chunkIndex, chunkCount: entry.chunkCount, chunkSha256: chunk.chunkSha256,
+      snapshotSha256: entry.sha256, byteSize: entry.byteSize
+    }));
+  }
+});
+
+test('no reconcile answer lets the plugin act on a snapshot by itself — not even applied', async () => {
+  for (const status of ['applied', 'not_found', 'conflict', 'unverifiable', 'purged']) {
+    const { storage, kv, model, drain } = await queuedThenRestored();
+    model.statusFor = () => status;
+    await drain.run();
+    const entry = upload(storage);
+    assert.equal(entry.status, 'needs_user', status);
+    assert.equal(entry.reconcileStatus, status, status);
+    assert.equal(kv.map.size, 1, `${status}: the staged copy is kept until the user decides`);
+    assert.equal(model.chunks.length, 0, status);
+  }
+});
+
+test('a mix of answers is summarised by the one that most needs a person', async () => {
+  const { storage, model, drain } = await queuedThenRestored();
+  model.statusFor = item => (item.chunkIndex === 1 ? 'conflict' : 'applied');
+  await drain.run();
+  assert.equal(upload(storage).reconcileStatus, 'conflict');
+});
+
+test('saving again uploads the same bytes under a new snapshot identity, persisted before sending', async () => {
+  const { storage, kv, model, drain, router, sent } = await queuedThenRestored();
+  await drain.run();
+  const old = upload(storage);
+  const oldIds = old.chunks.map(chunk => chunk.chunkMessageId);
+
+  const first = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' });
+  assert.equal(first.status, 'queued');
+  assert.equal(first.uploadQueued, true, 'the worker starts the new upload once the sidebar has its answer');
+  const again = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' });
+  assert.equal(again.status, 'rejected', 'a second click finds nothing left to resave');
+
+  const replacement = upload(storage);
+  assert.notEqual(replacement.snapshotId, old.snapshotId, 'the desktop refuses a snapshot id under a new epoch');
+  assert.equal(replacement.sourceRestoreEpoch, RESTORED);
+  assert.equal(replacement.sha256, old.sha256, 'same bytes');
+  assert.ok(replacement.chunks.every(chunk => !oldIds.includes(chunk.chunkMessageId)));
+  assert.equal(replacement.previousIdentity.snapshotId, old.snapshotId);
+  assert.deepEqual(replacement.previousIdentity.chunkMessageIds, oldIds);
+  assert.equal(replacement.previousIdentity.sourceRestoreEpoch, EPOCH);
+  assert.deepEqual([...kv.map.keys()], [replacement.snapshotId], 'the old copy is gone, the new one is staged');
+
+  // Its fill event was paused by the same restore, and the snapshot waits for that event.
+  await drain.run();
+  assert.equal(sent.filter(item => item.message.messageType === 'snapshot.chunk').length, 0, 'no chunk before its event');
+  const event = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: fill(storage).messageId, choice: 'resave' });
+  assert.equal(event.status, 'saved');
+
+  await drain.run();
+  const eventAt = sent.findIndex(item => item.message.messageType === 'fill.submit' && item.message.payload.sourceRestoreEpoch === RESTORED);
+  const firstChunk = sent.findIndex(item => item.message.messageType === 'snapshot.chunk');
+  assert.ok(eventAt >= 0 && firstChunk > eventAt, 'the event first, then the chunks');
+  const chunkSends = sent.filter(item => item.message.messageType === 'snapshot.chunk');
+  assert.ok(chunkSends.length > 0);
+  for (const item of chunkSends) {
+    assert.equal(item.message.payload.snapshotId, replacement.snapshotId);
+    assert.equal(item.message.payload.sourceRestoreEpoch, RESTORED);
+    assert.ok(item.kvKeys.includes(replacement.snapshotId), 'staged under the new id before the first send');
+  }
+  assert.equal(model.chunks.at(-1).payload.snapshotSha256, old.sha256);
+});
+
+test('a paused fill still in the queue is re-pointed at the resaved snapshot', async () => {
+  const { storage, drain, router } = await queuedThenRestored();
+  await drain.run();
+  const old = upload(storage);
+  await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' });
+  assert.equal(fill(storage).payload.snapshotId, upload(storage).snapshotId);
+});
+
+test('discarding a paused snapshot deletes the copy and keeps nothing of it', async () => {
+  const { storage, kv, drain, router } = await queuedThenRestored();
+  await drain.run();
+  const old = upload(storage);
+  const result = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'discard' });
+  assert.equal(result.status, 'discarded');
+  assert.equal(upload(storage), undefined);
+  assert.equal(kv.map.size, 0);
+});
+
+test('a snapshot whose copy is gone cannot be saved again, only discarded', async () => {
+  const { storage, kv, drain, router } = await queuedThenRestored();
+  await drain.run();
+  kv.map.clear();
+  const old = upload(storage);
+  const result = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' });
+  assert.equal(result.status, 'rejected');
+  assert.equal(result.reason, 'bytes_lost');
+});
+
+test('two clicks on "重新上传" at once stage one replacement, not two', async () => {
+  const { storage, kv, drain, router } = await queuedThenRestored();
+  await drain.run();
+  const old = upload(storage);
+  const results = await Promise.all([
+    router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' }),
+    router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' })
+  ]);
+  assert.deepEqual(results.map(result => result.status).sort(), ['queued', 'rejected']);
+  assert.equal(storage.data.desktopOutbox.filter(entry => entry.messageType === 'snapshot.upload').length, 1);
+  assert.equal(kv.map.size, 1, 'one staged copy, under the one new id');
+});
+
+test('a snapshot whose reconciliation went unanswered is asked about again later', async () => {
+  const created = [];
+  const alarms = { async create(name, info) { created.push(info); }, async clear() { return true; } };
+  const { storage, model, drain } = await queuedThenRestored({ alarms });
+  const answer = model.answer;
+  model.answer = message => (message.messageType === 'outbox.reconcile' ? { lastError: 'Native host has exited.' } : answer(message));
+  await drain.run();
+  assert.equal(upload(storage).status, 'paused');
+  assert.ok(created.length > 0, 'an alarm brings the next pass');
+
+  model.answer = answer;
+  await drain.run();
+  assert.equal(upload(storage).status, 'needs_user');
+});
+
+test('a resave whose old copy cannot be deleted yet never resurrects the old upload', async () => {
+  const { storage, kv, model, drain, router } = await queuedThenRestored();
+  await drain.run();
+  const old = upload(storage);
+  kv.onDelete = async () => { throw new Error('transient'); };
+  const result = await router.handle({ type: 'DESKTOP_RESOLVE', messageId: old.messageId, choice: 'resave' });
+  assert.equal(result.status, 'queued');
+  kv.onDelete = null;
+
+  const again = await worker({ storage, kv, model });
+  await again.uploads.repair();
+  const uploads = storage.data.desktopOutbox.filter(entry => entry.messageType === 'snapshot.upload' && entry.status !== 'discarding');
+  assert.equal(uploads.length, 1, 'only the replacement');
+  assert.notEqual(uploads[0].snapshotId, old.snapshotId);
+  assert.equal(kv.map.has(old.snapshotId), false, 'the old copy is gone by now');
+});


### PR DESCRIPTION
Part of #22 — **PR 5 of 7** in [the D08 breakdown](docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md). Stacked on #60.

## 只做

桌面恢复过备份后，旧的留档与快照块不许静默重放。

- 快照上传条目被 `pauseStale` 暂停后，**逐块**用完整旧身份对账：`{clientInstanceId, chunkMessageId, sourceRestoreEpoch, 块身份摘要, snapshotId, chunkIndex}`，每批 ≤ 32
- **任何回答都不让插件自己处理快照——包括全部 `applied`**：那只证明这些块在该档案的历史里，不证明快照已完整入库。条目进入 `needs_user`，汇总成最需要人看的那个状态（conflict > purged > unverifiable > not_found > applied）
- **重新上传（另存）**：同一份暂存字节，**新的 `snapshotId`** + 新的块 id + 当前 epoch，旧身份记在 `previousIdentity`。必须换 snapshotId：桌面 `snapshot_uploads` 以 `snapshot_id` 唯一、每块核对父记录 epoch，同 id 在新 epoch 下只会 `conflict`（原计划只写了换块 id，已在计划里更正）。新记录先暂存、再删旧记录、最后换队列条目；同一条留档还在暂停的 `fill.submit` 会改指向新 snapshotId；第二次点击找不到可另存的条目
- **丢弃**：删暂存副本与条目；副本已丢的只能丢弃
- 侧边栏：暂停的快照行说明对账结果，只给「重新上传到当前档案」和「丢弃快照」
- `fill.submit` 条目沿用 D07 的暂停 / 对账 / 三出口（PR 3 已接好清理）

## 测试

`node --test tests/*.test.js`：458 通过（新增 `link-reconcile-snapshot` 8、文案 1）

- 换 epoch 握手 → 快照与 `fill.submit` 都暂停，此后 `sendNative` 再没收到任何 `snapshot.chunk` / `fill.submit`（走查 10.21 反例 4）
- 44 块快照 → 两批对账，每批 ≤ 32，每项的块身份摘要与 vendored `snapshotChunkIdentitySha256` 一致
- `applied` / `not_found` / `conflict` / `unverifiable` / `purged` 各自都停下等用户，暂存副本保留；混合回答取最紧急的
- 重新上传：新 snapshotId、新块 id 全部不同于旧 id、epoch 为当前、`previousIdentity` 完整；**每次发块时 IDB 里已有新记录**；字节摘要不变；连点两次只有一套新身份
- 暂停中的兄弟 `fill.submit` 改指向新快照；丢弃后什么都不留；副本已丢时拒绝重新上传

🤖 Generated with [Claude Code](https://claude.com/claude-code)
