### PR TITLE
feat(d09): an application's detail shows its evidence and says what the state means (#66, PR 5/6)

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -108,6 +108,15 @@
               </div>
             </form>
           </dialog>
+          <dialog id="evidence-dialog">
+            <div class="stack">
+              <h3>回复证据</h3>
+              <div id="evidence-body"></div>
+              <div class="row">
+                <button type="button" id="evidence-close">关闭</button>
+              </div>
+            </div>
+          </dialog>
           <dialog id="snapshot-dialog">
             <div class="stack">
               <h3>简历快照</h3>

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -188,6 +188,8 @@ pub struct ApplicationView {
     /// The state of each snapshot a fill event names, so the timeline can say "uploading" or
     /// "not available" instead of offering a snapshot that is not there.
     pub snapshot_states: BTreeMap<String, SnapshotState>,
+    /// 当前关联到这条申请的回复证据（D09）。和别处一样，不含任何存储路径。
+    pub evidence: Vec<crate::evidence_commands::EvidenceSummary>,
 }
 
 /// What the WebView may know about a snapshot: never its path in the archive.
@@ -227,11 +229,13 @@ pub fn get_application(store: &ArchiveStore, id: &str) -> Result<ApplicationView
         }
     }
     let snapshots = store.list_snapshots(id)?.into_iter().map(SnapshotSummary::from).collect();
+    let evidence = crate::evidence_commands::list_for_application(store, id)?;
     Ok(ApplicationView {
         application,
         events,
         snapshots,
         snapshot_states,
+        evidence,
     })
 }
 

--- a/desktop/src-tauri/src/commands_regression.rs
+++ b/desktop/src-tauri/src/commands_regression.rs
@@ -578,4 +578,20 @@ mod evidence {
         assert!(preview.note.unwrap().contains("不在了"));
         assert!(evidence_commands::stored_path(&store, &id).is_err());
     }
+    #[test]
+    fn an_applications_detail_carries_its_evidence_without_any_path() {
+        let (dir, store, app) = archive();
+        let path = write(dir.path(), "面试邀请.eml", &eml("面试邀请"));
+        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        evidence_commands::associate(&store, &id, &app).unwrap();
+        evidence_commands::classify(&store, &id, "interview_invite", "automated").unwrap();
+
+        let view = get_application(&store, &app).unwrap();
+        assert_eq!(view.evidence.len(), 1);
+        assert_eq!(view.evidence[0].subject.as_deref(), Some("面试邀请"));
+        assert_eq!(view.evidence[0].reply_class.as_deref(), Some("interview_invite"));
+        let json = serde_json::to_string(&view).unwrap();
+        assert!(!json.contains("attachments/"), "{json}");
+        assert!(!json.contains(&store.archive_dir().to_string_lossy().to_string()));
+    }
 }

--- a/desktop/src/applications-ui.js
+++ b/desktop/src/applications-ui.js
@@ -1,6 +1,8 @@
 import {
   createApplicationsController,
   evidenceLabel,
+  evidenceLine,
+  evidenceNote,
   eventLabel,
   fillSummary,
   stageLabel,
@@ -179,6 +181,7 @@ export function mountApplications(invoke) {
       const events = view.events || [];
       const snapshotStates = view.snapshotStates || {};
       const snapshots = view.snapshots || [];
+      const evidence = view.evidence || [];
       detail.innerHTML = `
         <div class="detail-head">
           <h2 title="${escapeHtml(app.company)} · ${escapeHtml(app.title)}">${escapeHtml(app.company)} · ${escapeHtml(app.title)}</h2>
@@ -203,7 +206,19 @@ export function mountApplications(invoke) {
           <button type="button" data-act="note">新增备注</button>
           <button type="button" data-act="recycle">${(app.recycleState || app.recycle_state) === "recycled" ? "恢复" : "回收"}</button>
         </div>
-        <p class="muted">附件和待办尚未接入，这里不展示假数据。填写事件不等于投递成功。</p>
+        <p class="muted">待办尚未接入，这里不展示假数据。填写事件不等于投递成功。</p>
+        <h3>回复证据（${evidence.length}）</h3>
+        ${evidenceNote(app.replyEvidenceState || app.reply_evidence_state)
+          ? `<p class="muted">${escapeHtml(evidenceNote(app.replyEvidenceState || app.reply_evidence_state))}</p>`
+          : ""}
+        ${evidence.length ? `
+        <ul class="snapshot-list">
+          ${evidence.map((item) => `<li>
+            <span>${escapeHtml(item.subject || item.originalFilename || "导入的证据")} — ${escapeHtml(evidenceLine(item))}</span>
+            <button type="button" data-act="evidence" data-evidence="${escapeHtml(item.id)}">查看</button>
+            <button type="button" data-act="unassociate" data-evidence="${escapeHtml(item.id)}">取消关联</button>
+          </li>`).join("")}
+        </ul>` : `<p class="muted">收件箱里导入的证据关联到这条申请之后会出现在这里。</p>`}
         ${snapshots.length ? `
         <h3>简历快照（${snapshots.length}）</h3>
         <ul class="snapshot-list">
@@ -238,9 +253,12 @@ export function mountApplications(invoke) {
         </ol>
       `;
       detail.querySelectorAll("button[data-act]").forEach((btn) => {
-        btn.addEventListener("click", () =>
-          btn.dataset.act === "snapshot" ? openSnapshot(btn.dataset.snapshot) : handleAction(btn.dataset.act, view),
-        );
+        btn.addEventListener("click", () => {
+          if (btn.dataset.act === "snapshot") return openSnapshot(btn.dataset.snapshot);
+          if (btn.dataset.act === "evidence") return openEvidence(btn.dataset.evidence);
+          if (btn.dataset.act === "unassociate") return unassociateEvidence(btn.dataset.evidence, id);
+          return handleAction(btn.dataset.act, view);
+        });
       });
     } catch (err) {
       if (token !== detailToken || ctl.selectedId !== id) return;
@@ -283,6 +301,44 @@ export function mountApplications(invoke) {
   document.getElementById("snapshot-close")?.addEventListener("click", () => {
     document.getElementById("snapshot-dialog").close();
   });
+
+  // 只读预览，和收件箱看到的是同一份已经清洗过的数据（正文转义、图片 data: URL、
+  // PDF 不内嵌）。这里不做分类，分类在收件箱里做。
+  let evidenceToken = 0;
+  async function openEvidence(evidenceId) {
+    const token = ++evidenceToken;
+    const dialogEl = document.getElementById("evidence-dialog");
+    const body = document.getElementById("evidence-body");
+    body.innerHTML = '<p class="muted">加载中…</p>';
+    if (!dialogEl.open) dialogEl.showModal();
+    try {
+      const item = await invoke("get_evidence_preview_cmd", { evidenceId });
+      if (token !== evidenceToken) return;
+      body.innerHTML = `
+        <p class="muted">${escapeHtml(evidenceLine(item))}</p>
+        ${item.note ? `<p class="banner">${escapeHtml(item.note)}</p>` : ""}
+        ${item.imageDataUrl ? `<img class="evidence-image" alt="导入的截图" src="${escapeHtml(item.imageDataUrl)}">` : ""}
+        ${item.bodyExtract ? `<pre class="evidence-body">${escapeHtml(item.bodyExtract)}</pre>` : ""}
+      `;
+    } catch (err) {
+      if (token !== evidenceToken) return;
+      body.innerHTML = `<p class="banner">${escapeHtml(`读不出这条证据（${invokeError(err)}）。`)}</p>`;
+    }
+  }
+
+  document.getElementById("evidence-close")?.addEventListener("click", () => {
+    document.getElementById("evidence-dialog").close();
+  });
+
+  async function unassociateEvidence(evidenceId, applicationId) {
+    try {
+      await invoke("unassociate_evidence_cmd", { evidenceId });
+      msg.textContent = "已取出到收件箱。这条申请的证据状态按剩下的证据重算。";
+      if (ctl.selectedId === applicationId) await loadDetail(applicationId);
+    } catch (err) {
+      msg.textContent = invokeError(err);
+    }
+  }
 
   async function handleAction(act, view) {
     const app = view.application.summary || view.application;

--- a/desktop/src/applications-ui.test.js
+++ b/desktop/src/applications-ui.test.js
@@ -11,7 +11,7 @@ function harness(handler) {
     emit(type,event={}){return this.listeners[type]?.({preventDefault(){},...event});}
     showModal(){this.open=true;} close(){this.open=false;} focus(){}
     querySelectorAll(selector){
-      if(selector==='button[data-act]')return [...this.innerHTML.matchAll(/data-act="([^"]+)"(?:\s+data-snapshot="([^"]+)")?/g)].map(m=>{const n=new Node(m[1]);n.dataset={act:m[1],...(m[2]?{snapshot:m[2]}:{})};actions.set(m[1],n);actionList.push(n);return n;});
+      if(selector==='button[data-act]')return [...this.innerHTML.matchAll(/data-act="([^"]+)"(?:\s+data-(snapshot|evidence)="([^"]+)")?/g)].map(m=>{const n=new Node(m[1]);n.dataset={act:m[1],...(m[2]?{[m[2]]:m[3]}:{})};actions.set(m[1],n);actionList.push(n);return n;});
       if(selector==='tr')return [];
       const ids=this.id==='app-form'?['f-company','f-title','f-url','f-location','f-notes','btn-save-app','btn-cancel-app']:['progress-description','progress-date','progress-round','progress-update','progress-save','progress-cancel'];
       return ids.map(el);
@@ -164,3 +164,50 @@ function snapshotDoc(value) {
   return { templateName: '合成模板', capturedAt: '2026-09-12T08:00:00.000Z', omittedFieldCount: 0,
     groups: [{ name: '经历', fields: [{ key: '描述', value }] }] };
 }
+
+test('the detail lists its evidence, opens it read-only and can take it back out', async () => {
+  const E = 'ev-1';
+  const h = harness((name, args) => {
+    if (name === 'get_application_cmd') {
+      return {
+        ...h.view(args.id),
+        events: [],
+        snapshots: [],
+        snapshotStates: {},
+        evidence: [{ id: E, kind: 'eml', subject: '面试邀请', fromAddr: 'hr@example.test', replyClass: null, sendMode: null }],
+      };
+    }
+    if (name === 'get_evidence_preview_cmd') {
+      return { id: E, kind: 'eml', replyClass: null, sendMode: null, bodyExtract: '<script>alert(1)</script> 正文', imageDataUrl: null, note: null };
+    }
+    return undefined;
+  });
+  await h.select('A');
+  const html = h.el('app-detail').innerHTML;
+  assert.match(html, /回复证据（1）/);
+  assert.match(html, /面试邀请/);
+  assert.match(html, /待分类/);
+  assert.doesNotMatch(html, /附件和待办尚未接入/);
+
+  await h.actions.get('evidence').emit('click');
+  await h.tick();
+  assert.equal(h.el('evidence-dialog').open, true);
+  const body = h.el('evidence-body').innerHTML;
+  assert.match(body, /&lt;script&gt;/);
+  assert.doesNotMatch(body, /<script/);
+
+  await h.actions.get('unassociate').emit('click');
+  await h.tick();
+  const call = h.calls.find((entry) => entry.name === 'unassociate_evidence_cmd');
+  assert.deepEqual(call.args, { evidenceId: E });
+});
+
+test('an application with no evidence says so without claiming silence from the other side', async () => {
+  const h = harness((name, args) => (name === 'get_application_cmd'
+    ? { ...h.view(args.id), events: [], snapshots: [], snapshotStates: {}, evidence: [] }
+    : undefined));
+  await h.select('A');
+  const html = h.el('app-detail').innerHTML;
+  assert.match(html, /回复证据（0）/);
+  assert.match(html, /不代表对方没有回复/);
+});

--- a/desktop/src/applications.js
+++ b/desktop/src/applications.js
@@ -108,6 +108,56 @@ export function evidenceLabel(state) {
   return state || "尚未导入回复证据";
 }
 
+/**
+ * 「尚未导入回复证据」旁边永远跟着这句：没有证据只说明没人导入过东西，不说明对方
+ * 没有回复（§6.3 与 §11 的措辞约束）。
+ */
+export function evidenceNote(state) {
+  if (state === "none_imported" || !state) {
+    return "这只表示还没有导入任何回复证据，不代表对方没有回复。";
+  }
+  if (state === "imported_unclassified") {
+    return "已经导入了证据，还没有确认它属于哪一类。";
+  }
+  return "";
+}
+
+/** 详情里一条证据的摘要行：类型、来源、分类与发送方式，各说各的。 */
+export function evidenceLine(item) {
+  const parts = [];
+  parts.push(EVIDENCE_KIND[item?.kind] || "文件");
+  if (item?.fromAddr) parts.push(item.fromAddr);
+  if (item?.sentAt) parts.push(item.sentAt);
+  parts.push(item?.replyClass ? EVIDENCE_CLASS[item.replyClass] || item.replyClass : "待分类");
+  parts.push(`发送方式：${EVIDENCE_SEND_MODE[item?.sendMode || "unknown"]}`);
+  return parts.join(" · ");
+}
+
+const EVIDENCE_KIND = {
+  eml: "邮件",
+  screenshot: "截图",
+  pdf: "PDF",
+  paste: "粘贴文本",
+  unknown: "文本",
+};
+
+const EVIDENCE_CLASS = {
+  auto_ack: "自动回执",
+  assessment_invite: "测评邀请",
+  interview_invite: "面试邀请",
+  action_required: "需要处理",
+  offer: "Offer",
+  reject: "未通过",
+  other: "其他",
+  unknown: "看不出来",
+};
+
+const EVIDENCE_SEND_MODE = {
+  human: "人工发送",
+  automated: "系统自动发送",
+  unknown: "未知",
+};
+
 export function createApplicationsController() {
   let listToken = 0;
   let selectedId = null;

--- a/desktop/src/applications.test.js
+++ b/desktop/src/applications.test.js
@@ -83,3 +83,21 @@ test('a fill line does not invent a count the plugin did not send', async () => 
   assert.doesNotMatch(text, /0\/12/);
   assert.match(text, /共 12 项/);
 });
+
+test('an application with no evidence never implies nobody replied', async () => {
+  const { evidenceLabel, evidenceNote } = await import('./applications.js');
+  assert.equal(evidenceLabel('none_imported'), '尚未导入回复证据');
+  assert.match(evidenceNote('none_imported'), /不代表对方没有回复/);
+  assert.match(evidenceNote('imported_unclassified'), /还没有确认/);
+  assert.equal(evidenceNote('classified'), '');
+});
+
+test('an evidence line keeps class and send mode apart', async () => {
+  const { evidenceLine } = await import('./applications.js');
+  const line = evidenceLine({ kind: 'eml', fromAddr: 'hr@example.test', sentAt: '2026-09-12T08:00:00.000Z', replyClass: 'interview_invite', sendMode: 'automated' });
+  assert.match(line, /邮件/);
+  assert.match(line, /面试邀请/);
+  assert.match(line, /发送方式：系统自动发送/);
+  assert.doesNotMatch(line, /人工/);
+  assert.match(evidenceLine({ kind: 'paste' }), /待分类 · 发送方式：未知/);
+});


### PR DESCRIPTION
D09 PR 5/6，压在 #70 上。Ref #66。

## 只做了什么

- `ApplicationView` 增加 `evidence`：当前关联到这条申请的证据（和别处一样，**不含任何存储路径**）。
- 申请详情列出这些证据：类型、发件人、发送时间、**分类**与**发送方式**分开写；每条可以只读打开（对话框里是收件箱那份已经清洗过的预览：正文转义、图片 `data:`、PDF 不内嵌），也可以「取消关联」放回收件箱，之后这条申请的状态按剩下的证据重算。
- 状态文案补上要紧的那句：**没有证据只说明没人导入过，不代表对方没有回复**；「已导入，待分类」也自己解释一句。
- 顺手去掉过时的「附件和待办尚未接入」——附件已经接入了，只剩待办（D10）。

## 测试

`node --test src/*.test.js`：44 个（新增 4 个）。`cargo test --manifest-path src-tauri/Cargo.toml`：74 个（新增 1 个：详情带证据且 JSON 里没有路径）。

覆盖：详情列出证据并显示「待分类」、只读对话框里 `<script>` 只作为字面文本、取消关联发出正确命令、空证据时显示「不代表对方没有回复」、分类与发送方式不互相推断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)