### PR TITLE
feat(d09): the evidence inbox — drop, paste, preview, associate, classify (#66, PR 4/6)

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Frontend unit tests
         working-directory: desktop
-        run: node --test src/pairing-form.test.js src/applications.test.js src/applications-ui.test.js
+        run: node --test src/pairing-form.test.js src/applications.test.js src/applications-ui.test.js src/inbox.test.js src/inbox-ui.test.js
 
       - name: Development registration script tests
         working-directory: desktop

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -132,9 +132,20 @@
 
         <section id="view-inbox" class="view hidden">
           <h1>证据收件箱</h1>
-          <div class="empty">
-            <p>证据收件箱尚未接入。</p>
-            <p class="muted">邮件导入与分类属于后续交付。当前没有可展示的证据，也没有「尚未导入」的计数。</p>
+          <p class="muted">把回复邮件（.eml）、截图或 PDF 拖进窗口，或者粘贴一段文本。导入只是把原件存进档案，不代表对方回复了什么，也不会改变申请阶段。</p>
+          <div class="row">
+            <button type="button" id="inbox-pick">选择文件…</button>
+            <button type="button" id="inbox-refresh">刷新</button>
+          </div>
+          <details class="inbox-paste">
+            <summary>粘贴一段文本</summary>
+            <textarea id="inbox-paste" rows="4" placeholder="把邮件正文或一段说明粘贴到这里"></textarea>
+            <button type="button" id="inbox-paste-save">导入这段文本</button>
+          </details>
+          <p id="inbox-status" class="muted"></p>
+          <div class="inbox-split">
+            <div id="inbox-list"></div>
+            <div id="inbox-preview"></div>
           </div>
         </section>
 

--- a/desktop/src/inbox-ui.js
+++ b/desktop/src/inbox-ui.js
@@ -1,0 +1,264 @@
+// D09 收件箱视图：拖入 / 选择 / 粘贴 → 列表 → 预览 → 关联与分类。
+//
+// 这里不解析任何东西，也不碰路径：拿到的就是命令层已经清洗过的文本、`data:` 图片和说明。
+// 正文一律经 escapeHtml 写入，邮件里的标签只会以字面文本出现。
+
+import {
+  CHOOSE_APPLICATION_HINT,
+  EMPTY_INBOX,
+  REPLY_CLASS_OPTIONS,
+  SEND_MODE_OPTIONS,
+  describeAssociation,
+  describeClassification,
+  describeEvidenceMeta,
+  describeImport,
+  describeUnassociation,
+  duplicateNote,
+  evidenceTitle,
+  kindLabel,
+  replyClassLabel,
+  sendModeLabel,
+} from "./inbox.js";
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function invokeError(error) {
+  return error?.message || error?.code || "未知错误";
+}
+
+/**
+ * 挂载收件箱。`pickFiles` 与 `listenDrop` 由宿主注入（真实实现是 Tauri 的文件对话框与
+ * 拖放事件），测试里可以换成假的。
+ */
+export function mountInbox(invoke, { pickFiles = null, listenDrop = null } = {}) {
+  const list = document.getElementById("inbox-list");
+  const preview = document.getElementById("inbox-preview");
+  const status = document.getElementById("inbox-status");
+  const pasteBox = document.getElementById("inbox-paste");
+
+  let items = [];
+  let selectedId = null;
+  let previewToken = 0;
+  let applications = [];
+
+  function say(message) {
+    status.textContent = message?.text ?? "";
+    status.dataset.tone = message?.tone ?? "info";
+  }
+
+  async function refresh() {
+    try {
+      items = await invoke("list_inbox_cmd");
+    } catch (error) {
+      items = [];
+      say({ tone: "warn", text: `读不到收件箱：${invokeError(error)}` });
+    }
+    renderList();
+    if (selectedId && !items.some((item) => item.id === selectedId)) {
+      selectedId = null;
+      preview.innerHTML = "";
+    }
+  }
+
+  function renderList() {
+    if (!items.length) {
+      list.innerHTML = `<p class="muted">${escapeHtml(EMPTY_INBOX)}</p>`;
+      return;
+    }
+    list.innerHTML = `<ul class="inbox-list">${items
+      .map((item) => {
+        const active = item.id === selectedId ? " class=\"active\"" : "";
+        const badge = item.sameBytesAs?.length ? "<em>内容重复</em>" : "";
+        return `<li${active}>
+          <button type="button" data-evidence="${escapeHtml(item.id)}">
+            <span>${escapeHtml(evidenceTitle(item))}</span>
+            <small>${escapeHtml(kindLabel(item.kind))} · ${escapeHtml(item.importedAt)}</small>
+          </button>${badge}
+        </li>`;
+      })
+      .join("")}</ul>`;
+    list.querySelectorAll("button[data-evidence]").forEach((button) => {
+      button.addEventListener("click", () => select(button.dataset.evidence));
+    });
+  }
+
+  async function select(evidenceId) {
+    selectedId = evidenceId;
+    const token = ++previewToken;
+    preview.innerHTML = '<p class="muted">加载中…</p>';
+    renderList();
+    let data;
+    try {
+      data = await invoke("get_evidence_preview_cmd", { evidenceId });
+    } catch (error) {
+      if (token !== previewToken) return;
+      preview.innerHTML = `<p class="banner">${escapeHtml(`读不出这条证据：${invokeError(error)}`)}</p>`;
+      return;
+    }
+    if (token !== previewToken) return;
+    await loadApplications();
+    if (token !== previewToken) return;
+    renderPreview(data);
+  }
+
+  async function loadApplications() {
+    try {
+      const page = await invoke("list_applications_cmd", {
+        args: { stage: "all", recycle: "active", desc: true, limit: 100, offset: 0 },
+      });
+      applications = page?.items ?? [];
+    } catch {
+      applications = [];
+    }
+  }
+
+  function renderPreview(data) {
+    const item = data;
+    const duplicate = duplicateNote(item);
+    // 正文经过转义写入：邮件里的 <script> 只会作为字面文本出现。
+    const body = item.bodyExtract
+      ? `<pre class="evidence-body">${escapeHtml(item.bodyExtract)}</pre>`
+      : "";
+    const image = item.imageDataUrl
+      ? `<img class="evidence-image" alt="导入的截图" src="${escapeHtml(item.imageDataUrl)}">`
+      : "";
+    const note = item.note ? `<p class="banner">${escapeHtml(item.note)}</p>` : "";
+    const openable = item.kind === "pdf" || (item.kind === "screenshot" && !item.imageDataUrl);
+
+    preview.innerHTML = `
+      <h3>${escapeHtml(evidenceTitle(item))}</h3>
+      <p class="muted">${escapeHtml(describeEvidenceMeta(item))}</p>
+      ${duplicate ? `<p class="muted">${escapeHtml(duplicate)}</p>` : ""}
+      ${note}
+      ${image}
+      ${body}
+      ${openable ? '<button type="button" data-act="open">用系统程序打开本机副本</button>' : ""}
+      <h4>关联申请</h4>
+      <p class="muted">${escapeHtml(CHOOSE_APPLICATION_HINT)}</p>
+      <div class="row">
+        <select id="inbox-application">
+          <option value="">请选择一条申请…</option>
+          ${applications
+            .map(
+              (app) =>
+                `<option value="${escapeHtml(app.id)}">${escapeHtml(app.company)} · ${escapeHtml(app.title)}</option>`,
+            )
+            .join("")}
+        </select>
+        <button type="button" data-act="associate">关联</button>
+        ${item.applicationId ? '<button type="button" data-act="unassociate">取消关联</button>' : ""}
+      </div>
+      <h4>分类</h4>
+      <div class="row">
+        <label>通知类型
+          <select id="inbox-reply-class">
+            ${REPLY_CLASS_OPTIONS.map(
+              (option) =>
+                `<option value="${escapeHtml(option.value)}"${option.value === (item.replyClass ?? "") ? " selected" : ""}>${escapeHtml(option.label)}</option>`,
+            ).join("")}
+          </select>
+        </label>
+        <label>发送方式
+          <select id="inbox-send-mode">
+            ${SEND_MODE_OPTIONS.map(
+              (option) =>
+                `<option value="${escapeHtml(option.value)}"${option.value === (item.sendMode ?? "unknown") ? " selected" : ""}>${escapeHtml(option.label)}</option>`,
+            ).join("")}
+          </select>
+        </label>
+        <button type="button" data-act="classify">保存分类</button>
+      </div>
+      <p class="muted">现在记为「${escapeHtml(replyClassLabel(item.replyClass))}」，发送方式「${escapeHtml(sendModeLabel(item.sendMode))}」。</p>
+    `;
+    preview.querySelectorAll("button[data-act]").forEach((button) => {
+      button.addEventListener("click", () => act(button.dataset.act, item));
+    });
+  }
+
+  async function act(action, item) {
+    try {
+      if (action === "open") {
+        await invoke("open_evidence_cmd", { evidenceId: item.id });
+        say({ tone: "info", text: "已交给系统默认程序打开——那会离开这个应用。" });
+        return;
+      }
+      if (action === "associate") {
+        const applicationId = document.getElementById("inbox-application").value;
+        if (!applicationId) {
+          say({ tone: "warn", text: "请先选中一条申请。" });
+          return;
+        }
+        const chosen = applications.find((app) => app.id === applicationId);
+        await invoke("associate_evidence_cmd", { evidenceId: item.id, applicationId });
+        say(describeAssociation({ id: item.id }, chosen?.company));
+        await refresh();
+        return;
+      }
+      if (action === "unassociate") {
+        await invoke("unassociate_evidence_cmd", { evidenceId: item.id });
+        say(describeUnassociation());
+        await refresh();
+        return;
+      }
+      if (action === "classify") {
+        const replyClass = document.getElementById("inbox-reply-class").value || "unknown";
+        const sendMode = document.getElementById("inbox-send-mode").value || "unknown";
+        const updated = await invoke("classify_evidence_cmd", {
+          evidenceId: item.id,
+          replyClass,
+          sendMode,
+        });
+        say(describeClassification(updated ?? { replyClass, sendMode }));
+        await select(item.id);
+      }
+    } catch (error) {
+      say({ tone: "warn", text: `没能完成这一步：${invokeError(error)}` });
+    }
+  }
+
+  async function importPaths(paths) {
+    if (!paths?.length) return;
+    await runImport({ paths });
+  }
+
+  async function runImport(args) {
+    try {
+      const report = await invoke("import_evidence_cmd", { args });
+      say(describeImport(report));
+      await refresh();
+    } catch (error) {
+      say({ tone: "warn", text: `导入失败：${invokeError(error)}` });
+    }
+  }
+
+  document.getElementById("inbox-pick")?.addEventListener("click", async () => {
+    if (!pickFiles) {
+      say({ tone: "warn", text: "这个环境里打不开文件选择框，可以把文件拖进窗口。" });
+      return;
+    }
+    const paths = await pickFiles();
+    await importPaths(paths);
+  });
+
+  document.getElementById("inbox-refresh")?.addEventListener("click", () => refresh());
+
+  document.getElementById("inbox-paste-save")?.addEventListener("click", async () => {
+    const text = pasteBox?.value ?? "";
+    if (!text.trim()) {
+      say({ tone: "warn", text: "先粘贴一段文本再导入。" });
+      return;
+    }
+    await runImport({ text });
+    if (pasteBox) pasteBox.value = "";
+  });
+
+  if (listenDrop) listenDrop((paths) => importPaths(paths));
+
+  return { refresh, importPaths };
+}

--- a/desktop/src/inbox-ui.test.js
+++ b/desktop/src/inbox-ui.test.js
@@ -1,0 +1,258 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mountInbox } from './inbox-ui.js';
+
+/** 与 applications-ui.test.js 同一套假 DOM：只有 id 查询、innerHTML 与监听器。 */
+function harness(handler, options = {}) {
+  const nodes = new Map();
+  const calls = [];
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+  class Node {
+    constructor(id) {
+      this.id = id;
+      this.value = '';
+      this.innerHTML = '';
+      this.dataset = {};
+      this.textContent = '';
+      this.listeners = {};
+    }
+    addEventListener(type, fn) {
+      this.listeners[type] = fn;
+    }
+    emit(type, event = {}) {
+      return this.listeners[type]?.({ preventDefault() {}, ...event });
+    }
+    querySelectorAll(selector) {
+      const attribute = selector.includes('data-evidence') ? 'data-evidence' : 'data-act';
+      const pattern = new RegExp(`${attribute}="([^"]+)"`, 'g');
+      return [...this.innerHTML.matchAll(pattern)].map((match) => {
+        const node = new Node(match[1]);
+        node.dataset =
+          attribute === 'data-evidence' ? { evidence: match[1] } : { act: match[1] };
+        buttons.set(`${attribute}:${match[1]}`, node);
+        return node;
+      });
+    }
+  }
+
+  const buttons = new Map();
+  function el(id) {
+    if (!nodes.has(id)) nodes.set(id, new Node(id));
+    return nodes.get(id);
+  }
+  globalThis.document = { getElementById: el, addEventListener() {} };
+
+  const invoke = async (name, args) => {
+    calls.push({ name, args });
+    const custom = handler?.(name, args);
+    if (custom !== undefined) return custom;
+    if (name === 'list_inbox_cmd') return [];
+    if (name === 'list_applications_cmd') return { total: 0, items: [] };
+    return {};
+  };
+
+  const api = mountInbox(invoke, options);
+  return { el, buttons, calls, api, tick };
+}
+
+const MAIL = {
+  id: 'e1',
+  applicationId: null,
+  kind: 'eml',
+  mime: 'message/rfc822',
+  sizeBytes: 2048,
+  originalFilename: '面试邀请.eml',
+  importedAt: '2026-09-12T09:00:00.000Z',
+  subject: '面试邀请',
+  fromAddr: 'hr@example.test',
+  sentAt: '2026-09-12T08:00:00.000Z',
+  replyClass: null,
+  sendMode: null,
+  sameBytesAs: [],
+};
+
+test('an empty inbox explains itself without claiming nobody replied', async () => {
+  const h = harness();
+  await h.api.refresh();
+  assert.match(h.el('inbox-list').innerHTML, /没有待处理的证据/);
+  assert.doesNotMatch(h.el('inbox-list').innerHTML, /未回复|没有回复/);
+});
+
+test('dropped files are imported by path and the result is reported', async () => {
+  let dropped = null;
+  const h = harness(
+    (name) => {
+      if (name === 'import_evidence_cmd') {
+        return { imported: [MAIL], duplicates: [], failed: [{ name: 'invite.msg', code: 'unsupported' }] };
+      }
+      if (name === 'list_inbox_cmd') return [MAIL];
+      return undefined;
+    },
+    { listenDrop: (fn) => { dropped = fn; } },
+  );
+
+  await dropped(['C:/Users/me/面试邀请.eml', 'C:/Users/me/invite.msg']);
+  await h.tick();
+
+  const call = h.calls.find((entry) => entry.name === 'import_evidence_cmd');
+  assert.deepEqual(call.args.args.paths, ['C:/Users/me/面试邀请.eml', 'C:/Users/me/invite.msg']);
+  assert.match(h.el('inbox-status').textContent, /已导入 1 条，待分类/);
+  assert.match(h.el('inbox-status').textContent, /invite\.msg/);
+  assert.match(h.el('inbox-list').innerHTML, /面试邀请/);
+});
+
+test('a mail body is shown escaped, and nothing remote can be referenced', async () => {
+  const h = harness((name) => {
+    if (name === 'list_inbox_cmd') return [MAIL];
+    if (name === 'get_evidence_preview_cmd') {
+      return {
+        ...MAIL,
+        bodyExtract: '请点击 <img src=x onerror=alert(1)> 这里 <https://tracker.example.test/x>',
+        imageDataUrl: null,
+        note: null,
+      };
+    }
+    return undefined;
+  });
+  await h.api.refresh();
+  h.buttons.get('data-evidence:e1').emit('click');
+  await h.tick();
+
+  const html = h.el('inbox-preview').innerHTML;
+  assert.match(html, /&lt;img src=x onerror=alert\(1\)&gt;/);
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.doesNotMatch(html, /src="http/);
+  assert.match(html, /hr@example\.test/);
+});
+
+test('a screenshot is shown from a data URL, a PDF offers the system viewer instead', async () => {
+  const shot = { ...MAIL, id: 'e2', kind: 'screenshot', subject: null, originalFilename: 'shot.png' };
+  const h = harness((name, args) => {
+    if (name === 'list_inbox_cmd') return [shot];
+    if (name === 'get_evidence_preview_cmd' && args.evidenceId === 'e2') {
+      return { ...shot, bodyExtract: null, imageDataUrl: 'data:image/png;base64,AAAA', note: null };
+    }
+    return undefined;
+  });
+  await h.api.refresh();
+  h.buttons.get('data-evidence:e2').emit('click');
+  await h.tick();
+  assert.match(h.el('inbox-preview').innerHTML, /src="data:image\/png;base64,AAAA"/);
+
+  const pdf = { ...MAIL, id: 'e3', kind: 'pdf', subject: null, originalFilename: 'offer.pdf' };
+  const g = harness((name, args) => {
+    if (name === 'list_inbox_cmd') return [pdf];
+    if (name === 'get_evidence_preview_cmd' && args.evidenceId === 'e3') {
+      return { ...pdf, bodyExtract: null, imageDataUrl: null, note: 'PDF 不在应用内渲染。' };
+    }
+    return undefined;
+  });
+  await g.api.refresh();
+  g.buttons.get('data-evidence:e3').emit('click');
+  await g.tick();
+  assert.match(g.el('inbox-preview').innerHTML, /PDF 不在应用内渲染/);
+  await g.buttons.get('data-act:open').emit('click');
+  await g.tick();
+  assert.ok(g.calls.some((call) => call.name === 'open_evidence_cmd'));
+});
+
+test('two applications at the same company are both offered and neither is preselected', async () => {
+  const h = harness((name) => {
+    if (name === 'list_inbox_cmd') return [MAIL];
+    if (name === 'get_evidence_preview_cmd') return { ...MAIL, bodyExtract: '正文', imageDataUrl: null, note: null };
+    if (name === 'list_applications_cmd') {
+      return {
+        total: 2,
+        items: [
+          { id: 'app-1', company: '星河科技', title: '后端开发' },
+          { id: 'app-2', company: '星河科技', title: '数据平台' },
+        ],
+      };
+    }
+    return undefined;
+  });
+  await h.api.refresh();
+  h.buttons.get('data-evidence:e1').emit('click');
+  await h.tick();
+
+  const html = h.el('inbox-preview').innerHTML;
+  assert.match(html, /后端开发/);
+  assert.match(html, /数据平台/);
+  assert.doesNotMatch(html, /<option value="app-[^"]*" selected/, '两条都不预选，必须自己点');
+  assert.match(html, /不会替你猜/);
+
+  // 没选就点关联：不发命令，只提醒。
+  h.el('inbox-application').value = '';
+  await h.buttons.get('data-act:associate').emit('click');
+  await h.tick();
+  assert.equal(h.calls.some((call) => call.name === 'associate_evidence_cmd'), false);
+  assert.match(h.el('inbox-status').textContent, /请先选中一条申请/);
+
+  h.el('inbox-application').value = 'app-2';
+  await h.buttons.get('data-act:associate').emit('click');
+  await h.tick();
+  const call = h.calls.find((entry) => entry.name === 'associate_evidence_cmd');
+  assert.deepEqual(call.args, { evidenceId: 'e1', applicationId: 'app-2' });
+  assert.match(h.el('inbox-status').textContent, /已导入，待分类/);
+});
+
+test('classification sends both fields and never turns an invite into a human', async () => {
+  const h = harness((name) => {
+    if (name === 'list_inbox_cmd') return [MAIL];
+    if (name === 'get_evidence_preview_cmd') return { ...MAIL, bodyExtract: '正文', imageDataUrl: null, note: null };
+    if (name === 'classify_evidence_cmd') return { ...MAIL, replyClass: 'interview_invite', sendMode: 'unknown' };
+    return undefined;
+  });
+  await h.api.refresh();
+  h.buttons.get('data-evidence:e1').emit('click');
+  await h.tick();
+
+  h.el('inbox-reply-class').value = 'interview_invite';
+  h.el('inbox-send-mode').value = 'unknown';
+  await h.buttons.get('data-act:classify').emit('click');
+  await h.tick();
+
+  const call = h.calls.find((entry) => entry.name === 'classify_evidence_cmd');
+  assert.deepEqual(call.args, { evidenceId: 'e1', replyClass: 'interview_invite', sendMode: 'unknown' });
+  assert.match(h.el('inbox-status').textContent, /面试邀请/);
+  assert.match(h.el('inbox-status').textContent, /未知/);
+  assert.doesNotMatch(h.el('inbox-status').textContent, /人工/);
+});
+
+test('pasted text is imported as text and the box is cleared', async () => {
+  const h = harness((name) => (name === 'import_evidence_cmd'
+    ? { imported: [{ ...MAIL, kind: 'paste' }], duplicates: [], failed: [] }
+    : undefined));
+  h.el('inbox-paste').value = '他们说下周二面试。';
+  await h.el('inbox-paste-save').emit('click');
+  await h.tick();
+  const call = h.calls.find((entry) => entry.name === 'import_evidence_cmd');
+  assert.deepEqual(call.args.args, { text: '他们说下周二面试。' });
+  assert.equal(h.el('inbox-paste').value, '');
+});
+
+test('a preview that answers late cannot replace the one selected after it', async () => {
+  let releaseFirst;
+  const h = harness((name, args) => {
+    if (name === 'list_inbox_cmd') return [MAIL, { ...MAIL, id: 'e9', subject: '第二封' }];
+    if (name === 'get_evidence_preview_cmd' && args.evidenceId === 'e1') {
+      return new Promise((resolve) => {
+        releaseFirst = () => resolve({ ...MAIL, bodyExtract: '第一封的正文', imageDataUrl: null, note: null });
+      });
+    }
+    if (name === 'get_evidence_preview_cmd' && args.evidenceId === 'e9') {
+      return { ...MAIL, id: 'e9', subject: '第二封', bodyExtract: '第二封的正文', imageDataUrl: null, note: null };
+    }
+    return undefined;
+  });
+  await h.api.refresh();
+  h.buttons.get('data-evidence:e1').emit('click');
+  await h.tick();
+  h.buttons.get('data-evidence:e9').emit('click');
+  await h.tick();
+  releaseFirst();
+  await h.tick();
+  assert.match(h.el('inbox-preview').innerHTML, /第二封的正文/);
+  assert.doesNotMatch(h.el('inbox-preview').innerHTML, /第一封的正文/);
+});

--- a/desktop/src/inbox.js
+++ b/desktop/src/inbox.js
@@ -1,0 +1,138 @@
+// D09 收件箱的文案与纯函数。界面只负责拼 DOM，说什么由这里决定（沿用 D07/D08 的
+// 「文案只在一处说」）。这里的每一句都要经得起 §11 的检查：导入不等于对方回复了什么，
+// 关联后未分类不叫「尚未导入」。
+
+export const KIND_LABEL = {
+  eml: "邮件",
+  screenshot: "截图",
+  pdf: "PDF",
+  paste: "粘贴文本",
+  unknown: "文本",
+};
+
+/** 通知业务类型（§6.3）。与发送方式各选各的，互不推断。 */
+export const REPLY_CLASS_OPTIONS = [
+  { value: "", label: "未分类" },
+  { value: "auto_ack", label: "自动回执" },
+  { value: "assessment_invite", label: "测评邀请" },
+  { value: "interview_invite", label: "面试邀请" },
+  { value: "action_required", label: "需要我处理" },
+  { value: "offer", label: "Offer" },
+  { value: "reject", label: "未通过" },
+  { value: "other", label: "其他" },
+  { value: "unknown", label: "看不出来" },
+];
+
+/** 发送方式。判断不了就是「未知」，不因为类型是面试邀请就写成人工（走查 10.13）。 */
+export const SEND_MODE_OPTIONS = [
+  { value: "unknown", label: "未知" },
+  { value: "human", label: "人工发送" },
+  { value: "automated", label: "系统自动发送" },
+];
+
+const IMPORT_ERRORS = {
+  unsupported: "不支持这种文件。Outlook 的 .msg 请在邮件客户端里另存为 .eml，或者直接粘贴正文。",
+  too_large: "超过 25 MiB，没有导入。",
+  source_unreadable: "读不到这个文件，可能已经被移走或没有权限。",
+  storage: "写入档案目录失败，什么都没有留下。",
+  too_many_files: "一次最多导入 20 个文件，这个没有排上。",
+};
+
+export function kindLabel(kind) {
+  return KIND_LABEL[kind] || "文件";
+}
+
+export function replyClassLabel(value) {
+  return REPLY_CLASS_OPTIONS.find((option) => option.value === (value || ""))?.label || "未分类";
+}
+
+export function sendModeLabel(value) {
+  return SEND_MODE_OPTIONS.find((option) => option.value === (value || "unknown"))?.label || "未知";
+}
+
+/** 列表里这条叫什么：主题 → 原始文件名 → 类型兜底。 */
+export function evidenceTitle(item) {
+  const subject = (item?.subject || "").trim();
+  if (subject) return subject;
+  const filename = (item?.originalFilename || "").trim();
+  if (filename) return filename;
+  return kindLabel(item?.kind);
+}
+
+export function importErrorText(code) {
+  return IMPORT_ERRORS[code] || "这个文件没能导入。";
+}
+
+/**
+ * 一次导入之后说什么。成功、重复、失败分开讲：重复不是错误，用户可能真的想把同一封信
+ * 关到另一条申请上。
+ */
+export function describeImport(report) {
+  const imported = report?.imported?.length ?? 0;
+  const duplicates = report?.duplicates?.length ?? 0;
+  const failed = report?.failed ?? [];
+  if (!imported && !duplicates && !failed.length) {
+    return { tone: "info", text: "没有选择任何文件。" };
+  }
+
+  const parts = [];
+  if (imported) parts.push(`已导入 ${imported} 条，待分类`);
+  if (duplicates) parts.push(`${duplicates} 条内容和已有的完全相同，没有重复保存；需要的话可以把它关联到另一条申请`);
+  for (const item of failed) parts.push(`${item.name}：${importErrorText(item.code)}`);
+
+  const tone = failed.length ? "warn" : imported ? "success" : "info";
+  return { tone, text: parts.join("；") + "。" };
+}
+
+/** 这条证据和别的证据字节相同时的提示。 */
+export function duplicateNote(item) {
+  const count = item?.sameBytesAs?.length ?? 0;
+  if (!count) return "";
+  return `内容和另外 ${count} 条完全相同（同一份字节只存了一次）。`;
+}
+
+/** 预览面板顶部那行元数据。 */
+export function describeEvidenceMeta(item) {
+  const parts = [kindLabel(item?.kind)];
+  if (item?.fromAddr) parts.push(`来自 ${item.fromAddr}`);
+  if (item?.sentAt) parts.push(`发送于 ${item.sentAt}`);
+  parts.push(`导入于 ${item?.importedAt ?? "未知时间"}`);
+  if (Number.isInteger(item?.sizeBytes)) parts.push(sizeLabel(item.sizeBytes));
+  return parts.join(" · ");
+}
+
+export function sizeLabel(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+/** 关联结果的说法。关联本身不代表这封信说了什么。 */
+export function describeAssociation(result, company) {
+  if (!result) return { tone: "warn", text: "没能关联，请再试一次。" };
+  const where = company ? `「${company}」` : "所选申请";
+  return {
+    tone: "success",
+    text: `已关联到${where}，状态是「已导入，待分类」。分类由你确认，导入本身不改变申请阶段。`,
+  };
+}
+
+export function describeUnassociation() {
+  return { tone: "info", text: "已从那条申请里取出，回到收件箱。那条申请回到「尚未导入回复证据」。" };
+}
+
+export function describeClassification(item) {
+  return {
+    tone: "success",
+    text: `已记为「${replyClassLabel(item?.replyClass)}」，发送方式「${sendModeLabel(item?.sendMode)}」。这只是给这封信分类，不改变申请阶段。`,
+  };
+}
+
+/** 空收件箱：说清楚这里为什么空，不暗示对方没回复。 */
+export const EMPTY_INBOX =
+  "收件箱里没有待处理的证据。把回复邮件（.eml）、截图或 PDF 拖进窗口，或者粘贴一段文本，就能存进档案。";
+
+/** 候选申请列表的提示：同公司多个岗位不合并，必须自己选（§7、走查 10.1）。 */
+export const CHOOSE_APPLICATION_HINT =
+  "同一家公司可能有多条申请，这里不会替你猜——请选中具体那一条。";

--- a/desktop/src/inbox.test.js
+++ b/desktop/src/inbox.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CHOOSE_APPLICATION_HINT,
+  EMPTY_INBOX,
+  describeAssociation,
+  describeClassification,
+  describeEvidenceMeta,
+  describeImport,
+  describeUnassociation,
+  duplicateNote,
+  evidenceTitle,
+  importErrorText,
+  replyClassLabel,
+  sendModeLabel,
+  sizeLabel,
+} from './inbox.js';
+
+test('an import is reported per outcome, and a duplicate is not an error', () => {
+  const ok = describeImport({ imported: [{ id: 'a' }], duplicates: [], failed: [] });
+  assert.equal(ok.tone, 'success');
+  assert.match(ok.text, /已导入 1 条，待分类/);
+
+  const mixed = describeImport({
+    imported: [{ id: 'a' }],
+    duplicates: [{ id: 'b' }],
+    failed: [{ name: 'invite.msg', code: 'unsupported' }],
+  });
+  assert.equal(mixed.tone, 'warn');
+  assert.match(mixed.text, /invite\.msg/);
+  assert.match(mixed.text, /另存为 \.eml/);
+  assert.match(mixed.text, /没有重复保存/);
+
+  assert.equal(describeImport({ imported: [], duplicates: [], failed: [] }).tone, 'info');
+});
+
+test('every import failure has a sentence, including the ones we did not enumerate', () => {
+  assert.match(importErrorText('too_large'), /25 MiB/);
+  assert.match(importErrorText('source_unreadable'), /读不到/);
+  assert.match(importErrorText('storage'), /什么都没有留下/);
+  assert.match(importErrorText('too_many_files'), /20 个/);
+  assert.match(importErrorText('something-new'), /没能导入/);
+});
+
+test('classification words never claim a human sent it', () => {
+  assert.equal(replyClassLabel('interview_invite'), '面试邀请');
+  assert.equal(sendModeLabel(undefined), '未知');
+  assert.equal(sendModeLabel('automated'), '系统自动发送');
+  const said = describeClassification({ replyClass: 'interview_invite', sendMode: 'automated' }).text;
+  assert.match(said, /面试邀请/);
+  assert.match(said, /系统自动发送/);
+  assert.doesNotMatch(said, /人工/);
+  assert.match(said, /不改变申请阶段/);
+});
+
+test('associating says what it did and what it did not do', () => {
+  const said = describeAssociation({ id: 'e1' }, '星河科技').text;
+  assert.match(said, /星河科技/);
+  assert.match(said, /已导入，待分类/);
+  assert.doesNotMatch(said, /投递|回复了/);
+  assert.match(describeUnassociation().text, /尚未导入回复证据/);
+});
+
+test('a title falls back from subject to filename to kind', () => {
+  assert.equal(evidenceTitle({ subject: '面试邀请', originalFilename: 'x.eml' }), '面试邀请');
+  assert.equal(evidenceTitle({ subject: '   ', originalFilename: 'x.eml' }), 'x.eml');
+  assert.equal(evidenceTitle({ kind: 'paste' }), '粘贴文本');
+});
+
+test('the meta line carries the sender and both times, and sizes read as sizes', () => {
+  const meta = describeEvidenceMeta({
+    kind: 'eml',
+    fromAddr: 'hr@example.test',
+    sentAt: '2026-09-12T08:00:00.000Z',
+    importedAt: '2026-09-12T09:00:00.000Z',
+    sizeBytes: 2048,
+  });
+  assert.match(meta, /邮件/);
+  assert.match(meta, /hr@example\.test/);
+  assert.match(meta, /发送于 2026-09-12T08:00:00\.000Z/);
+  assert.match(meta, /导入于 2026-09-12T09:00:00\.000Z/);
+  assert.match(meta, /2\.0 KiB/);
+  assert.equal(sizeLabel(999), '999 B');
+  assert.equal(sizeLabel(5 * 1024 * 1024), '5.0 MiB');
+});
+
+test('the duplicate hint counts the others and explains the single copy', () => {
+  assert.equal(duplicateNote({ sameBytesAs: [] }), '');
+  assert.match(duplicateNote({ sameBytesAs: ['a', 'b'] }), /另外 2 条/);
+  assert.match(duplicateNote({ sameBytesAs: ['a'] }), /只存了一次/);
+});
+
+test('the empty inbox and the application hint say the honest thing', () => {
+  assert.match(EMPTY_INBOX, /没有待处理/);
+  assert.doesNotMatch(EMPTY_INBOX, /没有回复|未回复/);
+  assert.match(CHOOSE_APPLICATION_HINT, /不会替你猜/);
+});

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -1,5 +1,6 @@
 import { createPairingController } from "./pairing-form.js";
 import { mountApplications } from "./applications-ui.js";
+import { mountInbox } from "./inbox-ui.js";
 
 const invoke = window.__TAURI__?.core?.invoke;
 const pairing = createPairingController();
@@ -146,6 +147,28 @@ document.getElementById("btn-diag").addEventListener("click", async () => {
 
 const applications = mountApplications(invoke);
 
+// 文件选择与拖放是宿主能力：这里注入真实实现，测试里注入假的。拖放事件带来的是用户
+// 自己刚拖进来的路径，只在这一次导入里用；档案里的存储路径永远不下发到界面。
+const dialog = window.__TAURI__?.dialog;
+const events = window.__TAURI__?.event;
+const inbox = mountInbox(invoke, {
+  pickFiles: dialog?.open
+    ? async () => {
+        const chosen = await dialog.open({
+          multiple: true,
+          filters: [{ name: "回复证据", extensions: ["eml", "txt", "png", "jpg", "jpeg", "pdf"] }],
+        });
+        if (!chosen) return [];
+        return Array.isArray(chosen) ? chosen : [chosen];
+      }
+    : null,
+  listenDrop: events?.listen
+    ? (handle) => {
+        events.listen("tauri://drag-drop", (event) => handle(event?.payload?.paths ?? []));
+      }
+    : null,
+});
+
 showRoute("applications");
 refreshStatus().catch((err) => {
   document.getElementById("runtime-pill").textContent = String(err);
@@ -153,6 +176,7 @@ refreshStatus().catch((err) => {
 applications.refreshList().catch((err) => {
   document.getElementById("apps-msg").textContent = String(err);
 });
+inbox.refresh().catch(() => {});
 setInterval(() => {
   refreshStatus().catch(() => {});
 }, 4000);

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -190,3 +190,61 @@ dialog { border: 1px solid var(--line); border-radius: 12px; padding: 20px; max-
   max-height: 80vh;
   overflow: auto;
 }
+
+.inbox-split {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.inbox-paste {
+  margin: 8px 0;
+}
+
+.inbox-paste textarea {
+  display: block;
+  width: 100%;
+  margin: 6px 0;
+}
+
+ul.inbox-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+ul.inbox-list li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+ul.inbox-list li.active button {
+  font-weight: 600;
+}
+
+ul.inbox-list button {
+  flex: 1;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.evidence-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 40vh;
+  overflow: auto;
+  background: var(--surface, #f6f6f6);
+  padding: 8px;
+}
+
+.evidence-image {
+  max-width: 100%;
+  max-height: 40vh;
+}


### PR DESCRIPTION
D09 PR 4/6，压在 #69 上。Ref #66。

## 只做了什么

`#view-inbox` 从空视图变成能用的界面：`desktop/src/inbox.js`（纯函数与全部文案）、`desktop/src/inbox-ui.js`（视图）、`index.html`、`styles.css`、`main.js` 挂载。

- **三种入口**：把文件拖进窗口（Tauri 的拖放事件给路径）、「选择文件…」（原生对话框）、粘贴文本。字节不过 IPC，只有路径。
- **预览**是命令层已经做安全的东西：转义后的文本、`data:` 图片，或者一句说明。PDF 不内嵌，给「用系统程序打开本机副本」，并说明那会离开应用。
- **关联**：同一家公司的多条申请都列出来、**都不预选**，必须自己点（§7、走查 10.1）；没选就点关联只会得到提醒，不发命令。
- **分类**：两个独立下拉。选「面试邀请」不会把发送方式变成「人工」（§6.3、走查 10.13）。
- **说法**：导入成功说「已导入 N 条，待分类」；重复说「内容完全相同，没有重复保存；需要的话可以关联到另一条申请」；空收件箱说「没有待处理的证据」，绝不说「对方没回复」。

## 测试

`node --test src/*.test.js`：40 个（新增 16 个）。覆盖拖入两个文件（一个 `.msg` 失败）后的报告、正文转义（`<img src=x onerror=…>` 只作为字面文本出现、页面里没有 `src="http`）、截图的 `data:` URL、PDF 的系统程序按钮、同公司两条申请都不预选、分类两个字段各自独立、粘贴导入后清空输入框、晚到的预览不覆盖后选中的那条。

CI 的前端作业加上了这两个测试文件。

> 与拆分计划的一点出入：收件箱只列**未关联**的证据，已关联的在申请详情里看（PR 5）。这样不用为「已关联」再加一条命令，语义也更清楚。

🤖 Generated with [Claude Code](https://claude.com/claude-code)