### PR TITLE
把商店公钥写进 manifest，固定扩展 ID

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "name": "Resume Pro",
   "version": "0.4.0",
   "description": "求职网申场景的简历信息填写辅助插件。",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvw54FDt3uRc5KJ5wD9aLAI/xL39E7uw65DNNbXy5oiTl/PBj/t7j169cgosKpGS0IIshxA4yV4cB31TnIMXjh1WR+irtMh8qvLwvHH5ULsML/037bwOL0QxDiVp5qMk5yZvWfi27S2pk01/wbajTa43EqIcX+6egE7BeTik77DAmazBTzBj7xbLclCW+RoKmdWR0okQB0nBJMCoI8G+hkTjL8AtnrR53qiNpojOdgawhJNWgYxhGQKP4kmnJV5n+b0vyUKeCeo42lAdWwYB2Yphx/uGkg2dpCtNE0MllD3PTYY7Z48X2MQVLyU+wfuZr29q7MU2o6UcBGXWu6EP69QIDAQAB",
   "permissions": [
     "offscreen",
     "storage",


### PR DESCRIPTION
商店 item 已建（草稿，未提交审核），扩展 ID 是 `diagjmploldedipjdenmecmjokckelkl`。

以前本地 load unpacked 每次拿到的都是随机 ID，跟商店版对不上，native messaging 的 `allowed_origins` 没法照真实情况测。把商店那边的公钥填进 manifest 的 `key` 字段之后两边同一个 ID，D13（#29）的 host 注册可以直接对着它写。

**核对方式**：公钥 base64 解成 DER → SHA-256 → 前 16 字节按 `0-f → a-p` 映射，结果正好是上面那个 ID。抄错任何一个字符算出来的 ID 都会完全不同，所以内容是对的。

`key` 是公钥，不是凭据，公开没有问题。

**待确认**：下次往商店传包时留意一下带 `key` 的包会不会被拒（我们这个 key 和 item 自己的 key 一致，正常应该接受）。真被拒的话就在打包步骤里剥掉它。

```
node --test tests/*.test.js → 510 passed
node desktop/scripts/check-plugin-release-allowlist.js → 50 runtime files OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)