### PR TITLE
chore(desktop): pin the wire keys and drop the snake/camel guessing

### DIFF
--- a/desktop/src-tauri/src/commands_regression.rs
+++ b/desktop/src-tauri/src/commands_regression.rs
@@ -130,35 +130,52 @@ mod snapshots {
     }
 
     fn fill(store: &ArchiveStore, message_id: &str, app: &str, snapshot: &str) {
-        submit(store, message_id, PluginOp::FillSubmit(FillSubmitInput {
-            application_id: app.into(),
-            outcome: FillOutcome::Partial,
-            field_count: Some(12),
-            filled_count: Some(9),
-            unconfirmed_count: Some(3),
-            durations_ms: None,
-            url_redacted: None,
-            template_name: Some("合成模板".into()),
-            template_version: Some("0123456789ab".into()),
-            snapshot_id: Some(snapshot.into()),
-            plugin_version: Some("0.4.0".into()),
-            occurred: Occurred::Unknown,
-        }));
+        submit(
+            store,
+            message_id,
+            PluginOp::FillSubmit(FillSubmitInput {
+                application_id: app.into(),
+                outcome: FillOutcome::Partial,
+                field_count: Some(12),
+                filled_count: Some(9),
+                unconfirmed_count: Some(3),
+                durations_ms: None,
+                url_redacted: None,
+                template_name: Some("合成模板".into()),
+                template_version: Some("0123456789ab".into()),
+                snapshot_id: Some(snapshot.into()),
+                plugin_version: Some("0.4.0".into()),
+                occurred: Occurred::Unknown,
+            }),
+        );
     }
 
-    fn chunk(store: &ArchiveStore, message_id: &str, app: &str, snapshot: &str, bytes: &[u8], index: i64, count: i64, piece: Vec<u8>) {
-        submit(store, message_id, PluginOp::SnapshotChunk(SnapshotChunkInput {
-            application_id: Some(app.into()),
-            snapshot_id: snapshot.into(),
-            chunk_index: index,
-            chunk_count: count,
-            total_sha256: sha(bytes),
-            byte_size: bytes.len() as i64,
-            chunk_sha256: sha(&piece),
-            template_name: None,
-            template_version: None,
-            bytes: piece,
-        }));
+    fn chunk(
+        store: &ArchiveStore,
+        message_id: &str,
+        app: &str,
+        snapshot: &str,
+        bytes: &[u8],
+        index: i64,
+        count: i64,
+        piece: Vec<u8>,
+    ) {
+        submit(
+            store,
+            message_id,
+            PluginOp::SnapshotChunk(SnapshotChunkInput {
+                application_id: Some(app.into()),
+                snapshot_id: snapshot.into(),
+                chunk_index: index,
+                chunk_count: count,
+                total_sha256: sha(bytes),
+                byte_size: bytes.len() as i64,
+                chunk_sha256: sha(&piece),
+                template_name: None,
+                template_version: None,
+                bytes: piece,
+            }),
+        );
     }
 
     fn document() -> Vec<u8> {
@@ -177,7 +194,11 @@ mod snapshots {
 
     fn archive() -> (tempfile::TempDir, ArchiveStore, String) {
         let dir = tempfile::tempdir().unwrap();
-        let store = open_store(&dir.path().join("archive"), &dir.path().join("current.json")).unwrap();
+        let store = open_store(
+            &dir.path().join("archive"),
+            &dir.path().join("current.json"),
+        )
+        .unwrap();
         let app = create_application(
             &store,
             serde_json::from_value(json!({ "company": "Synthetic", "title": "Job" })).unwrap(),
@@ -189,12 +210,40 @@ mod snapshots {
         .clone();
         let bytes = document();
         fill(&store, "aaaaaaaa-0000-4000-8000-000000000001", &app, STORED);
-        chunk(&store, "aaaaaaaa-0000-4000-8000-000000000002", &app, STORED, &bytes, 0, 1, bytes.clone());
+        chunk(
+            &store,
+            "aaaaaaaa-0000-4000-8000-000000000002",
+            &app,
+            STORED,
+            &bytes,
+            0,
+            1,
+            bytes.clone(),
+        );
         store.complete_snapshot_upload(CLIENT, STORED).unwrap();
-        fill(&store, "aaaaaaaa-0000-4000-8000-000000000003", &app, UPLOADING);
+        fill(
+            &store,
+            "aaaaaaaa-0000-4000-8000-000000000003",
+            &app,
+            UPLOADING,
+        );
         let half = bytes[..bytes.len() / 2].to_vec();
-        chunk(&store, "aaaaaaaa-0000-4000-8000-000000000004", &app, UPLOADING, &bytes, 0, 2, half);
-        fill(&store, "aaaaaaaa-0000-4000-8000-000000000005", &app, MISSING);
+        chunk(
+            &store,
+            "aaaaaaaa-0000-4000-8000-000000000004",
+            &app,
+            UPLOADING,
+            &bytes,
+            0,
+            2,
+            half,
+        );
+        fill(
+            &store,
+            "aaaaaaaa-0000-4000-8000-000000000005",
+            &app,
+            MISSING,
+        );
         (dir, store, app)
     }
 
@@ -213,8 +262,22 @@ mod snapshots {
 
     /// Store `bytes` as a complete snapshot `id` under the application.
     fn stored(store: &ArchiveStore, app: &str, id: &str, prefix: &str, bytes: Vec<u8>) {
-        fill(store, &format!("{prefix}-0000-4000-8000-000000000001"), app, id);
-        chunk(store, &format!("{prefix}-0000-4000-8000-000000000002"), app, id, &bytes, 0, 1, bytes.clone());
+        fill(
+            store,
+            &format!("{prefix}-0000-4000-8000-000000000001"),
+            app,
+            id,
+        );
+        chunk(
+            store,
+            &format!("{prefix}-0000-4000-8000-000000000002"),
+            app,
+            id,
+            &bytes,
+            0,
+            1,
+            bytes.clone(),
+        );
         store.complete_snapshot_upload(CLIENT, id).unwrap();
     }
 
@@ -249,10 +312,18 @@ mod snapshots {
 
         let view = serde_json::to_value(get_snapshot(&store, LEAKY).unwrap()).unwrap();
         let text = view.to_string();
-        for secret in ["hunter2-synthetic", "tok-synthetic", "sk-synthetic", "abcdefghijklmnopqrstuvwxyz"] {
+        for secret in [
+            "hunter2-synthetic",
+            "tok-synthetic",
+            "sk-synthetic",
+            "abcdefghijklmnopqrstuvwxyz",
+        ] {
             assert!(!text.contains(secret), "{secret} reached the viewer");
         }
-        assert_eq!(view["omittedFieldCount"], 5, "the one the plugin dropped plus four more");
+        assert_eq!(
+            view["omittedFieldCount"], 5,
+            "the one the plugin dropped plus four more"
+        );
         let groups = view["groups"].as_array().unwrap();
         assert_eq!(groups.len(), 1, "a group with nothing left is not shown");
         assert_eq!(groups[0]["fields"][0]["key"], "个人简介");
@@ -351,8 +422,11 @@ mod evidence {
 
     fn archive() -> (tempfile::TempDir, ArchiveStore, String) {
         let dir = tempfile::tempdir().unwrap();
-        let store =
-            open_store(&dir.path().join("archive"), &dir.path().join("current.json")).unwrap();
+        let store = open_store(
+            &dir.path().join("archive"),
+            &dir.path().join("current.json"),
+        )
+        .unwrap();
         let app = create_application(
             &store,
             serde_json::from_value(json!({ "company": "Synthetic", "title": "Job" })).unwrap(),
@@ -427,10 +501,7 @@ mod evidence {
             Some("2026-09-12T08:00:00.000Z"),
             "档案层把时间规范成毫秒精度"
         );
-        assert_eq!(
-            one.application_id, None,
-            "还没有选申请：它待在收件箱里"
-        );
+        assert_eq!(one.application_id, None, "还没有选申请：它待在收件箱里");
         assert_eq!(store.list_evidence(None).unwrap().len(), 1);
     }
 
@@ -468,7 +539,9 @@ mod evidence {
     fn evidence_moves_in_and_out_of_an_application_with_the_state_following() {
         let (dir, store, app) = archive();
         let path = write(dir.path(), "reply.eml", &eml("回复"));
-        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        let id = import(&store, vec![path], None, None).imported[0]
+            .id
+            .clone();
         let state = |store: &ArchiveStore| {
             store
                 .get_application(&app)
@@ -519,7 +592,11 @@ mod evidence {
         let (dir, store, _app) = archive();
         let mail = write(dir.path(), "reply.eml", &eml("面试邀请"));
         let shot = write(dir.path(), "screenshot.png", &png());
-        let pdf = write(dir.path(), "offer.pdf", b"%PDF-1.7\n1 0 obj\n<<>>\nendobj\n");
+        let pdf = write(
+            dir.path(),
+            "offer.pdf",
+            b"%PDF-1.7\n1 0 obj\n<<>>\nendobj\n",
+        );
         let report = import(
             &store,
             vec![mail, shot, pdf],
@@ -557,9 +634,8 @@ mod evidence {
 
         // 给 WebView 的任何一条里都没有存储路径。
         for id in report.imported.iter().map(|item| item.id.clone()) {
-            let json =
-                serde_json::to_string(&evidence_commands::get_preview(&store, &id).unwrap())
-                    .unwrap();
+            let json = serde_json::to_string(&evidence_commands::get_preview(&store, &id).unwrap())
+                .unwrap();
             assert!(!json.contains("attachments/"), "{json}");
             assert!(!json.contains(&store.archive_dir().to_string_lossy().to_string()));
         }
@@ -569,7 +645,9 @@ mod evidence {
     fn a_copy_that_is_gone_says_so_instead_of_pretending() {
         let (dir, store, _app) = archive();
         let path = write(dir.path(), "reply.eml", &eml("回复"));
-        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        let id = import(&store, vec![path], None, None).imported[0]
+            .id
+            .clone();
         let stored: PathBuf = evidence_commands::stored_path(&store, &id).unwrap();
         assert!(stored.starts_with(store.archive_dir().canonicalize().unwrap()));
 
@@ -582,16 +660,81 @@ mod evidence {
     fn an_applications_detail_carries_its_evidence_without_any_path() {
         let (dir, store, app) = archive();
         let path = write(dir.path(), "面试邀请.eml", &eml("面试邀请"));
-        let id = import(&store, vec![path], None, None).imported[0].id.clone();
+        let id = import(&store, vec![path], None, None).imported[0]
+            .id
+            .clone();
         evidence_commands::associate(&store, &id, &app).unwrap();
         evidence_commands::classify(&store, &id, "interview_invite", "automated").unwrap();
 
         let view = get_application(&store, &app).unwrap();
         assert_eq!(view.evidence.len(), 1);
         assert_eq!(view.evidence[0].subject.as_deref(), Some("面试邀请"));
-        assert_eq!(view.evidence[0].reply_class.as_deref(), Some("interview_invite"));
+        assert_eq!(
+            view.evidence[0].reply_class.as_deref(),
+            Some("interview_invite")
+        );
         let json = serde_json::to_string(&view).unwrap();
         assert!(!json.contains("attachments/"), "{json}");
         assert!(!json.contains(&store.archive_dir().to_string_lossy().to_string()));
+    }
+}
+
+// --- The wire shape the frontend reads ------------------------------------------------
+
+mod boundary {
+    use crate::commands::*;
+    use serde_json::json;
+
+    /// 前端读哪些键，这里就钉哪些键。改名或换 `rename_all` 都会让这条测试先红，
+    /// 而不是让界面安静地显示空白（那正是以前要写 `a.updatedAt || a.updated_at` 的原因）。
+    #[test]
+    fn the_json_keys_the_desktop_frontend_reads_are_pinned() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = open_store(
+            &dir.path().join("archive"),
+            &dir.path().join("current.json"),
+        )
+        .unwrap();
+        let created = create_application(
+            &store,
+            serde_json::from_value(json!({ "company": "Synthetic", "title": "Job", "sourceUrl": "https://jobs.example.test/1" })).unwrap(),
+        )
+        .unwrap();
+        let id = created.application.unwrap().id.clone();
+
+        let page = serde_json::to_value(
+            list_applications(&store, serde_json::from_value(json!({})).unwrap()).unwrap(),
+        )
+        .unwrap();
+        let row = &page["items"][0];
+        for key in [
+            "id",
+            "company",
+            "title",
+            "location",
+            "current_stage",
+            "reply_evidence_state",
+            "recycle_state",
+            "updated_at",
+            "source_url",
+        ] {
+            assert!(row.get(key).is_some(), "列表少了前端要读的键：{key}\n{row}");
+        }
+        assert!(page.get("total").is_some());
+
+        let view = serde_json::to_value(get_application(&store, &id).unwrap()).unwrap();
+        for key in [
+            "application",
+            "events",
+            "snapshots",
+            "snapshotStates",
+            "evidence",
+        ] {
+            assert!(view.get(key).is_some(), "详情少了前端要读的键：{key}");
+        }
+        let app = &view["application"];
+        for key in ["notes", "company", "title", "current_stage", "updated_at"] {
+            assert!(app.get(key).is_some(), "详情里的申请少了：{key}");
+        }
     }
 }

--- a/desktop/src/api.ts
+++ b/desktop/src/api.ts
@@ -1,8 +1,11 @@
 // 桌面前端与 Rust 命令层之间的形状。
 //
-// 这些接口现在是手写的，**下一步会由 Rust 的结构体生成**（ts-rs），这样字段改名时前端
-// 立刻红，而不是像以前那样在界面里写 `app.replyEvidenceState || app.reply_evidence_state`
-// 两种命名都试一遍。在那之前，这个文件是唯一一处描述边界的地方。
+// 这些接口是手写的，但**不是没人看着**：`desktop/src-tauri/src/commands_regression.rs` 里的
+// `the_json_keys_the_desktop_frontend_reads_are_pinned` 会把前端真正读的那些键逐个断言，
+// 谁改了字段名或 `rename_all`，那条 Rust 测试先红。
+//
+// 更彻底的做法是用 ts-rs 从 Rust 结构体生成这个文件（archive-store 的模型也要跟着加 derive，
+// 包括 `#[serde(flatten)]` 与那个大 EventPayload 枚举）——留作后续。
 
 export type Invoke = <T = unknown>(command: string, args?: Record<string, unknown>) => Promise<T>;
 
@@ -43,22 +46,23 @@ export type SendMode = "human" | "automated" | "unknown";
 
 export type EvidenceKind = "eml" | "screenshot" | "pdf" | "paste" | "unknown";
 
-/** 列表里的一行。命令层给的是 snake_case，两种命名都在这里声明，界面只读其中一种。 */
+/**
+ * 列表与详情里的一条申请。
+ *
+ * **键名就是命令层真正发出来的那些**：archive-store 的模型走 snake_case，D08/D09 的命令层
+ * 结构体标了 `rename_all = "camelCase"`。两边都由 `commands_regression.rs` 的
+ * `the_json_keys_the_desktop_frontend_reads_are_pinned` 钉死——改名会先让那条 Rust 测试红。
+ */
 export interface ApplicationSummary {
   id: string;
   company: string;
   title: string;
   location?: string | null;
   current_stage?: Stage;
-  currentStage?: Stage;
   reply_evidence_state?: ReplyEvidenceState;
-  replyEvidenceState?: ReplyEvidenceState;
   recycle_state?: string;
-  recycleState?: string;
   updated_at?: string;
-  updatedAt?: string;
   source_url?: string | null;
-  sourceUrl?: string | null;
   notes?: string | null;
 }
 

--- a/desktop/src/applications-ui.ts
+++ b/desktop/src/applications-ui.ts
@@ -127,7 +127,7 @@ export function mountApplications(invoke: Invoke) {
     must("app-form-title").textContent = title;
     input("f-company").value = values.company || "";
     input("f-title").value = values.title || "";
-    input("f-url").value = values.sourceUrl || values.source_url || "";
+    input("f-url").value = values.source_url || "";
     input("f-location").value = values.location || "";
     input("f-notes").value = values.notes || "";
     formMsg.textContent = "";
@@ -160,8 +160,8 @@ export function mountApplications(invoke: Invoke) {
             <td title="${escapeHtml(row.company)}">${escapeHtml(row.company)}</td>
             <td title="${escapeHtml(row.title)}">${escapeHtml(row.title)}</td>
             <td>${escapeHtml(row.location || "—")}</td>
-            <td>${escapeHtml(stageLabel(row.currentStage || row.current_stage))}</td>
-            <td>${escapeHtml(formatTime(row.updatedAt || row.updated_at))}</td>
+            <td>${escapeHtml(stageLabel(row.current_stage))}</td>
+            <td>${escapeHtml(formatTime(row.updated_at))}</td>
           </tr>`;
         })
         .join("");
@@ -199,13 +199,13 @@ export function mountApplications(invoke: Invoke) {
       detail.innerHTML = `
         <div class="detail-head">
           <h2 title="${escapeHtml(app.company)} · ${escapeHtml(app.title)}">${escapeHtml(app.company)} · ${escapeHtml(app.title)}</h2>
-          <p class="muted">${escapeHtml(stageLabel(app.currentStage || app.current_stage))} · ${escapeHtml(evidenceLabel(app.replyEvidenceState || app.reply_evidence_state))}</p>
+          <p class="muted">${escapeHtml(stageLabel(app.current_stage))} · ${escapeHtml(evidenceLabel(app.reply_evidence_state))}</p>
         </div>
         <dl class="facts compact">
           <dt>地点</dt><dd>${escapeHtml(app.location || "—")}</dd>
-          <dt>链接</dt><dd class="break">${escapeHtml(app.sourceUrl || app.source_url || "—")}</dd>
+          <dt>链接</dt><dd class="break">${escapeHtml(app.source_url || "—")}</dd>
           <dt>备注</dt><dd class="break">${escapeHtml(notes || "—")}</dd>
-          <dt>更新</dt><dd>${escapeHtml(formatTime(app.updatedAt || app.updated_at))}</dd>
+          <dt>更新</dt><dd>${escapeHtml(formatTime(app.updated_at))}</dd>
         </dl>
         <div class="row wrap">
           <button type="button" data-act="edit">编辑资料</button>
@@ -218,12 +218,12 @@ export function mountApplications(invoke: Invoke) {
           <button type="button" data-act="closed">结束申请</button>
           <button type="button" data-act="correct">纠正阶段</button>
           <button type="button" data-act="note">新增备注</button>
-          <button type="button" data-act="recycle">${(app.recycleState || app.recycle_state) === "recycled" ? "恢复" : "回收"}</button>
+          <button type="button" data-act="recycle">${app.recycle_state === "recycled" ? "恢复" : "回收"}</button>
         </div>
         <p class="muted">待办尚未接入，这里不展示假数据。填写事件不等于投递成功。</p>
         <h3>回复证据（${evidence.length}）</h3>
-        ${evidenceNote(app.replyEvidenceState || app.reply_evidence_state)
-          ? `<p class="muted">${escapeHtml(evidenceNote(app.replyEvidenceState || app.reply_evidence_state))}</p>`
+        ${evidenceNote(app.reply_evidence_state)
+          ? `<p class="muted">${escapeHtml(evidenceNote(app.reply_evidence_state))}</p>`
           : ""}
         ${evidence.length ? `
         <ul class="snapshot-list">
@@ -381,7 +381,7 @@ export function mountApplications(invoke: Invoke) {
         openForm("编辑申请", {
           company: app.company,
           title: app.title,
-          sourceUrl: app.sourceUrl || app.source_url,
+          source_url: app.source_url,
           location: app.location,
           notes: view.application.notes,
         });
@@ -391,7 +391,7 @@ export function mountApplications(invoke: Invoke) {
         if (!window.confirm("确认这条申请已经投递？填写完成不会自动变成已投递。")) return;
         await invoke("confirm_submit_cmd", { args: { id } });
       } else if (act === "correct") {
-        const to = window.prompt("纠正到哪个阶段？(saved/filling/submitted/assessment/interview/offer/rejected/withdrawn/closed)", app.currentStage || app.current_stage);
+        const to = window.prompt("纠正到哪个阶段？(saved/filling/submitted/assessment/interview/offer/rejected/withdrawn/closed)", app.current_stage ?? "");
         if (!to) return;
         const reason = window.prompt("纠正原因（必填）", "");
         if (!reason || !reason.trim()) {
@@ -399,14 +399,14 @@ export function mountApplications(invoke: Invoke) {
           return;
         }
         await invoke("correct_stage_cmd", {
-          args: { id, from: app.currentStage || app.current_stage, to: to.trim(), reason: reason.trim() },
+          args: { id, from: app.current_stage, to: to.trim(), reason: reason.trim() },
         });
       } else if (act === "note") {
         const text = window.prompt("备注", "");
         if (!text || !text.trim()) return;
         await invoke("add_note_cmd", { args: { id, text } });
       } else if (act === "recycle") {
-        const recycled = (app.recycleState || app.recycle_state) !== "recycled";
+        const recycled = app.recycle_state !== "recycled";
         const ok = window.confirm(
           recycled
             ? "回收后申请离开进行中列表，历史事件仍保留，可以恢复。本次不提供永久删除。"


### PR DESCRIPTION
接 #73 的第二步。

## 问题

前端有 11 处写着 `app.replyEvidenceState || app.reply_evidence_state`——两种命名都试一遍，因为没有任何东西说清楚命令层到底发的是哪个。真实情况是：archive-store 的模型走 snake_case，D08/D09 新写的命令层结构体标了 `rename_all = "camelCase"`。

## 做了什么

- **Rust 侧钉死键名**：`commands_regression.rs` 新增 `the_json_keys_the_desktop_frontend_reads_are_pinned`，把列表页和详情视图序列化出来，逐个断言前端真正读的键（`current_stage`、`updated_at`、`reply_evidence_state`、`recycle_state`、`source_url`、`snapshotStates`、`evidence`…）。谁改字段名或翻转 `rename_all`，这条测试先红，而不是界面上安静地空一列。
- **前端删掉全部 fallback**，`api.ts` 只声明真正发出来的键。

## 为什么不是 ts-rs

ts-rs 从 Rust 结构体生成 `api.ts` 仍然是最终答案，但要给 archive-store 的模型也加 derive，其中包括一个 `#[serde(flatten)]` 的结构体和一个二十来个变体的事件枚举——那是独立的一块工作。`api.ts` 顶部的注释写明了这一点，现在有测试兜着，不会再靠猜。

## 验证

`npm run typecheck` 0 错误；前端测试 44/44；`npm run build` 通过；`src-tauri` 75/75（新增 1 条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **变更**
  - 申请列表、详情页、表单及相关操作统一读取下划线格式字段，提升数据展示与操作的一致性。
  - 移除对驼峰格式申请字段的兼容读取；相关字段现以统一格式提供。
  - 申请数据接口字段定义同步调整，涵盖阶段、更新时间、来源地址、回复证据状态和回收状态等信息。

- **测试**
  - 增加回归校验，确保桌面端读取的申请数据字段名称保持稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->