### PR TITLE
feat(d09): commands for importing, previewing, associating and classifying evidence (#66, PR 3/6)

### DIFF
--- a/desktop/crates/archive-store/src/evidence.rs
+++ b/desktop/crates/archive-store/src/evidence.rs
@@ -191,7 +191,7 @@ impl StoreTx<'_> {
                 Some(from) => EventPayload::AssociationChanged {
                     evidence_id: evidence_id.to_string(),
                     from_application_id: Some(from),
-                    to_application_id: to_application.to_string(),
+                    to_application_id: Some(to_application.to_string()),
                 },
             },
         };
@@ -202,6 +202,70 @@ impl StoreTx<'_> {
         }
         self.get_evidence(evidence_id)?
             .ok_or_else(|| StoreError::Internal("evidence vanished in same transaction".into()))
+    }
+
+    /// 取消关联:证据回到收件箱,原申请的投影按 §6.3 重算(可能回到 none_imported)。
+    /// 原始 blob 与分类保持不变——用户只是说「这封信不属于那条申请」。
+    pub fn unassociate_evidence(&mut self, evidence_id: &str) -> Result<ReplyEvidence, StoreError> {
+        let ev = self
+            .get_evidence(evidence_id)?
+            .ok_or_else(|| StoreError::NotFound(format!("evidence {evidence_id}")))?;
+        let Some(from) = ev.application_id.clone() else {
+            return Ok(ev);
+        };
+        let now = now_utc();
+        self.conn().execute(
+            "UPDATE reply_evidence SET application_id = NULL WHERE id = ?1",
+            params![evidence_id],
+        )?;
+        let draft = EventDraft {
+            occurred: Occurred::DateTime {
+                rfc3339: now.clone(),
+                time_zone: None,
+            },
+            source: EventSource::Manual,
+            source_request_id: None,
+            actor: Actor::User,
+            payload: EventPayload::AssociationChanged {
+                evidence_id: evidence_id.to_string(),
+                from_application_id: Some(from.clone()),
+                to_application_id: None,
+            },
+        };
+        // 事件留在原申请的时间线上:那条申请确实发生过「证据被取走」。
+        self.append_events(Some(&from), &[draft], &now)?;
+        self.recompute_reply_state(&from)?;
+        self.get_evidence(evidence_id)?
+            .ok_or_else(|| StoreError::Internal("evidence vanished in same transaction".into()))
+    }
+
+    /// 按 sha256 找已经登记的字节。导入管线用它去重,界面用它提示重复导入。
+    pub fn find_blob(&self, sha256: &str) -> Result<Option<AttachmentBlob>, StoreError> {
+        let mut stmt = self.conn().prepare(
+            "SELECT sha256, size_bytes, stored_rel_path, ref_count, mime FROM attachment_blobs \
+             WHERE sha256 = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![sha256.to_lowercase()], |r| {
+            Ok(AttachmentBlob {
+                meta: AttachmentBlobMeta {
+                    sha256: r.get(0)?,
+                    size_bytes: r.get(1)?,
+                    stored_rel_path: r.get(2)?,
+                    mime: r.get(4)?,
+                },
+                ref_count: r.get(3)?,
+            })
+        })?;
+        rows.next().transpose().map_err(StoreError::from)
+    }
+
+    /// 引用同一份字节的证据 id。同哈希不等于同一次导入,也不撤销用户有意的不同关联。
+    pub fn evidence_for_blob(&self, sha256: &str) -> Result<Vec<String>, StoreError> {
+        let mut stmt = self
+            .conn()
+            .prepare("SELECT id FROM reply_evidence WHERE blob_sha256 = ?1 ORDER BY imported_at ASC")?;
+        let rows = stmt.query_map(params![sha256.to_lowercase()], |r| r.get(0))?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(StoreError::from)
     }
 
     /// 手动/确认后分类(确认前的建议走 AiSuggestion)。

--- a/desktop/crates/archive-store/src/facade.rs
+++ b/desktop/crates/archive-store/src/facade.rs
@@ -107,6 +107,18 @@ impl ArchiveStore {
         self.transaction(|tx| tx.classify_evidence(evidence_id, reply_class, send_mode))
     }
 
+    pub fn unassociate_evidence(&self, evidence_id: &str) -> Result<ReplyEvidence, StoreError> {
+        self.transaction(|tx| tx.unassociate_evidence(evidence_id))
+    }
+
+    pub fn find_blob(&self, sha256: &str) -> Result<Option<AttachmentBlob>, StoreError> {
+        self.transaction(|tx| tx.find_blob(sha256))
+    }
+
+    pub fn evidence_for_blob(&self, sha256: &str) -> Result<Vec<String>, StoreError> {
+        self.transaction(|tx| tx.evidence_for_blob(sha256))
+    }
+
     pub fn get_evidence(&self, id: &str) -> Result<Option<ReplyEvidence>, StoreError> {
         self.transaction(|tx| tx.get_evidence(id))
     }

--- a/desktop/crates/archive-store/src/model.rs
+++ b/desktop/crates/archive-store/src/model.rs
@@ -425,7 +425,9 @@ pub enum EventPayload {
     AssociationChanged {
         evidence_id: String,
         from_application_id: Option<String>,
-        to_application_id: String,
+        /// 取消关联时为空：证据回到收件箱，没有新的申请接手。
+        #[serde(default)]
+        to_application_id: Option<String>,
     },
     EvidenceClassified {
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/desktop/crates/archive-store/tests/storage.rs
+++ b/desktop/crates/archive-store/tests/storage.rs
@@ -959,3 +959,56 @@ fn confirmed_suggestion_replay_cannot_change_any_approved_decision() {
         Err(StoreError::Conflict(_))
     ));
 }
+
+#[test]
+fn evidence_can_be_taken_back_out_of_an_application() {
+    // D09：取消关联之后这条申请才回到 none_imported（走查 10.20 的反面）。
+    let dir = tempfile::tempdir().unwrap();
+    let db = ArchiveStore::open(config(dir.path())).unwrap();
+    let a = db.create_application(app()).unwrap();
+    let e = db.import_evidence(evidence(Some(a.id.clone()))).unwrap();
+    assert_eq!(
+        db.get_application(&a.id).unwrap().unwrap().reply_evidence_state,
+        ReplyEvidenceState::ImportedUnclassified
+    );
+
+    let back = db.unassociate_evidence(&e.id).unwrap();
+    assert_eq!(back.application_id, None);
+    assert_eq!(
+        db.get_application(&a.id).unwrap().unwrap().reply_evidence_state,
+        ReplyEvidenceState::NoneImported
+    );
+    assert_eq!(db.list_evidence(None).unwrap().len(), 1, "it is back in the inbox");
+
+    // 事件留痕：申请的时间线上看得到它被取走。
+    let kinds: Vec<String> = db
+        .list_events(&a.id)
+        .unwrap()
+        .iter()
+        .map(|event| event.event_type.clone())
+        .collect();
+    assert!(kinds.iter().any(|kind| kind == "association_changed"), "{kinds:?}");
+
+    // 已经在收件箱里的证据再取消一次是 no-op，不写第二条事件。
+    let before = db.list_events(&a.id).unwrap().len();
+    db.unassociate_evidence(&e.id).unwrap();
+    assert_eq!(db.list_events(&a.id).unwrap().len(), before);
+}
+
+#[test]
+fn the_same_bytes_are_found_by_their_digest() {
+    // 导入管线用它回答「这份字节已经在档案里了吗」，界面用它提示重复导入。
+    let dir = tempfile::tempdir().unwrap();
+    let db = ArchiveStore::open(config(dir.path())).unwrap();
+    let a = db.create_application(app()).unwrap();
+    assert!(db.find_blob(&"a".repeat(64)).unwrap().is_none());
+
+    db.import_evidence(evidence(Some(a.id.clone()))).unwrap();
+    let blob = db.find_blob(&"a".repeat(64)).unwrap().expect("the blob is registered");
+    assert_eq!(blob.meta.stored_rel_path, "attachments/example.eml");
+    assert_eq!(blob.ref_count, 1);
+
+    db.import_evidence(evidence(None)).unwrap();
+    assert_eq!(db.find_blob(&"a".repeat(64)).unwrap().unwrap().ref_count, 2);
+    assert_eq!(db.evidence_for_blob(&"a".repeat(64)).unwrap().len(), 2);
+}

--- a/desktop/crates/evidence-import/src/eml.rs
+++ b/desktop/crates/evidence-import/src/eml.rs
@@ -250,7 +250,7 @@ fn decode_entities(text: &str) -> String {
 }
 
 /// UTC 秒 → `YYYY-MM-DDTHH:MM:SSZ`（Howard Hinnant 的 civil_from_days，不引第三方时间库）。
-fn rfc3339_utc(timestamp: i64) -> String {
+pub(crate) fn rfc3339_utc(timestamp: i64) -> String {
     let days = timestamp.div_euclid(86_400);
     let secs = timestamp.rem_euclid(86_400);
     let z = days + 719_468;

--- a/desktop/crates/evidence-import/src/lib.rs
+++ b/desktop/crates/evidence-import/src/lib.rs
@@ -239,6 +239,11 @@ fn sha256_hex(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
+/// 导入时间决定文件落在哪个月份的桶里：`YYYY/MM`。
+pub fn bucket_from_unix(seconds: i64) -> String {
+    eml::rfc3339_utc(seconds)[..7].replace('-', "/")
+}
+
 /// `attachments/<bucket>` 的绝对路径。
 pub fn bucket_dir(archive_dir: &Path, bucket: &str) -> PathBuf {
     archive_dir.join("attachments").join(bucket)

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -556,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +925,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
+dependencies = [
+ "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1011,16 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "evidence-import"
+version = "0.1.0"
+dependencies = [
+ "infer",
+ "mail-parser",
+ "sha2",
+ "uuid",
 ]
 
 [[package]]
@@ -1504,6 +1535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.14.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1877,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "mail-parser"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec00bda90c6e645a54506c630c2820cd6b1890cfd2b0a169b50f74b2b8c7c86"
+dependencies = [
+ "encoding_rs",
+ "hashify",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2271,33 @@ dependencies = [
  "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
 name = "ndk"
@@ -2394,6 +2493,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2471,6 +2571,17 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "open"
+version = "5.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa576c76302b7b808eecc68061e67336c47833ef9d22caa74dda10fa9675eebc"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
 
 [[package]]
 name = "option-ext"
@@ -2926,6 +3037,7 @@ version = "0.1.0"
 dependencies = [
  "archive-store",
  "data-service",
+ "evidence-import",
  "local-ipc",
  "nm-frame",
  "regex",
@@ -2934,6 +3046,8 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tempfile",
  "windows-sys 0.59.0",
@@ -2948,6 +3062,30 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3295,6 +3433,12 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -3665,6 +3809,86 @@ dependencies = [
  "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61854a36651aa48381e5e209f69a01273b77f3f9f91f0c430b1b98d33bd47229"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.20",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de22eef34fd78c0da050e748710edd50bf127e651d02ea1b2bfada1523cc5c51"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.20",
+ "toml 1.1.5+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d60366174b745b4ef5824b8bbc1c457fd08f0ce101ff643c0a49181a9f4e91"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.20",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 archive-store = { path = "../crates/archive-store" }
 data-service = { path = "../crates/data-service" }
+evidence-import = { path = "../crates/evidence-import" }
 local-ipc = { path = "../crates/local-ipc" }
 nm-frame = { path = "../crates/nm-frame" }
 regex = "1"
@@ -24,6 +25,8 @@ resume-pro-protocol = { path = "../crates/protocol" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri-plugin-dialog = "2"
+tauri-plugin-opener = "2"
 tauri-plugin-single-instance = "2"
 
 [dev-dependencies]

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-hide",
     "core:window:allow-set-focus",
     "core:window:allow-unminimize",
-    "core:window:allow-is-visible"
+    "core:window:allow-is-visible",
+    "dialog:allow-open"
   ]
 }

--- a/desktop/src-tauri/src/commands_regression.rs
+++ b/desktop/src-tauri/src/commands_regression.rs
@@ -337,3 +337,245 @@ mod snapshots {
         assert_eq!(get_snapshot(&store, MISSING).unwrap_err().code, "NOT_FOUND");
     }
 }
+
+// --- D09 PR 3: importing evidence, the inbox, previews, association and classification ---
+
+mod evidence {
+    use crate::commands::*;
+    use crate::evidence_commands::{self, ImportArgs};
+    use archive_store::ArchiveStore;
+    use serde_json::json;
+    use std::path::{Path, PathBuf};
+
+    const BUCKET: &str = "2026/09";
+
+    fn archive() -> (tempfile::TempDir, ArchiveStore, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let store =
+            open_store(&dir.path().join("archive"), &dir.path().join("current.json")).unwrap();
+        let app = create_application(
+            &store,
+            serde_json::from_value(json!({ "company": "Synthetic", "title": "Job" })).unwrap(),
+        )
+        .unwrap()
+        .application
+        .unwrap()
+        .id
+        .clone();
+        (dir, store, app)
+    }
+
+    fn write(dir: &Path, name: &str, bytes: &[u8]) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, bytes).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    fn eml(subject: &str) -> Vec<u8> {
+        format!("From: hr@example.test\r\nSubject: {subject}\r\nDate: Fri, 12 Sep 2026 08:00:00 +0000\r\n\r\n下周二上午十点面试。\r\n")
+            .into_bytes()
+    }
+
+    /// 一个合成 PNG：魔数对得上、能读回来就够了。
+    fn png() -> Vec<u8> {
+        let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+        bytes.extend_from_slice(&[0, 0, 0, 13, b'I', b'H', b'D', b'R']);
+        bytes.extend_from_slice(&[0u8; 32]);
+        bytes
+    }
+
+    fn import(
+        store: &ArchiveStore,
+        paths: Vec<String>,
+        text: Option<String>,
+        app: Option<&str>,
+    ) -> evidence_commands::ImportReport {
+        evidence_commands::import_evidence(
+            store,
+            ImportArgs {
+                paths,
+                text,
+                application_id: app.map(str::to_string),
+            },
+            BUCKET,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn one_bad_file_does_not_take_the_good_ones_with_it() {
+        let (dir, store, _app) = archive();
+        let good = write(dir.path(), "面试邀请.eml", &eml("面试邀请"));
+        let bad = write(
+            dir.path(),
+            "invite.msg",
+            b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1 padding",
+        );
+
+        let report = import(&store, vec![good, bad], None, None);
+
+        assert_eq!(report.imported.len(), 1);
+        assert_eq!(report.failed.len(), 1);
+        assert_eq!(report.failed[0].code, "unsupported");
+        assert_eq!(report.failed[0].name, "invite.msg");
+        let one = &report.imported[0];
+        assert_eq!(one.kind, "eml");
+        assert_eq!(one.subject.as_deref(), Some("面试邀请"));
+        assert_eq!(one.from_addr.as_deref(), Some("hr@example.test"));
+        assert_eq!(
+            one.sent_at.as_deref(),
+            Some("2026-09-12T08:00:00.000Z"),
+            "档案层把时间规范成毫秒精度"
+        );
+        assert_eq!(
+            one.application_id, None,
+            "还没有选申请：它待在收件箱里"
+        );
+        assert_eq!(store.list_evidence(None).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn the_same_bytes_are_reported_as_a_duplicate_and_stored_once() {
+        let (dir, store, _app) = archive();
+        let path = write(dir.path(), "reply.eml", &eml("同一封"));
+
+        let first = import(&store, vec![path.clone()], None, None);
+        assert_eq!(first.imported.len(), 1);
+        assert!(first.duplicates.is_empty());
+
+        let again = import(&store, vec![path], None, None);
+        assert!(again.imported.is_empty());
+        assert_eq!(again.duplicates.len(), 1);
+        assert_eq!(
+            again.duplicates[0].same_bytes_as.len(),
+            1,
+            "提示指向先导入的那条"
+        );
+
+        let blob_dir = store
+            .archive_dir()
+            .join("attachments")
+            .join("2026")
+            .join("09");
+        assert_eq!(
+            std::fs::read_dir(blob_dir).unwrap().count(),
+            1,
+            "字节只存一份"
+        );
+    }
+
+    #[test]
+    fn evidence_moves_in_and_out_of_an_application_with_the_state_following() {
+        let (dir, store, app) = archive();
+        let path = write(dir.path(), "reply.eml", &eml("回复"));
+        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        let state = |store: &ArchiveStore| {
+            store
+                .get_application(&app)
+                .unwrap()
+                .unwrap()
+                .reply_evidence_state
+                .as_str()
+                .to_string()
+        };
+        assert_eq!(state(&store), "none_imported");
+
+        evidence_commands::associate(&store, &id, &app).unwrap();
+        assert_eq!(
+            state(&store),
+            "imported_unclassified",
+            "关联后未分类，不能说尚未导入"
+        );
+
+        evidence_commands::unassociate(&store, &id).unwrap();
+        assert_eq!(state(&store), "none_imported");
+        assert_eq!(evidence_commands::list_inbox(&store).unwrap().len(), 1);
+
+        evidence_commands::associate(&store, &id, &app).unwrap();
+        let classified =
+            evidence_commands::classify(&store, &id, "interview_invite", "automated").unwrap();
+        assert_eq!(classified.reply_class.as_deref(), Some("interview_invite"));
+        assert_eq!(
+            classified.send_mode.as_deref(),
+            Some("automated"),
+            "不因为是面试邀请就写成人工"
+        );
+        assert_eq!(state(&store), "classified");
+        assert_eq!(
+            store
+                .get_application(&app)
+                .unwrap()
+                .unwrap()
+                .current_stage
+                .as_str(),
+            "saved",
+            "导入与分类都不改阶段"
+        );
+        assert!(evidence_commands::classify(&store, &id, "made_up", "human").is_err());
+    }
+
+    #[test]
+    fn a_preview_is_text_or_a_data_url_and_never_a_path() {
+        let (dir, store, _app) = archive();
+        let mail = write(dir.path(), "reply.eml", &eml("面试邀请"));
+        let shot = write(dir.path(), "screenshot.png", &png());
+        let pdf = write(dir.path(), "offer.pdf", b"%PDF-1.7\n1 0 obj\n<<>>\nendobj\n");
+        let report = import(
+            &store,
+            vec![mail, shot, pdf],
+            Some("他们说下周二面试。".into()),
+            None,
+        );
+        assert_eq!(report.imported.len(), 4, "{:?}", report.failed);
+
+        let by_kind = |kind: &str| {
+            report
+                .imported
+                .iter()
+                .find(|item| item.kind == kind)
+                .unwrap()
+                .id
+                .clone()
+        };
+
+        let mail = evidence_commands::get_preview(&store, &by_kind("eml")).unwrap();
+        assert!(mail.body_extract.unwrap().contains("下周二上午十点"));
+        assert!(mail.image_data_url.is_none());
+
+        let shot = evidence_commands::get_preview(&store, &by_kind("screenshot")).unwrap();
+        assert!(shot
+            .image_data_url
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        let pdf = evidence_commands::get_preview(&store, &by_kind("pdf")).unwrap();
+        assert!(pdf.image_data_url.is_none());
+        assert!(pdf.note.unwrap().contains("系统程序"));
+
+        let pasted = evidence_commands::get_preview(&store, &by_kind("paste")).unwrap();
+        assert_eq!(pasted.body_extract.as_deref(), Some("他们说下周二面试。"));
+
+        // 给 WebView 的任何一条里都没有存储路径。
+        for id in report.imported.iter().map(|item| item.id.clone()) {
+            let json =
+                serde_json::to_string(&evidence_commands::get_preview(&store, &id).unwrap())
+                    .unwrap();
+            assert!(!json.contains("attachments/"), "{json}");
+            assert!(!json.contains(&store.archive_dir().to_string_lossy().to_string()));
+        }
+    }
+
+    #[test]
+    fn a_copy_that_is_gone_says_so_instead_of_pretending() {
+        let (dir, store, _app) = archive();
+        let path = write(dir.path(), "reply.eml", &eml("回复"));
+        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        let stored: PathBuf = evidence_commands::stored_path(&store, &id).unwrap();
+        assert!(stored.starts_with(store.archive_dir().canonicalize().unwrap()));
+
+        std::fs::remove_file(&stored).unwrap();
+        let preview = evidence_commands::get_preview(&store, &id).unwrap();
+        assert!(preview.note.unwrap().contains("不在了"));
+        assert!(evidence_commands::stored_path(&store, &id).is_err());
+    }
+}

--- a/desktop/src-tauri/src/evidence_commands.rs
+++ b/desktop/src-tauri/src/evidence_commands.rs
@@ -1,0 +1,511 @@
+//! D09 命令层：导入、收件箱、预览、关联与分类。
+//!
+//! 顺序固定：`evidence-import` 先把字节落进 `attachments/`，成功之后 archive-store 才登记
+//! 一行证据。一个文件失败不影响同一批里的其他文件。
+//!
+//! 给 WebView 的每个结构里都**没有存储路径**：预览要么是文本，要么是这里生成的 `data:`
+//! 图片；PDF 只给元数据，由 `open_evidence` 交给系统程序打开（拆分计划决策 6、Q2）。
+
+use std::path::{Path, PathBuf};
+
+use archive_store::{
+    ArchiveStore, AttachmentBlobMeta, EvidenceKind as StoredKind, NewEvidence, Occurred,
+    ReplyClass, ReplyEvidence, SendMode,
+};
+use evidence_import::{
+    bucket_from_unix, parse_eml, stage_file, stage_text, EvidenceKind, MAX_FILES_PER_IMPORT,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::commands::CommandError;
+
+/// 超过这个大小的图片不做 `data:` 预览，只给元数据：一份内存里的副本已经够贵了。
+const MAX_INLINE_IMAGE_BYTES: i64 = 8 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvidenceSummary {
+    pub id: String,
+    pub application_id: Option<String>,
+    pub kind: String,
+    pub mime: Option<String>,
+    pub size_bytes: i64,
+    pub original_filename: Option<String>,
+    pub imported_at: String,
+    pub subject: Option<String>,
+    pub from_addr: Option<String>,
+    pub sent_at: Option<String>,
+    pub reply_class: Option<String>,
+    pub send_mode: Option<String>,
+    /// 引用同一份字节的其他证据。同哈希只是提示，不代表这次导入是多余的。
+    pub same_bytes_as: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedImport {
+    /// 安全文件名，**不是**用户机器上的路径。
+    pub name: String,
+    pub code: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportReport {
+    pub imported: Vec<EvidenceSummary>,
+    pub duplicates: Vec<EvidenceSummary>,
+    pub failed: Vec<FailedImport>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportArgs {
+    #[serde(default)]
+    pub paths: Vec<String>,
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub application_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvidencePreview {
+    #[serde(flatten)]
+    pub summary: EvidenceSummary,
+    pub body_extract: Option<String>,
+    /// 图片才有；`data:` URL 由这里生成，页面的 CSP 允许 `img-src data:`。
+    pub image_data_url: Option<String>,
+    /// 不能内嵌预览时说明为什么，以及还能做什么。
+    pub note: Option<String>,
+}
+
+/// 一批导入。失败逐个记录，成功逐个登记；这一批里没有全有或全无的语义。
+pub fn import_evidence(
+    store: &ArchiveStore,
+    args: ImportArgs,
+    bucket: &str,
+) -> Result<ImportReport, CommandError> {
+    let mut report = ImportReport {
+        imported: Vec::new(),
+        duplicates: Vec::new(),
+        failed: Vec::new(),
+    };
+    let archive_dir = store.archive_dir().to_path_buf();
+
+    let paths: Vec<PathBuf> = args
+        .paths
+        .iter()
+        .take(MAX_FILES_PER_IMPORT)
+        .map(PathBuf::from)
+        .collect();
+    for path in &args.paths[paths.len().min(args.paths.len())..] {
+        report.failed.push(FailedImport {
+            name: evidence_import::safe_file_name(
+                Path::new(path).file_name().and_then(|n| n.to_str()),
+            ),
+            code: "too_many_files".into(),
+        });
+    }
+
+    for path in paths {
+        match import_one(
+            store,
+            &archive_dir,
+            &path,
+            bucket,
+            args.application_id.as_deref(),
+        ) {
+            Ok((summary, duplicated)) => {
+                if duplicated {
+                    report.duplicates.push(summary);
+                } else {
+                    report.imported.push(summary);
+                }
+            }
+            Err(failed) => report.failed.push(failed),
+        }
+    }
+
+    if let Some(text) = args
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        match import_pasted(
+            store,
+            &archive_dir,
+            text,
+            bucket,
+            args.application_id.as_deref(),
+        ) {
+            Ok((summary, duplicated)) => {
+                if duplicated {
+                    report.duplicates.push(summary);
+                } else {
+                    report.imported.push(summary);
+                }
+            }
+            Err(failed) => report.failed.push(failed),
+        }
+    }
+
+    Ok(report)
+}
+
+fn import_one(
+    store: &ArchiveStore,
+    archive_dir: &Path,
+    source: &Path,
+    bucket: &str,
+    application_id: Option<&str>,
+) -> Result<(EvidenceSummary, bool), FailedImport> {
+    let name = evidence_import::safe_file_name(source.file_name().and_then(|n| n.to_str()));
+    let existing = |sha: &str| {
+        store
+            .find_blob(sha)
+            .ok()
+            .flatten()
+            .map(|b| b.meta.stored_rel_path)
+    };
+    let staged =
+        stage_file(archive_dir, source, bucket, &existing).map_err(|err| FailedImport {
+            name: name.clone(),
+            code: err.code().to_string(),
+        })?;
+
+    // 文本类的原件再问一次邮件解析：一个只有 From 头的残信 sniff 判不出来，但它确实是信。
+    let parsed = matches!(staged.kind, EvidenceKind::Eml | EvidenceKind::Unknown)
+        .then(|| std::fs::read(archive_dir.join(&staged.stored_rel_path)).ok())
+        .flatten()
+        .and_then(|bytes| parse_eml(&bytes));
+    let kind = if parsed.is_some() {
+        StoredKind::Eml
+    } else {
+        stored_kind(staged.kind)
+    };
+
+    let record = store
+        .import_evidence(NewEvidence {
+            application_id: application_id.map(str::to_string),
+            kind,
+            blob: AttachmentBlobMeta {
+                sha256: staged.sha256.clone(),
+                size_bytes: staged.size_bytes,
+                stored_rel_path: staged.stored_rel_path.clone(),
+                mime: staged.mime.clone(),
+            },
+            original_filename: staged.original_filename.clone(),
+            subject: parsed.as_ref().and_then(|mail| mail.subject.clone()),
+            from_addr: parsed.as_ref().and_then(|mail| mail.from_addr.clone()),
+            sent_at: parsed
+                .as_ref()
+                .and_then(|mail| mail.sent_at.clone())
+                .map(|rfc3339| Occurred::DateTime {
+                    rfc3339,
+                    time_zone: None,
+                }),
+            body_extract: parsed.as_ref().and_then(|mail| mail.body_extract.clone()),
+            append_event: true,
+        })
+        .map_err(|_| FailedImport {
+            name,
+            code: "storage".into(),
+        })?;
+
+    Ok((summarise(store, record), staged.deduplicated))
+}
+
+fn import_pasted(
+    store: &ArchiveStore,
+    archive_dir: &Path,
+    text: &str,
+    bucket: &str,
+    application_id: Option<&str>,
+) -> Result<(EvidenceSummary, bool), FailedImport> {
+    let existing = |sha: &str| {
+        store
+            .find_blob(sha)
+            .ok()
+            .flatten()
+            .map(|b| b.meta.stored_rel_path)
+    };
+    let staged = stage_text(archive_dir, text, bucket, &existing).map_err(|err| FailedImport {
+        name: "paste.txt".into(),
+        code: err.code().to_string(),
+    })?;
+    let record = store
+        .import_evidence(NewEvidence {
+            application_id: application_id.map(str::to_string),
+            kind: StoredKind::Paste,
+            blob: AttachmentBlobMeta {
+                sha256: staged.sha256.clone(),
+                size_bytes: staged.size_bytes,
+                stored_rel_path: staged.stored_rel_path.clone(),
+                mime: staged.mime.clone(),
+            },
+            original_filename: None,
+            subject: None,
+            from_addr: None,
+            sent_at: None,
+            body_extract: Some(first_lines(text)),
+            append_event: true,
+        })
+        .map_err(|_| FailedImport {
+            name: "paste.txt".into(),
+            code: "storage".into(),
+        })?;
+    Ok((summarise(store, record), staged.deduplicated))
+}
+
+fn first_lines(text: &str) -> String {
+    let mut extract: String = text
+        .chars()
+        .take(evidence_import::MAX_BODY_EXTRACT / 4)
+        .collect();
+    if extract.len() < text.len() {
+        extract.push_str("（正文已截断）");
+    }
+    extract
+}
+
+/// 收件箱：还没有关联到任何申请的证据，最近导入的在前。
+pub fn list_inbox(store: &ArchiveStore) -> Result<Vec<EvidenceSummary>, CommandError> {
+    let mut items: Vec<EvidenceSummary> = store
+        .list_evidence(None)?
+        .into_iter()
+        .map(|record| summarise(store, record))
+        .collect();
+    items.sort_by(|a, b| b.imported_at.cmp(&a.imported_at));
+    Ok(items)
+}
+
+pub fn list_for_application(
+    store: &ArchiveStore,
+    application_id: &str,
+) -> Result<Vec<EvidenceSummary>, CommandError> {
+    Ok(store
+        .list_evidence(Some(application_id))?
+        .into_iter()
+        .map(|record| summarise(store, record))
+        .collect())
+}
+
+pub fn get_preview(
+    store: &ArchiveStore,
+    evidence_id: &str,
+) -> Result<EvidencePreview, CommandError> {
+    let record = store
+        .get_evidence(evidence_id)?
+        .ok_or_else(|| CommandError {
+            code: "NOT_FOUND".into(),
+            message: "找不到这条证据".into(),
+        })?;
+    let summary = summarise(store, record.clone());
+    let path = store.archive_dir().join(&record.blob.meta.stored_rel_path);
+    let missing = !path.exists();
+
+    let (image_data_url, note) = match (&record.kind, missing) {
+        (_, true) => (
+            None,
+            Some("本机副本不在了：档案目录里找不到这份文件，可以重新导入原件。".into()),
+        ),
+        (StoredKind::Screenshot, false)
+            if record.blob.meta.size_bytes <= MAX_INLINE_IMAGE_BYTES =>
+        {
+            match std::fs::read(&path) {
+                Ok(bytes) => (
+                    Some(format!(
+                        "data:{};base64,{}",
+                        record.blob.meta.mime.as_deref().unwrap_or("image/png"),
+                        base64(&bytes)
+                    )),
+                    None,
+                ),
+                Err(_) => (
+                    None,
+                    Some("这张图片读不出来，档案里的原件可能已损坏。".into()),
+                ),
+            }
+        }
+        (StoredKind::Screenshot, false) => (
+            None,
+            Some("这张图片超过 8 MiB，没有在应用内展开；可以用系统程序打开本机副本。".into()),
+        ),
+        (StoredKind::Pdf, false) => (
+            None,
+            Some("PDF 不在应用内渲染。可以用系统程序打开本机副本——那会离开这个应用。".into()),
+        ),
+        _ => (None, None),
+    };
+
+    Ok(EvidencePreview {
+        summary,
+        body_extract: record.body_extract,
+        image_data_url,
+        note,
+    })
+}
+
+pub fn associate(
+    store: &ArchiveStore,
+    evidence_id: &str,
+    application_id: &str,
+) -> Result<EvidenceSummary, CommandError> {
+    let record = store.associate_evidence(evidence_id, application_id)?;
+    Ok(summarise(store, record))
+}
+
+pub fn unassociate(
+    store: &ArchiveStore,
+    evidence_id: &str,
+) -> Result<EvidenceSummary, CommandError> {
+    let record = store.unassociate_evidence(evidence_id)?;
+    Ok(summarise(store, record))
+}
+
+/// 用户确认的分类。两个字段各自独立：选了「面试邀请」不会让发送方式变成「人工」。
+pub fn classify(
+    store: &ArchiveStore,
+    evidence_id: &str,
+    reply_class: &str,
+    send_mode: &str,
+) -> Result<EvidenceSummary, CommandError> {
+    let class = parse_reply_class(reply_class).ok_or_else(|| CommandError {
+        code: "VALIDATION".into(),
+        message: format!("未知的通知类型：{reply_class}"),
+    })?;
+    let mode = parse_send_mode(send_mode).ok_or_else(|| CommandError {
+        code: "VALIDATION".into(),
+        message: format!("未知的发送方式：{send_mode}"),
+    })?;
+    let record = store.classify_evidence(evidence_id, class, mode)?;
+    Ok(summarise(store, record))
+}
+
+/// 这份证据在档案里的绝对路径，只给宿主用来交给系统程序（永远不返回给 WebView）。
+pub fn stored_path(store: &ArchiveStore, evidence_id: &str) -> Result<PathBuf, CommandError> {
+    let record = store
+        .get_evidence(evidence_id)?
+        .ok_or_else(|| CommandError {
+            code: "NOT_FOUND".into(),
+            message: "找不到这条证据".into(),
+        })?;
+    let root = store
+        .archive_dir()
+        .canonicalize()
+        .map_err(|err| CommandError {
+            code: "STORE_ERROR".into(),
+            message: err.to_string(),
+        })?;
+    let path = root
+        .join(&record.blob.meta.stored_rel_path)
+        .canonicalize()
+        .map_err(|_| CommandError {
+            code: "NOT_FOUND".into(),
+            message: "本机副本不在了".into(),
+        })?;
+    if !path.starts_with(&root) {
+        return Err(CommandError {
+            code: "VALIDATION".into(),
+            message: "这条证据指向档案目录之外".into(),
+        });
+    }
+    Ok(path)
+}
+
+fn summarise(store: &ArchiveStore, record: ReplyEvidence) -> EvidenceSummary {
+    let same_bytes_as = store
+        .evidence_for_blob(&record.blob.meta.sha256)
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|id| id != &record.id)
+        .collect();
+    EvidenceSummary {
+        id: record.id,
+        application_id: record.application_id,
+        kind: record.kind.as_str().to_string(),
+        mime: record.blob.meta.mime,
+        size_bytes: record.blob.meta.size_bytes,
+        original_filename: record.original_filename,
+        imported_at: record.imported_at,
+        subject: record.subject,
+        from_addr: record.from_addr,
+        sent_at: occurred_text(record.sent_at),
+        reply_class: record.reply_class.map(|c| c.as_str().to_string()),
+        send_mode: record.send_mode.map(|m| m.as_str().to_string()),
+        same_bytes_as,
+    }
+}
+
+fn occurred_text(occurred: Option<Occurred>) -> Option<String> {
+    match occurred {
+        Some(Occurred::DateTime { rfc3339, .. }) => Some(rfc3339),
+        Some(Occurred::Date { date, .. }) => Some(date),
+        _ => None,
+    }
+}
+
+fn stored_kind(kind: EvidenceKind) -> StoredKind {
+    match kind {
+        EvidenceKind::Eml => StoredKind::Eml,
+        EvidenceKind::Screenshot => StoredKind::Screenshot,
+        EvidenceKind::Pdf => StoredKind::Pdf,
+        EvidenceKind::Paste => StoredKind::Paste,
+        EvidenceKind::Unknown => StoredKind::Unknown,
+    }
+}
+
+fn parse_reply_class(value: &str) -> Option<ReplyClass> {
+    Some(match value {
+        "auto_ack" => ReplyClass::AutoAck,
+        "assessment_invite" => ReplyClass::AssessmentInvite,
+        "interview_invite" => ReplyClass::InterviewInvite,
+        "action_required" => ReplyClass::ActionRequired,
+        "offer" => ReplyClass::Offer,
+        "reject" => ReplyClass::Reject,
+        "other" => ReplyClass::Other,
+        "unknown" => ReplyClass::Unknown,
+        _ => return None,
+    })
+}
+
+fn parse_send_mode(value: &str) -> Option<SendMode> {
+    Some(match value {
+        "human" => SendMode::Human,
+        "automated" => SendMode::Automated,
+        "unknown" => SendMode::Unknown,
+        _ => return None,
+    })
+}
+
+/// 导入时间决定桶名，也就决定了文件落在 `attachments/<yyyy>/<mm>/`。
+pub fn bucket_now() -> String {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    bucket_from_unix(seconds)
+}
+
+fn base64(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b = [
+            chunk[0],
+            *chunk.get(1).unwrap_or(&0),
+            *chunk.get(2).unwrap_or(&0),
+        ];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        for i in 0..4 {
+            if i <= chunk.len() {
+                out.push(TABLE[((n >> (18 - i * 6)) & 63) as usize] as char);
+            } else {
+                out.push('=');
+            }
+        }
+    }
+    out
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod commands;
+mod evidence_commands;
 #[cfg(test)]
 mod commands_regression;
 mod ipc_client;
@@ -290,6 +291,83 @@ fn get_snapshot_cmd(
 }
 
 #[tauri::command]
+fn import_evidence_cmd(
+    state: State<AppState>,
+    args: evidence_commands::ImportArgs,
+) -> Result<evidence_commands::ImportReport, CommandError> {
+    let bucket = evidence_commands::bucket_now();
+    with_store(&state, |store| {
+        evidence_commands::import_evidence(store, args.clone(), &bucket)
+    })
+}
+
+#[tauri::command]
+fn list_inbox_cmd(state: State<AppState>) -> Result<Vec<evidence_commands::EvidenceSummary>, CommandError> {
+    with_store(&state, evidence_commands::list_inbox)
+}
+
+#[tauri::command]
+fn get_evidence_preview_cmd(
+    state: State<AppState>,
+    evidence_id: String,
+) -> Result<evidence_commands::EvidencePreview, CommandError> {
+    with_store(&state, |store| {
+        evidence_commands::get_preview(store, &evidence_id)
+    })
+}
+
+#[tauri::command]
+fn associate_evidence_cmd(
+    state: State<AppState>,
+    evidence_id: String,
+    application_id: String,
+) -> Result<evidence_commands::EvidenceSummary, CommandError> {
+    with_store(&state, |store| {
+        evidence_commands::associate(store, &evidence_id, &application_id)
+    })
+}
+
+#[tauri::command]
+fn unassociate_evidence_cmd(
+    state: State<AppState>,
+    evidence_id: String,
+) -> Result<evidence_commands::EvidenceSummary, CommandError> {
+    with_store(&state, |store| {
+        evidence_commands::unassociate(store, &evidence_id)
+    })
+}
+
+#[tauri::command]
+fn classify_evidence_cmd(
+    state: State<AppState>,
+    evidence_id: String,
+    reply_class: String,
+    send_mode: String,
+) -> Result<evidence_commands::EvidenceSummary, CommandError> {
+    with_store(&state, |store| {
+        evidence_commands::classify(store, &evidence_id, &reply_class, &send_mode)
+    })
+}
+
+/// 用系统默认程序打开本机副本。路径在这里解析并核对在档案目录之内，**不经过 WebView**。
+#[tauri::command]
+fn open_evidence_cmd(
+    app: tauri::AppHandle,
+    state: State<AppState>,
+    evidence_id: String,
+) -> Result<(), CommandError> {
+    let path = with_store(&state, |store| {
+        evidence_commands::stored_path(store, &evidence_id)
+    })?;
+    tauri_plugin_opener::OpenerExt::opener(&app)
+        .open_path(path.to_string_lossy(), None::<&str>)
+        .map_err(|err| CommandError {
+            code: "OPEN_FAILED".into(),
+            message: err.to_string(),
+        })
+}
+
+#[tauri::command]
 fn update_application_cmd(
     state: State<AppState>,
     args: UpdateApplicationArgs,
@@ -575,6 +653,8 @@ pub fn run() {
     let hidden_launch = args.hidden;
     let quit_launch = args.quit;
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             let wants_hidden = argv.iter().any(|a| a == "--hidden");
             let wants_probe = argv.iter().any(|a| a == "--probe");
@@ -691,6 +771,13 @@ pub fn run() {
             create_application_cmd,
             get_application_cmd,
             get_snapshot_cmd,
+            import_evidence_cmd,
+            list_inbox_cmd,
+            get_evidence_preview_cmd,
+            associate_evidence_cmd,
+            unassociate_evidence_cmd,
+            classify_evidence_cmd,
+            open_evidence_cmd,
             update_application_cmd,
             add_note_cmd,
             confirm_submit_cmd,


### PR DESCRIPTION
D09 PR 3/6，压在 #68 上。Ref #66。

## 只做了什么

`desktop/src-tauri/src/evidence_commands.rs` + 注册：`import_evidence_cmd`、`list_inbox_cmd`、`get_evidence_preview_cmd`、`associate_evidence_cmd`、`unassociate_evidence_cmd`、`classify_evidence_cmd`、`open_evidence_cmd`。

archive-store 补了三个方法：`unassociate_evidence`（取消关联，重算 `replyEvidenceState`——这是回到 `none_imported` 的唯一路径）、`find_blob`、`evidence_for_blob`。`association_changed` 事件的目标现在可以为空，那就是「证据被从这条申请里取走」在时间线上的样子。

## 几条硬规矩

- **一批里一个失败不影响其他**：同一次拖入 `.eml` + `.msg`，前者进档案，后者进 `failed`，带错误码 `unsupported`（界面据此提示「另存为 .eml 或粘贴正文」）。
- **同字节只存一份**：第二次导入进 `duplicates`，磁盘上仍然只有一个文件，`ref_count` 变 2；但**不会**因为哈希相同就撤销用户有意的第二次关联。
- **给 WebView 的结构里没有任何路径**：预览是文本，或这里生成的 `data:` 图片；PDF 只给元数据与说明。要用系统程序打开时，路径在 Rust 里解析并核对在档案目录之内（`open_evidence_cmd`）。
- **导入和分类都不改阶段**；`replyClass` 与 `sendMode` 分开写，选「面试邀请」不会把发送方式变成「人工」（§6.3、走查 10.13）。
- 本机副本被删掉之后，预览明说「本机副本不在了」，而不是显示半份东西。

## 测试

`cargo test --manifest-path src-tauri/Cargo.toml`：73 个（新增 5 个 D09 用例）。`cargo test --manifest-path crates/archive-store/Cargo.toml`：52 个（新增取消关联与按哈希查找两个用例）。插件侧 484 个不受影响。

新依赖：`tauri-plugin-dialog`（文件选择，JS 侧用）、`tauri-plugin-opener`（打开本机副本，Rust 侧用）；capability 只放开了 `dialog:allow-open`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)