### PR TITLE
补 D09 验收项：原文件删掉后副本还在

### DIFF
--- a/desktop/src-tauri/src/commands_regression.rs
+++ b/desktop/src-tauri/src/commands_regression.rs
@@ -641,6 +641,23 @@ mod evidence {
         }
     }
 
+    // D09 验收：导入之后原文件挪走或删掉，主程序还看得到自己那份副本。
+    #[test]
+    fn deleting_the_original_does_not_take_the_imported_copy_with_it() {
+        let (dir, store, _app) = archive();
+        let source = write(dir.path(), "reply.eml", &eml("回复"));
+        let id = import(&store, vec![source.clone()], None, None).imported[0]
+            .id
+            .clone();
+
+        std::fs::remove_file(&source).unwrap();
+        assert!(!std::path::Path::new(&source).exists());
+
+        let preview = evidence_commands::get_preview(&store, &id).unwrap();
+        assert!(preview.body_extract.unwrap().contains("下周二上午十点"));
+        assert!(preview.note.is_none(), "副本还在，不该有「不在了」的提示");
+    }
+
     #[test]
     fn a_copy_that_is_gone_says_so_instead_of_pretending() {
         let (dir, store, _app) = archive();


### PR DESCRIPTION
#66 的验收里有一条「导入后把原文件移走或删除，主程序仍能查看已保存副本」。

拷贝而不是移动本来就有测试（`a_file_lands_inside_attachments_with_its_digest_and_size`），删掉**存储副本**之后的降级提示也有（`a_copy_that_is_gone_says_so_instead_of_pretending`），但没有一条真的把**源文件**删掉再读一次预览。关 #66 之前先补上，验收记录才对得上代码。

```
cargo test --lib → 76 passed / 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **测试**
  - 新增回归测试，验证导入的 `.eml` 邮件在删除原始文件后仍可正常预览正文副本。
  - 确保预览中不会错误显示“文件不存在”等提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->