### PR TITLE
feat(d08): desktop timeline shows fill records and opens snapshots (#22, PR 6/7)

### DIFF
--- a/desktop/crates/archive-store/src/facade.rs
+++ b/desktop/crates/archive-store/src/facade.rs
@@ -7,7 +7,7 @@ use crate::applications::{
 use crate::error::StoreError;
 use crate::evidence::AttachmentRefReport;
 use crate::model::*;
-use crate::receipts::{SnapshotCompletion, SnapshotProgress};
+use crate::receipts::{SnapshotCompletion, SnapshotProgress, SnapshotState};
 use crate::store::ArchiveStore;
 use crate::suggestions::{ConfirmOutcome, ConfirmSuggestionInput};
 use crate::todos::TodoPatch;
@@ -263,6 +263,18 @@ impl ArchiveStore {
         snapshot_id: &str,
     ) -> Result<Option<ResumeSnapshotMeta>, StoreError> {
         self.transaction(|tx| tx.get_snapshot(snapshot_id))
+    }
+
+    pub fn snapshot_state(
+        &self,
+        application_id: &str,
+        snapshot_id: &str,
+    ) -> Result<SnapshotState, StoreError> {
+        self.transaction(|tx| tx.snapshot_state(application_id, snapshot_id))
+    }
+
+    pub fn read_snapshot(&self, snapshot_id: &str) -> Result<(ResumeSnapshotMeta, Vec<u8>), StoreError> {
+        self.transaction(|tx| tx.read_snapshot(snapshot_id))
     }
 
     pub fn list_snapshots(

--- a/desktop/crates/archive-store/src/lib.rs
+++ b/desktop/crates/archive-store/src/lib.rs
@@ -40,7 +40,7 @@ pub use identity::{ArchiveIdentity, ArchiveMetaFile, CurrentPointer};
 pub use migration::current_schema_version;
 // model::* 已含 Stage / StageUpdateMode / Fold / Occurred / EventPayload 等模型类型。
 pub use model::*;
-pub use receipts::{SnapshotCompletion, SnapshotProgress};
+pub use receipts::{SnapshotCompletion, SnapshotProgress, SnapshotState};
 pub use receipts::{
     FillSubmitInput, JobSaveInput, PluginOp, PluginWriteContext, PluginWriteOutcome,
     ReconcileOutcome, ReconcileQueryItem, ReconcileReply, SnapshotChunkInput, SubmitConfirmInput,

--- a/desktop/crates/archive-store/src/receipts.rs
+++ b/desktop/crates/archive-store/src/receipts.rs
@@ -151,6 +151,18 @@ pub struct SnapshotProgress {
     pub staged_bytes: i64,
 }
 
+/// Where a snapshot named by a fill event stands, for the desktop UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotState {
+    /// The snapshot file and row are committed.
+    Stored,
+    /// Chunks have arrived but the snapshot is not complete.
+    Uploading,
+    /// Nothing under this id in this archive.
+    Missing,
+}
+
 /// What [crate::ArchiveStore::complete_snapshot_upload] found.
 #[derive(Debug, Clone)]
 pub enum SnapshotCompletion {
@@ -767,6 +779,44 @@ impl StoreTx<'_> {
             created_at: now,
             byte_size,
         })
+    }
+
+    /// The state of `snapshot_id` as a snapshot of `application_id`. An event can name any
+    /// id; one committed or uploading under another application is not this one's.
+    pub fn snapshot_state(
+        &self,
+        application_id: &str,
+        snapshot_id: &str,
+    ) -> Result<SnapshotState, StoreError> {
+        if let Some(meta) = self.get_snapshot(snapshot_id)? {
+            return Ok(if meta.application_id == application_id {
+                SnapshotState::Stored
+            } else {
+                SnapshotState::Missing
+            });
+        }
+        let uploads: i64 = self.conn().query_row(
+            "SELECT COUNT(*) FROM snapshot_uploads WHERE snapshot_id = ?1 AND application_id = ?2",
+            params![snapshot_id, application_id],
+            |r| r.get(0),
+        )?;
+        Ok(if uploads > 0 { SnapshotState::Uploading } else { SnapshotState::Missing })
+    }
+
+    /// A committed snapshot's metadata and bytes. The file is checked against the recorded
+    /// length and digest before, and the bytes read are checked again after: a file changed
+    /// in between is still refused, and nothing partial is ever returned.
+    pub fn read_snapshot(&self, snapshot_id: &str) -> Result<(ResumeSnapshotMeta, Vec<u8>), StoreError> {
+        use sha2::{Digest, Sha256};
+        let meta = self
+            .get_snapshot(snapshot_id)?
+            .ok_or_else(|| StoreError::NotFound(format!("snapshot {snapshot_id}")))?;
+        crate::tx::verify_file(&self.archive_dir, &meta.stored_rel_path, meta.byte_size, &meta.sha256)?;
+        let bytes = std::fs::read(self.archive_dir.join(&meta.stored_rel_path))?;
+        if bytes.len() as i64 != meta.byte_size || format!("{:x}", Sha256::digest(&bytes)) != meta.sha256 {
+            return Err(StoreError::Validation("snapshot file changed while reading".into()));
+        }
+        Ok((meta, bytes))
     }
 
     pub fn get_snapshot(

--- a/desktop/crates/archive-store/tests/snapshots.rs
+++ b/desktop/crates/archive-store/tests/snapshots.rs
@@ -329,6 +329,57 @@ fn a_version_one_archive_is_upgraded_with_a_backup() {
     assert_eq!(tables, 1);
 }
 
+// --- PR 6: what the desktop UI reads ------------------------------------------------------
+
+#[test]
+fn a_snapshot_is_stored_uploading_or_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = ArchiveStore::open(config(dir.path())).unwrap();
+    let a = db.create_application(app()).unwrap();
+    let upload = Upload::new(snapshot_v1(), 4096);
+
+    assert_eq!(db.snapshot_state(&a.id, SNAPSHOT).unwrap(), SnapshotState::Missing);
+    upload.send(&db, &a.id, 0).unwrap();
+    assert_eq!(db.snapshot_state(&a.id, SNAPSHOT).unwrap(), SnapshotState::Uploading);
+    for index in 1..upload.count() {
+        upload.send(&db, &a.id, index).unwrap();
+    }
+    db.complete_snapshot_upload(CLIENT, SNAPSHOT).unwrap();
+    assert_eq!(db.snapshot_state(&a.id, SNAPSHOT).unwrap(), SnapshotState::Stored);
+
+    // Asked from another application, the same id is not this application's snapshot.
+    let other = db.create_application(app()).unwrap();
+    assert_eq!(db.snapshot_state(&other.id, SNAPSHOT).unwrap(), SnapshotState::Missing);
+}
+
+#[test]
+fn reading_a_snapshot_checks_the_file_before_returning_a_byte() {
+    let dir = tempfile::tempdir().unwrap();
+    let cfg = config(dir.path());
+    let db = ArchiveStore::open(cfg.clone()).unwrap();
+    let a = db.create_application(app()).unwrap();
+    let upload = Upload::new(snapshot_v1(), 4096);
+    for index in 0..upload.count() {
+        upload.send(&db, &a.id, index).unwrap();
+    }
+    db.complete_snapshot_upload(CLIENT, SNAPSHOT).unwrap();
+
+    let (meta, bytes) = db.read_snapshot(SNAPSHOT).unwrap();
+    assert_eq!(meta.snapshot_id, SNAPSHOT);
+    assert_eq!(bytes, upload.bytes);
+
+    // Tampered: same length, different content. Nothing partial comes back.
+    let path = cfg.archive_dir.join(&meta.stored_rel_path);
+    let mut changed = upload.bytes.clone();
+    changed[10] ^= 0x01;
+    std::fs::write(&path, &changed).unwrap();
+    assert!(db.read_snapshot(SNAPSHOT).is_err());
+
+    std::fs::remove_file(&path).unwrap();
+    assert!(db.read_snapshot(SNAPSHOT).is_err());
+    assert!(matches!(db.read_snapshot("no-such-snapshot"), Err(StoreError::NotFound(_))));
+}
+
 #[test]
 fn chunks_that_add_up_to_more_than_the_declared_size_are_refused() {
     // Each chunk fits the declared byteSize on its own; together they may not. Otherwise a

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -108,6 +108,15 @@
               </div>
             </form>
           </dialog>
+          <dialog id="snapshot-dialog">
+            <div class="stack">
+              <h3>简历快照</h3>
+              <div id="snapshot-body"></div>
+              <div class="row">
+                <button type="button" id="snapshot-close">关闭</button>
+              </div>
+            </div>
+          </dialog>
           <dialog id="progress-dialog">
             <form id="progress-form" class="stack">
               <h2 id="progress-title">记录进度</h2>

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2928,6 +2928,7 @@ dependencies = [
  "data-service",
  "local-ipc",
  "nm-frame",
+ "regex",
  "resume-pro-protocol",
  "serde",
  "serde_json",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ archive-store = { path = "../crates/archive-store" }
 data-service = { path = "../crates/data-service" }
 local-ipc = { path = "../crates/local-ipc" }
 nm-frame = { path = "../crates/nm-frame" }
+regex = "1"
 resume-pro-protocol = { path = "../crates/protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -3,9 +3,10 @@
 use archive_store::{
     timeutil::now_utc, Actor, ApplicationDetail, ApplicationFilter, ApplicationOrigin,
     ApplicationSummary, ArchiveConfig, ArchiveStore, Candidates, EventDraft, EventPayload,
-    EventSource, ListSort, NewApplication, Occurred, RecycleState, Stage, StageUpdateMode,
-    StoreError, StoredEvent, UpdateApplicationInput,
+    EventSource, ListSort, NewApplication, Occurred, RecycleState, ResumeSnapshotMeta,
+    SnapshotState, Stage, StageUpdateMode, StoreError, StoredEvent, UpdateApplicationInput,
 };
+use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
@@ -181,6 +182,34 @@ pub fn list_applications(
 pub struct ApplicationView {
     pub application: ApplicationDetail,
     pub events: Vec<StoredEvent>,
+    /// Every committed snapshot of this application, including ones uploaded again after a
+    /// restore under a new identity that no fill event names.
+    pub snapshots: Vec<SnapshotSummary>,
+    /// The state of each snapshot a fill event names, so the timeline can say "uploading" or
+    /// "not available" instead of offering a snapshot that is not there.
+    pub snapshot_states: BTreeMap<String, SnapshotState>,
+}
+
+/// What the WebView may know about a snapshot: never its path in the archive.
+#[derive(Debug, Serialize)]
+pub struct SnapshotSummary {
+    pub snapshot_id: String,
+    pub template_name: String,
+    pub template_version: Option<String>,
+    pub created_at: String,
+    pub byte_size: i64,
+}
+
+impl From<ResumeSnapshotMeta> for SnapshotSummary {
+    fn from(meta: ResumeSnapshotMeta) -> Self {
+        Self {
+            snapshot_id: meta.snapshot_id,
+            template_name: meta.template_name,
+            template_version: meta.template_version,
+            created_at: meta.created_at,
+            byte_size: meta.byte_size,
+        }
+    }
 }
 
 pub fn get_application(store: &ArchiveStore, id: &str) -> Result<ApplicationView, CommandError> {
@@ -189,10 +218,150 @@ pub fn get_application(store: &ArchiveStore, id: &str) -> Result<ApplicationView
         message: format!("申请不存在: {id}"),
     })?;
     let events = store.list_events(id)?;
+    let mut snapshot_states = BTreeMap::new();
+    for event in &events {
+        if let EventPayload::FillEvent { snapshot_id: Some(snapshot), .. } = &event.payload {
+            if !snapshot_states.contains_key(snapshot) {
+                snapshot_states.insert(snapshot.clone(), store.snapshot_state(id, snapshot)?);
+            }
+        }
+    }
+    let snapshots = store.list_snapshots(id)?.into_iter().map(SnapshotSummary::from).collect();
     Ok(ApplicationView {
         application,
         events,
+        snapshots,
+        snapshot_states,
     })
+}
+
+/// One snapshot, read for display. The file is verified against its recorded digest first;
+/// a missing or altered file is an error, never a partial view.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotView {
+    pub snapshot_id: String,
+    pub template_name: String,
+    pub template_version: Option<String>,
+    pub created_at: String,
+    pub captured_at: Option<String>,
+    pub omitted_field_count: i64,
+    pub groups: Vec<SnapshotGroup>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotGroup {
+    pub name: String,
+    pub fields: Vec<SnapshotField>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SnapshotField {
+    pub key: String,
+    pub value: String,
+}
+
+/// The plugin's snapshot document (link/snapshot.mjs, format v1).
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SnapshotDocument {
+    format: String,
+    #[serde(default)]
+    format_version: Option<i64>,
+    #[serde(default)]
+    captured_at: Option<String>,
+    #[serde(default)]
+    omitted_field_count: i64,
+    groups: Vec<SnapshotGroup>,
+}
+
+pub fn get_snapshot(store: &ArchiveStore, snapshot_id: &str) -> Result<SnapshotView, CommandError> {
+    let (meta, bytes) = store.read_snapshot(snapshot_id)?;
+    let unreadable = || CommandError {
+        code: "UNREADABLE_SNAPSHOT".into(),
+        message: "快照内容不是可识别的格式".into(),
+    };
+    let doc: SnapshotDocument = serde_json::from_slice(&bytes).map_err(|_| unreadable())?;
+    if doc.format != "resume-pro.snapshot" {
+        return Err(unreadable());
+    }
+    // Only v1 is read as v1. A later format stays on disk untouched for a newer desktop.
+    if doc.format_version != Some(1) {
+        return Err(CommandError {
+            code: "UNSUPPORTED_SNAPSHOT_VERSION".into(),
+            message: format!(
+                "这份快照的格式版本（{}）需要更新桌面程序才能查看",
+                doc.format_version
+                    .map_or_else(|| "未知".to_string(), |v| v.to_string())
+            ),
+        });
+    }
+
+    let mut omitted = doc.omitted_field_count.max(0);
+    let mut groups = Vec::with_capacity(doc.groups.len());
+    for mut group in doc.groups {
+        let before = group.fields.len();
+        // A group named like a credential ("API Keys") loses every field in it.
+        let secret_group = is_secret_field(&group.name, "");
+        group
+            .fields
+            .retain(|field| !secret_group && !is_secret_field(&field.key, &field.value));
+        omitted += (before - group.fields.len()) as i64;
+        if !group.fields.is_empty() {
+            groups.push(group);
+        }
+    }
+    Ok(SnapshotView {
+        snapshot_id: meta.snapshot_id,
+        template_name: meta.template_name,
+        template_version: meta.template_version,
+        created_at: meta.created_at,
+        captured_at: doc.captured_at,
+        omitted_field_count: omitted,
+        groups,
+    })
+}
+
+/// The plugin's credential rules (link/snapshot.mjs `isSecretFieldName` / `isSecretFieldValue`),
+/// applied again before a snapshot reaches the WebView. The plugin strips these before it
+/// serialises, but the archive keeps whatever bytes a paired client sent (data-privacy §4.1).
+/// Keep the two lists in step.
+fn is_secret_field(key: &str, value: &str) -> bool {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    struct Rules {
+        camel: Regex,
+        name_cjk: Regex,
+        name_latin: Regex,
+        values: Vec<Regex>,
+    }
+    static RULES: OnceLock<Rules> = OnceLock::new();
+    let rules = RULES.get_or_init(|| Rules {
+        camel: Regex::new("([a-z0-9])([A-Z])").unwrap(),
+        name_cjk: Regex::new("(密码|口令|验证码|校验码|授权码|密钥|私钥|令牌)").unwrap(),
+        name_latin: Regex::new(
+            r"(?i)(?:^|[^a-z])(password|passwd|pwd|otp|api[\s_-]?key|token|cookie|secret)s?(?:[^a-z]|$)",
+        )
+        .unwrap(),
+        values: [
+            r"(?i)(?:^|[^a-z])(password|passwd|pwd|passcode|otp|api[\s_-]?key|(?:access|refresh|auth)?[\s_-]?token|secret|cookie|authorization)\s*[:=：]\s*\S",
+            r"(密码|口令|验证码|校验码|授权码|密钥|令牌)\s*[:=：]\s*\S",
+            r"(?i)\bbearer\s+[a-z0-9._~+/=-]{16,}",
+            r"(?i)[?&#](?:access_token|refresh_token|id_token|token|api_?key|key|secret|password|sig|signature|auth|code|ticket)=[^&#\s]+",
+            r"(?i)\b(?:sk|pk|rk)-[a-z0-9_-]{16,}",
+            r"(?i)\bgh[pousr]_[a-z0-9]{20,}",
+            r"\bAKIA[0-9A-Z]{16}\b",
+            r"(?i)\beyJ[a-z0-9_-]{10,}\.[a-z0-9_-]{10,}\.[a-z0-9_-]{10,}",
+        ]
+        .iter()
+        .map(|pattern| Regex::new(pattern).unwrap())
+        .collect(),
+    });
+    let name = rules.camel.replace_all(key, "$1 $2");
+    rules.name_cjk.is_match(&name)
+        || rules.name_latin.is_match(&name)
+        || rules.values.iter().any(|pattern| pattern.is_match(value))
 }
 
 #[derive(Debug, Deserialize)]

--- a/desktop/src-tauri/src/commands_regression.rs
+++ b/desktop/src-tauri/src/commands_regression.rs
@@ -98,3 +98,242 @@ fn rounds_dates_unknown_time_and_invalid_inputs_cross_command_boundary() {
     }
     assert_eq!(get_application(&store, &a.id).unwrap().events.len(), count);
 }
+
+// --- D08 PR 6: fill events, their snapshots, and reading one ---------------------------
+
+mod snapshots {
+    use crate::commands::*;
+    use archive_store::{
+        ArchiveStore, FillOutcome, FillSubmitInput, Occurred, PluginOp, PluginWriteContext,
+        SnapshotChunkInput,
+    };
+    use serde_json::json;
+
+    const CLIENT: &str = "11111111-1111-4111-8111-111111111111";
+    const STORED: &str = "66666666-6666-4666-8666-666666666666";
+    const UPLOADING: &str = "77777777-7777-4777-8777-777777777777";
+    const MISSING: &str = "88888888-8888-4888-8888-888888888888";
+
+    fn sha(bytes: &[u8]) -> String {
+        resume_pro_protocol::sha256_hex(bytes)
+    }
+
+    fn submit(store: &ArchiveStore, message_id: &str, op: PluginOp) {
+        let ctx = PluginWriteContext {
+            envelope_identity: Some(store.identity()),
+            client_instance_id: CLIENT.into(),
+            message_id: message_id.into(),
+            source_restore_epoch: store.identity().restore_epoch,
+            payload_sha256: op.digest().unwrap(),
+        };
+        store.submit_plugin_message(&ctx, op).unwrap();
+    }
+
+    fn fill(store: &ArchiveStore, message_id: &str, app: &str, snapshot: &str) {
+        submit(store, message_id, PluginOp::FillSubmit(FillSubmitInput {
+            application_id: app.into(),
+            outcome: FillOutcome::Partial,
+            field_count: Some(12),
+            filled_count: Some(9),
+            unconfirmed_count: Some(3),
+            durations_ms: None,
+            url_redacted: None,
+            template_name: Some("合成模板".into()),
+            template_version: Some("0123456789ab".into()),
+            snapshot_id: Some(snapshot.into()),
+            plugin_version: Some("0.4.0".into()),
+            occurred: Occurred::Unknown,
+        }));
+    }
+
+    fn chunk(store: &ArchiveStore, message_id: &str, app: &str, snapshot: &str, bytes: &[u8], index: i64, count: i64, piece: Vec<u8>) {
+        submit(store, message_id, PluginOp::SnapshotChunk(SnapshotChunkInput {
+            application_id: Some(app.into()),
+            snapshot_id: snapshot.into(),
+            chunk_index: index,
+            chunk_count: count,
+            total_sha256: sha(bytes),
+            byte_size: bytes.len() as i64,
+            chunk_sha256: sha(&piece),
+            template_name: None,
+            template_version: None,
+            bytes: piece,
+        }));
+    }
+
+    fn document() -> Vec<u8> {
+        json!({
+            "capturedAt": "2026-09-12T08:00:00.000Z",
+            "format": "resume-pro.snapshot",
+            "formatVersion": 1,
+            "groups": [{ "name": "基本信息", "fields": [{ "key": "姓名", "value": "合成" }, { "key": "备注", "value": "<img src=x onerror=alert(1)>" }] }],
+            "omittedFieldCount": 2,
+            "templateName": "合成模板",
+            "templateVersion": "0123456789ab"
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    fn archive() -> (tempfile::TempDir, ArchiveStore, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_store(&dir.path().join("archive"), &dir.path().join("current.json")).unwrap();
+        let app = create_application(
+            &store,
+            serde_json::from_value(json!({ "company": "Synthetic", "title": "Job" })).unwrap(),
+        )
+        .unwrap()
+        .application
+        .unwrap()
+        .id
+        .clone();
+        let bytes = document();
+        fill(&store, "aaaaaaaa-0000-4000-8000-000000000001", &app, STORED);
+        chunk(&store, "aaaaaaaa-0000-4000-8000-000000000002", &app, STORED, &bytes, 0, 1, bytes.clone());
+        store.complete_snapshot_upload(CLIENT, STORED).unwrap();
+        fill(&store, "aaaaaaaa-0000-4000-8000-000000000003", &app, UPLOADING);
+        let half = bytes[..bytes.len() / 2].to_vec();
+        chunk(&store, "aaaaaaaa-0000-4000-8000-000000000004", &app, UPLOADING, &bytes, 0, 2, half);
+        fill(&store, "aaaaaaaa-0000-4000-8000-000000000005", &app, MISSING);
+        (dir, store, app)
+    }
+
+    #[test]
+    fn the_detail_view_carries_every_snapshot_and_the_state_of_each_one_a_fill_names() {
+        let (_dir, store, app) = archive();
+        let view = serde_json::to_value(get_application(&store, &app).unwrap()).unwrap();
+        assert_eq!(view["snapshotStates"][STORED], "stored");
+        assert_eq!(view["snapshotStates"][UPLOADING], "uploading");
+        assert_eq!(view["snapshotStates"][MISSING], "missing");
+        let snapshots = view["snapshots"].as_array().unwrap();
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0]["snapshot_id"], STORED);
+        assert_eq!(snapshots[0]["template_name"], "合成模板");
+    }
+
+    /// Store `bytes` as a complete snapshot `id` under the application.
+    fn stored(store: &ArchiveStore, app: &str, id: &str, prefix: &str, bytes: Vec<u8>) {
+        fill(store, &format!("{prefix}-0000-4000-8000-000000000001"), app, id);
+        chunk(store, &format!("{prefix}-0000-4000-8000-000000000002"), app, id, &bytes, 0, 1, bytes.clone());
+        store.complete_snapshot_upload(CLIENT, id).unwrap();
+    }
+
+    #[test]
+    fn a_credential_a_careless_client_put_in_a_snapshot_never_reaches_the_viewer() {
+        // The plugin strips these before it serialises; the archive keeps whatever a paired
+        // client sent, so the desktop applies the same rules again (data-privacy §4.1).
+        let (_dir, store, app) = archive();
+        const LEAKY: &str = "99999999-9999-4999-8999-999999999999";
+        let doc = json!({
+            "capturedAt": "2026-09-12T08:00:00.000Z",
+            "format": "resume-pro.snapshot",
+            "formatVersion": 1,
+            "groups": [
+                { "name": "账号", "fields": [
+                    { "key": "登录密码", "value": "hunter2-synthetic" },
+                    { "key": "access_token", "value": "tok-synthetic" },
+                    { "key": "apiKey", "value": "sk-synthetic" }
+                ] },
+                { "name": "其他", "fields": [
+                    { "key": "备注", "value": "Authorization: Bearer abcdefghijklmnopqrstuvwxyz" },
+                    { "key": "个人简介", "value": "熟悉 API Key 管理平台" }
+                ] }
+            ],
+            "omittedFieldCount": 1,
+            "templateName": "合成模板",
+            "templateVersion": "0123456789ab"
+        })
+        .to_string()
+        .into_bytes();
+        stored(&store, &app, LEAKY, "bbbbbbbb", doc);
+
+        let view = serde_json::to_value(get_snapshot(&store, LEAKY).unwrap()).unwrap();
+        let text = view.to_string();
+        for secret in ["hunter2-synthetic", "tok-synthetic", "sk-synthetic", "abcdefghijklmnopqrstuvwxyz"] {
+            assert!(!text.contains(secret), "{secret} reached the viewer");
+        }
+        assert_eq!(view["omittedFieldCount"], 5, "the one the plugin dropped plus four more");
+        let groups = view["groups"].as_array().unwrap();
+        assert_eq!(groups.len(), 1, "a group with nothing left is not shown");
+        assert_eq!(groups[0]["fields"][0]["key"], "个人简介");
+    }
+
+    #[test]
+    fn a_fill_that_names_another_applications_snapshot_is_not_offered_it() {
+        let (_dir, store, app) = archive();
+        let other = create_application(
+            &store,
+            serde_json::from_value(json!({ "company": "Other", "title": "Job" })).unwrap(),
+        )
+        .unwrap()
+        .application
+        .unwrap()
+        .id
+        .clone();
+        const THEIRS: &str = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+        stored(&store, &other, THEIRS, "dddddddd", document());
+        fill(&store, "eeeeeeee-0000-4000-8000-000000000001", &app, THEIRS);
+        let view = serde_json::to_value(get_application(&store, &app).unwrap()).unwrap();
+        assert_eq!(view["snapshotStates"][THEIRS], "missing");
+    }
+
+    #[test]
+    fn plural_labels_and_credential_groups_are_stripped_at_the_desktop_too() {
+        let (_dir, store, app) = archive();
+        const SHEET: &str = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+        let doc = json!({
+            "format": "resume-pro.snapshot",
+            "formatVersion": 1,
+            "groups": [
+                { "name": "API Keys", "fields": [{ "key": "OpenAI", "value": "opaque-synthetic" }] },
+                { "name": "账号", "fields": [{ "key": "Passwords", "value": "plural-synthetic" }, { "key": "邮箱", "value": "a@example.com" }] }
+            ],
+            "omittedFieldCount": 0,
+            "templateName": "合成模板"
+        })
+        .to_string()
+        .into_bytes();
+        stored(&store, &app, SHEET, "abababab", doc);
+        let view = serde_json::to_value(get_snapshot(&store, SHEET).unwrap()).unwrap();
+        let text = view.to_string();
+        assert!(!text.contains("opaque-synthetic") && !text.contains("plural-synthetic"));
+        assert!(!text.contains("API Keys"));
+        assert_eq!(view["omittedFieldCount"], 2);
+    }
+
+    #[test]
+    fn a_snapshot_in_a_later_format_version_is_not_read_as_version_one() {
+        let (_dir, store, app) = archive();
+        const LATER: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+        let doc = json!({
+            "format": "resume-pro.snapshot",
+            "formatVersion": 2,
+            "groups": [{ "name": "经历", "fields": [{ "key": "描述", "value": "合成" }] }],
+            "templateName": "合成模板"
+        })
+        .to_string()
+        .into_bytes();
+        stored(&store, &app, LATER, "cccccccc", doc);
+        let err = get_snapshot(&store, LATER).unwrap_err();
+        assert_eq!(err.code, "UNSUPPORTED_SNAPSHOT_VERSION");
+        assert!(err.message.contains("更新桌面程序"));
+    }
+
+    #[test]
+    fn reading_a_snapshot_returns_its_groups_and_nothing_from_a_tampered_file() {
+        let (dir, store, _app) = archive();
+        let view = serde_json::to_value(get_snapshot(&store, STORED).unwrap()).unwrap();
+        assert_eq!(view["templateName"], "合成模板");
+        assert_eq!(view["capturedAt"], "2026-09-12T08:00:00.000Z");
+        assert_eq!(view["omittedFieldCount"], 2);
+        assert_eq!(view["groups"][0]["fields"][0]["key"], "姓名");
+
+        let meta = store.get_snapshot(STORED).unwrap().unwrap();
+        let path = dir.path().join("archive").join(&meta.stored_rel_path);
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes[5] ^= 0x01;
+        std::fs::write(&path, bytes).unwrap();
+        assert!(get_snapshot(&store, STORED).is_err());
+        assert_eq!(get_snapshot(&store, MISSING).unwrap_err().code, "NOT_FOUND");
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -282,6 +282,14 @@ fn get_application_cmd(
 }
 
 #[tauri::command]
+fn get_snapshot_cmd(
+    state: State<AppState>,
+    snapshot_id: String,
+) -> Result<commands::SnapshotView, CommandError> {
+    with_store(&state, |store| commands::get_snapshot(store, &snapshot_id))
+}
+
+#[tauri::command]
 fn update_application_cmd(
     state: State<AppState>,
     args: UpdateApplicationArgs,
@@ -682,6 +690,7 @@ pub fn run() {
             list_applications_cmd,
             create_application_cmd,
             get_application_cmd,
+            get_snapshot_cmd,
             update_application_cmd,
             add_note_cmd,
             confirm_submit_cmd,

--- a/desktop/src/applications-ui.js
+++ b/desktop/src/applications-ui.js
@@ -2,8 +2,11 @@ import {
   createApplicationsController,
   evidenceLabel,
   eventLabel,
+  fillSummary,
   stageLabel,
   occurredLabel,
+  snapshotStateLabel,
+  SNAPSHOT_DISCLAIMER,
 } from "./applications.js";
 
 function escapeHtml(value) {
@@ -174,6 +177,8 @@ export function mountApplications(invoke) {
       const app = view.application.summary || view.application;
       const notes = view.application.notes;
       const events = view.events || [];
+      const snapshotStates = view.snapshotStates || {};
+      const snapshots = view.snapshots || [];
       detail.innerHTML = `
         <div class="detail-head">
           <h2 title="${escapeHtml(app.company)} · ${escapeHtml(app.title)}">${escapeHtml(app.company)} · ${escapeHtml(app.title)}</h2>
@@ -198,7 +203,15 @@ export function mountApplications(invoke) {
           <button type="button" data-act="note">新增备注</button>
           <button type="button" data-act="recycle">${(app.recycleState || app.recycle_state) === "recycled" ? "恢复" : "回收"}</button>
         </div>
-        <p class="muted">附件、简历快照和待办尚未接入，这里不展示假数据。填写事件不等于投递成功。</p>
+        <p class="muted">附件和待办尚未接入，这里不展示假数据。填写事件不等于投递成功。</p>
+        ${snapshots.length ? `
+        <h3>简历快照（${snapshots.length}）</h3>
+        <ul class="snapshot-list">
+          ${snapshots.map((snap) => `<li>
+            <span>${escapeHtml(snap.template_name)} · ${escapeHtml(formatTime(snap.created_at))}</span>
+            <button type="button" data-act="snapshot" data-snapshot="${escapeHtml(snap.snapshot_id)}">查看</button>
+          </li>`).join("")}
+        </ul>` : ""}
         <h3>时间线</h3>
         <ol class="timeline">
           ${events
@@ -207,25 +220,69 @@ export function mountApplications(invoke) {
               const extra = payload.text || payload.note || payload.reason || payload.label || payload.name || "";
               const mode = payload.stage_update_mode || payload.stageUpdateMode;
               const modeText = mode === "update_progress" ? "更新当前进度" : mode === "history_only" ? "仅历史补录" : "";
+              const fill = fillSummary(payload);
+              const snapshotId = payload.snapshot_id;
+              const snapshotNote = snapshotId ? snapshotStateLabel(snapshotStates[snapshotId]) : null;
               return `<li>
                 <strong>#${escapeHtml(ev.eventSequence || ev.event_sequence)} ${escapeHtml(eventLabel(ev.eventType || ev.event_type))}</strong>
                 <span class="muted">发生：${escapeHtml(occurredLabel(ev.occurred))} · 记录于：${escapeHtml(formatTime(ev.recordedAt || ev.recorded_at))}</span>
                 ${payload.round ? `<div>第 ${escapeHtml(payload.round)} 轮面试</div>` : ""}
                 ${extra ? `<div class="break">${escapeHtml(extra)}</div>` : ""}
-                ${modeText ? `<div class="muted">${escapeHtml(modeText)}</div>` : ""}
+                ${fill ? `<div>${escapeHtml(fill)}</div>` : ""}
+                ${snapshotId && !snapshotNote ? `<div><button type="button" data-act="snapshot" data-snapshot="${escapeHtml(snapshotId)}">查看简历快照</button></div>` : ""}
+                ${snapshotNote ? `<div class="muted">${escapeHtml(snapshotNote)}</div>` : ""}
+                ${modeText && !fill ? `<div class="muted">${escapeHtml(modeText)}</div>` : ""}
               </li>`;
             })
             .join("")}
         </ol>
       `;
       detail.querySelectorAll("button[data-act]").forEach((btn) => {
-        btn.addEventListener("click", () => handleAction(btn.dataset.act, view));
+        btn.addEventListener("click", () =>
+          btn.dataset.act === "snapshot" ? openSnapshot(btn.dataset.snapshot) : handleAction(btn.dataset.act, view),
+        );
       });
     } catch (err) {
       if (token !== detailToken || ctl.selectedId !== id) return;
       detail.innerHTML = `<p class="banner">${escapeHtml(invokeError(err))}</p>`;
     }
   }
+
+  // Read-only. The disclaimer is always shown first, and a snapshot that fails its digest
+  // check is reported as unreadable rather than shown in part.
+  let snapshotToken = 0;
+  async function openSnapshot(snapshotId) {
+    // Only the snapshot opened last may fill the dialog; an earlier one answering late is dropped.
+    const token = ++snapshotToken;
+    const dialogEl = document.getElementById("snapshot-dialog");
+    const body = document.getElementById("snapshot-body");
+    body.innerHTML = `<p class="banner">${escapeHtml(SNAPSHOT_DISCLAIMER)}</p><p class="muted">加载中…</p>`;
+    if (!dialogEl.open) dialogEl.showModal();
+    try {
+      const snap = await invoke("get_snapshot_cmd", { snapshotId });
+      if (token !== snapshotToken) return;
+      const omitted = snap.omittedFieldCount
+        ? `<p class="muted">${escapeHtml(snap.omittedFieldCount)} 个疑似密码、验证码类的字段没有保存。</p>`
+        : "";
+      body.innerHTML = `
+        <p class="banner">${escapeHtml(SNAPSHOT_DISCLAIMER)}</p>
+        <p class="muted">模板：${escapeHtml(snap.templateName)}${snap.templateVersion ? `（${escapeHtml(snap.templateVersion)}）` : ""} · 拷贝于 ${escapeHtml(formatTime(snap.capturedAt || snap.createdAt))}</p>
+        ${omitted}
+        ${(snap.groups || []).map((group) => `
+          <h4>${escapeHtml(group.name)}</h4>
+          <dl class="facts compact">
+            ${(group.fields || []).map((field) => `<dt>${escapeHtml(field.key)}</dt><dd class="break">${escapeHtml(field.value)}</dd>`).join("")}
+          </dl>`).join("")}
+      `;
+    } catch (err) {
+      if (token !== snapshotToken) return;
+      body.innerHTML = `<p class="banner">${escapeHtml(SNAPSHOT_DISCLAIMER)}</p><p class="banner">无法读取这份快照（${escapeHtml(invokeError(err))}）。桌面不会展示部分内容。</p>`;
+    }
+  }
+
+  document.getElementById("snapshot-close")?.addEventListener("click", () => {
+    document.getElementById("snapshot-dialog").close();
+  });
 
   async function handleAction(act, view) {
     const app = view.application.summary || view.application;

--- a/desktop/src/applications-ui.test.js
+++ b/desktop/src/applications-ui.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mountApplications } from './applications-ui.js';
 
 function harness(handler) {
-  const nodes = new Map(), actions = new Map(), calls = [];
+  const nodes = new Map(), actions = new Map(), actionList = [], calls = [];
   const tick = () => new Promise(resolve => setImmediate(resolve));
   class Node {
     constructor(id) { this.id=id;this.value='';this.checked=false;this.open=false;this.disabled=false;this.innerHTML='';this.listeners={};this.classList={toggle(){},add(){},remove(){}}; }
@@ -11,7 +11,7 @@ function harness(handler) {
     emit(type,event={}){return this.listeners[type]?.({preventDefault(){},...event});}
     showModal(){this.open=true;} close(){this.open=false;} focus(){}
     querySelectorAll(selector){
-      if(selector==='button[data-act]')return [...this.innerHTML.matchAll(/data-act="([^"]+)"/g)].map(m=>{const n=new Node(m[1]);n.dataset={act:m[1]};actions.set(m[1],n);return n;});
+      if(selector==='button[data-act]')return [...this.innerHTML.matchAll(/data-act="([^"]+)"(?:\s+data-snapshot="([^"]+)")?/g)].map(m=>{const n=new Node(m[1]);n.dataset={act:m[1],...(m[2]?{snapshot:m[2]}:{})};actions.set(m[1],n);actionList.push(n);return n;});
       if(selector==='tr')return [];
       const ids=this.id==='app-form'?['f-company','f-title','f-url','f-location','f-notes','btn-save-app','btn-cancel-app']:['progress-description','progress-date','progress-round','progress-update','progress-save','progress-cancel'];
       return ids.map(el);
@@ -29,7 +29,7 @@ function harness(handler) {
   };
   const api=mountApplications(invoke);
   const select=async id=>{el('apps-tbody').emit('click',{target:{closest:()=>({dataset:{id}})}});await tick();};
-  return {el,actions,calls,api,select,tick,view};
+  return {el,actions,actionList,calls,api,select,tick,view};
 }
 
 test('progress cancel and Escape never dispatch writes for any outcome',async()=>{
@@ -79,3 +79,88 @@ test('new selection survives completion of an earlier action',async()=>{
  await h.select('A');const pending=h.actions.get('submit').emit('click');await h.select('B');complete({});await pending;
  assert.equal(h.api.ctl.selectedId,'B');assert.match(h.el('app-detail').innerHTML,/Company-B/);
 });
+
+const fillEvent = (snapshot) => ({ id: 'e1', event_sequence: 2, event_type: 'fill_partial', occurred: { precision: 'unknown' }, recorded_at: '2026-09-12T08:00:00Z',
+  payload: { kind: 'fill_event', outcome: 'partial', field_count: 12, filled_count: 9, unconfirmed_count: 3, template_name: '合成模板', snapshot_id: snapshot } });
+
+test('a fill event with a stored snapshot opens it, with the disclaimer, escaped', async () => {
+  const S = '66666666-6666-4666-8666-666666666666';
+  const h = harness((name, args) => {
+    if (name === 'get_application_cmd') return { ...h.view(args.id), events: [fillEvent(S)], snapshotStates: { [S]: 'stored' },
+      snapshots: [{ snapshot_id: S, template_name: '合成模板', created_at: '2026-09-12T08:00:00Z', byte_size: 344 }] };
+    if (name === 'get_snapshot_cmd') return { snapshotId: S, templateName: '合成模板', capturedAt: '2026-09-12T08:00:00.000Z', omittedFieldCount: 2,
+      groups: [{ name: '基本信息', fields: [{ key: '姓名', value: '合成' }, { key: '备注', value: '<img src=x onerror=alert(1)>' }] }] };
+    return undefined;
+  });
+  await h.select('A');
+  const html = h.el('app-detail').innerHTML;
+  assert.match(html, /已写入网页 9\/12 项/);
+  assert.match(html, /data-act="snapshot" data-snapshot="66666666-6666-4666-8666-666666666666"/);
+  assert.doesNotMatch(html, /简历快照尚未接入|简历快照和待办尚未接入/);
+  await h.actions.get('snapshot').emit('click');
+  await h.tick();
+  const call = h.calls.find(c => c.name === 'get_snapshot_cmd');
+  assert.deepEqual(call.args, { snapshotId: S });
+  assert.equal(h.el('snapshot-dialog').open, true);
+  const body = h.el('snapshot-body').innerHTML;
+  assert.match(body, /不能/);
+  assert.match(body, /姓名/);
+  assert.match(body, /2 个疑似密码/);
+  assert.doesNotMatch(body, /<img/);
+  assert.match(body, /&lt;img/);
+});
+
+test('a snapshot still uploading or missing is described, not offered', async () => {
+  for (const [state, pattern] of [['uploading', /上传中/], ['missing', /不可用/]]) {
+    const S = '77777777-7777-4777-8777-777777777777';
+    const h = harness((name, args) => name === 'get_application_cmd'
+      ? { ...h.view(args.id), events: [fillEvent(S)], snapshotStates: { [S]: state }, snapshots: [] } : undefined);
+    await h.select('A');
+    const html = h.el('app-detail').innerHTML;
+    assert.match(html, pattern, state);
+    assert.doesNotMatch(html, /data-act="snapshot"/, state);
+  }
+});
+
+test('a snapshot that cannot be read says so instead of showing part of it', async () => {
+  const S = '66666666-6666-4666-8666-666666666666';
+  const h = harness((name, args) => {
+    if (name === 'get_application_cmd') return { ...h.view(args.id), events: [fillEvent(S)], snapshotStates: { [S]: 'stored' }, snapshots: [] };
+    if (name === 'get_snapshot_cmd') return Promise.reject({ code: 'VALIDATION', message: 'file digest mismatch' });
+    return undefined;
+  });
+  await h.select('A');
+  await h.actions.get('snapshot').emit('click');
+  await h.tick();
+  assert.match(h.el('snapshot-body').innerHTML, /无法读取/);
+  assert.doesNotMatch(h.el('snapshot-body').innerHTML, /姓名/);
+});
+
+test('a snapshot opened after another one is not overwritten when the first answers late', async () => {
+  const A = '66666666-6666-4666-8666-666666666666';
+  const B = '99999999-9999-4999-8999-999999999999';
+  let releaseA;
+  const h = harness((name, args) => {
+    if (name === 'get_application_cmd') return { ...h.view(args.id), events: [], snapshotStates: {},
+      snapshots: [{ snapshot_id: A, template_name: '旧模板', created_at: '2026-09-12T08:00:00Z' }, { snapshot_id: B, template_name: '新模板', created_at: '2026-09-12T09:00:00Z' }] };
+    if (name === 'get_snapshot_cmd' && args.snapshotId === A) return new Promise(resolve => { releaseA = () => resolve(snapshotDoc('旧的内容')); });
+    if (name === 'get_snapshot_cmd' && args.snapshotId === B) return snapshotDoc('新的内容');
+    return undefined;
+  });
+  await h.select('A');
+  const button = id => h.actionList.filter(node => node.dataset.snapshot === id).at(-1);
+  button(A).emit('click');
+  await h.tick();
+  await button(B).emit('click');
+  await h.tick();
+  assert.match(h.el('snapshot-body').innerHTML, /新的内容/);
+  releaseA();
+  await h.tick();
+  assert.match(h.el('snapshot-body').innerHTML, /新的内容/);
+  assert.doesNotMatch(h.el('snapshot-body').innerHTML, /旧的内容/);
+});
+
+function snapshotDoc(value) {
+  return { templateName: '合成模板', capturedAt: '2026-09-12T08:00:00.000Z', omittedFieldCount: 0,
+    groups: [{ name: '经历', fields: [{ key: '描述', value }] }] };
+}

--- a/desktop/src/applications.js
+++ b/desktop/src/applications.js
@@ -29,6 +29,62 @@ const EVENT_LABEL = {
   fill_cancelled: "填写取消",
 };
 
+const FILL_OUTCOME = {
+  started: "开始",
+  completed: "完成",
+  partial: "部分完成",
+  failed: "失败",
+  cancelled: "已取消",
+};
+
+// Shown with every snapshot the desktop displays (D08 acceptance): a snapshot is what the
+// plugin copied from the template when the fill was archived, not a record of what the
+// website received.
+export const SNAPSHOT_DISCLAIMER =
+  "这是插件在留档时从简历模板拷贝的内容，用来追溯当时用了哪份资料；它不能证明网站最终收到或保存了这些内容。";
+
+/**
+ * One line for a fill event: its outcome and how many fields were written into the page.
+ * "Written into the page" is all the plugin can know; nothing here says the site accepted
+ * anything, and a fill is never a submission.
+ */
+export function fillSummary(payload) {
+  if (payload?.kind !== "fill_event") return "";
+  const parts = [FILL_OUTCOME[payload.outcome] || "结束"];
+  // Only what was sent: an absent filled count is unknown, not zero.
+  if (Number.isInteger(payload.field_count) && Number.isInteger(payload.filled_count)) {
+    parts.push(`已写入网页 ${payload.filled_count}/${payload.field_count} 项`);
+  } else if (Number.isInteger(payload.field_count)) {
+    parts.push(`共 ${payload.field_count} 项`);
+  } else if (Number.isInteger(payload.filled_count)) {
+    parts.push(`已写入网页 ${payload.filled_count} 项`);
+  }
+  if (payload.unconfirmed_count) parts.push(`${payload.unconfirmed_count} 项未确认`);
+  const took = durationLabel(payload.durations_ms?.total);
+  if (took) parts.push(`用时 ${took}`);
+  // The version tells two revisions of a template with the same name apart.
+  if (payload.template_name) {
+    parts.push(`模板：${payload.template_name}${payload.template_version ? `（${payload.template_version}）` : ""}`);
+  }
+  return parts.join(" · ");
+}
+
+function durationLabel(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} 秒`;
+  const seconds = Math.round(ms / 1000);
+  return `${Math.floor(seconds / 60)} 分 ${seconds % 60} 秒`;
+}
+
+/** Null when the snapshot can be opened; otherwise the sentence to show in its place. */
+export function snapshotStateLabel(state) {
+  if (state === "stored") return null;
+  if (state === "uploading") return "简历快照上传中，还没有传完。";
+  // After a restore the plugin can upload the same bytes again, but only under a new id; the
+  // fill event cannot be rewritten to point at it, so the copy shows up in the list instead.
+  return "简历快照不可用：桌面没有收到这份快照。恢复备份后重新上传的快照会单独出现在上方的快照列表里。";
+}
+
 export function stageLabel(code) {
   return STAGE_LABEL[code] || code;
 }

--- a/desktop/src/applications.test.js
+++ b/desktop/src/applications.test.js
@@ -39,3 +39,47 @@ test('occurrence displays date or unknown without substituting recorded time',()
   assert.equal(occurredLabel({precision:'date',value:{date:'2026-08-21'}}),'2026-08-21');
   assert.equal(occurredLabel({precision:'date_time',value:{rfc3339:'2026-08-21T10:00:00Z'}}),'2026-08-21T10:00:00Z');
 });
+
+test('a fill event says what was written into the page, never that it was submitted', async () => {
+  const { fillSummary } = await import('./applications.js');
+  const text = fillSummary({ kind: 'fill_event', outcome: 'partial', field_count: 12, filled_count: 9, unconfirmed_count: 3, template_name: '合成模板', template_version: '0123456789ab' });
+  assert.match(text, /部分完成/);
+  assert.match(text, /已写入网页 9\/12 项/);
+  assert.match(text, /3 项未确认/);
+  assert.match(text, /合成模板/);
+  assert.doesNotMatch(text, /投递|提交|已接受/);
+  assert.equal(fillSummary({ kind: 'note_added', text: 'x' }), '');
+});
+
+test('a snapshot that is not stored is never offered as if it were', async () => {
+  const { snapshotStateLabel, SNAPSHOT_DISCLAIMER } = await import('./applications.js');
+  assert.equal(snapshotStateLabel('stored'), null);
+  assert.match(snapshotStateLabel('uploading'), /上传中/);
+  assert.match(snapshotStateLabel('missing'), /不可用/);
+  assert.match(snapshotStateLabel(undefined), /不可用/);
+  assert.match(SNAPSHOT_DISCLAIMER, /不能/);
+  assert.match(SNAPSHOT_DISCLAIMER, /网站/);
+});
+
+test('a fill line shows how long it took and which revision of the template it used', async () => {
+  const { fillSummary } = await import('./applications.js');
+  const text = fillSummary({ kind: 'fill_event', outcome: 'completed', field_count: 5, filled_count: 5,
+    durations_ms: { scan: 40, match: 900, fill: 1480, total: 2420 }, template_name: '合成模板', template_version: '0123456789ab' });
+  assert.match(text, /用时 2\.4 秒/);
+  assert.match(text, /合成模板（0123456789ab）/);
+  const long = fillSummary({ kind: 'fill_event', outcome: 'completed', durations_ms: { total: 125000 } });
+  assert.match(long, /用时 2 分 5 秒/);
+  assert.doesNotMatch(fillSummary({ kind: 'fill_event', outcome: 'failed', durations_ms: {} }), /用时/);
+});
+
+test('a missing snapshot points at the list where a re-uploaded copy would be', async () => {
+  const { snapshotStateLabel } = await import('./applications.js');
+  assert.match(snapshotStateLabel('missing'), /快照列表/);
+});
+
+test('a fill line does not invent a count the plugin did not send', async () => {
+  const { fillSummary } = await import('./applications.js');
+  const text = fillSummary({ kind: 'fill_event', outcome: 'completed', field_count: 12 });
+  assert.doesNotMatch(text, /0\/12/);
+  assert.match(text, /共 12 项/);
+});

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -168,3 +168,25 @@ dialog { border: 1px solid var(--line); border-radius: 12px; padding: 20px; max-
 @media (max-width: 900px) {
   .apps-layout { grid-template-columns: 1fr; }
 }
+
+.snapshot-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.snapshot-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+#snapshot-dialog {
+  width: min(640px, 92vw);
+  max-height: 80vh;
+  overflow: auto;
+}


### PR DESCRIPTION
Part of #22 — **PR 6 of 7** in [the D08 breakdown](docs/superpowers/plans/2026-09-11-d08-pr-breakdown.md). Stacked on #61（功能上只依赖 PR 2）。

## 只做

用户在桌面申请详情里看得到每次填写的结果，并能从事件打开当次快照；界面明确说明快照不是网站最终提交内容的证明。

- **archive-store**：`snapshot_state`（stored / uploading / missing）；`read_snapshot` 读前核对文件长度与摘要、读后再核一次——缺失或被改过一律报错，**不返回部分内容**
- **`get_application_cmd`** 增加 `snapshots`（这条申请的全部快照，含恢复后重新上传、换了新身份的）与 `snapshotStates`（时间线里填写事件引用的每个快照的状态）。给 WebView 的是**不含档案路径**的摘要（`commands.rs` 的原则：WebView 看不到 SQL 和路径）
- 新命令 **`get_snapshot_cmd`**：解析插件的快照 v1 文档
- **时间线**：填写事件显示结果与「已写入网页 X/Y 项」，从不说投递；快照已存 → 「查看简历快照」，上传中 / 不可用 → 显示原因而不给按钮；另有「简历快照」列表
- **查看视图**：只读，**顶部固定免责声明**「这是插件在留档时从简历模板拷贝的内容……它不能证明网站最终收到或保存了这些内容」；说明被剥离的疑似密码/验证码字段数；所有值转义
- 去掉详情里「简历快照尚未接入」的说法（附件、待办仍未接入）

## 测试

- archive-store 49（新增 2）：三种状态；篡改 / 缺文件 / 不存在都报错
- src-tauri 63（新增 2）：详情带全部快照与每个引用快照的状态、摘要不含路径；读快照得到分组，篡改后报错
- 前端 20（新增 5）：填写摘要不含「投递/提交/已接受」；未存的快照不给按钮；打开快照调用 `get_snapshot_cmd`、先显示免责声明、`<img onerror>` 被转义；读取失败只说无法读取、不显示任何字段
- `npm run build` 与桌面二进制编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
